### PR TITLE
Why libcst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,9 +23,6 @@ fields, we've created a lossless CST that looks and feels like an AST.
 
 .. why-libcst-intro-end
 
-
-.. why-libcst-example-start
-
 ::
 
     1 + 2
@@ -54,8 +51,6 @@ fields, we've created a lossless CST that looks and feels like an AST.
         lpar=[],
         rpar=[],
     )
-
-.. why-libcst-example-end
 
 Getting Started
 ===============

--- a/docs/source/why_libcst.rst
+++ b/docs/source/why_libcst.rst
@@ -15,19 +15,21 @@ Let's look at Python's AST for the following code snippet::
 
     fn(1, 2)  # calls fn
 
-.. code-block:: python
+.. container:: toggle
 
-    ast.Module(
-        body=[
-            ast.Expr(
-                value=ast.Call(
-                    func=ast.Name("fn", ctx=ast.Load()),
-                    args=[ast.Num(n=1), ast.Num(n=2)],
-                    keywords=[],
+    .. code-block:: python
+
+        ast.Module(
+            body=[
+                ast.Expr(
+                    value=ast.Call(
+                        func=ast.Name("fn", ctx=ast.Load()),
+                        args=[ast.Num(n=1), ast.Num(n=2)],
+                        keywords=[],
+                    ),
                 ),
-            ),
-        ],
-    )
+            ],
+        )
 
 .. graphviz::
 
@@ -128,7 +130,6 @@ A popular CST library for Python is `lib2to3 <https://github.com/python/cpython/
             prefix="",
         )
 
-
 .. graphviz::
 
     digraph cst {
@@ -175,14 +176,192 @@ A popular CST library for Python is `lib2to3 <https://github.com/python/cpython/
         trailer -> COMMA [label="2"];
         trailer -> NUMBER_2 [label="3"];
         trailer -> RPAR [label="4"];
-      }
+    }
 
-This tree is lossless. It retains enough information to reprint the exact input code by storing whitespace information in `prefix` properties. This makes it a "Concrete" Syntax Tree, or CST.
+This tree is lossless. It retains enough information to reprint the exact input code by storing whitespace information in ``prefix`` properties. This makes it a "Concrete" Syntax Tree, or CST.
+
+However, much of the semantics of the code is now difficult to understand and extract. lib2to3 presents a tree that closely matches `Python's grammar <https://docs.python.org/3/reference/grammar.html>`_ which can be hard to manipulate for complex operations.
+
+- Adding or removing a parameter from ``fn`` requires careful preservation of ``COMMA`` nodes.
+- Whitespace and comment ownership is unclear. Deleting nodes could result in invalid generated code.
+
+Concrete Syntax Trees are good for operations that don't significantly change the tree and tools that do not wish to change the semantics of the code itself, such as `Black <https://github.com/ambv/black>`_.
 
 LibCST
 ======
 
-.. include:: ../../README.rst
-    :start-after: why-libcst-example-start
-    :end-before: why-libcst-example-end
+LibCST takes a compromise between the two formats outlined above. Like a CST, LibCST preserves all whitespace and can be reprinted exactly. Like an AST, LibCST parses source into nodes that represent the semtantics of the code.
 
+.. code-block:: python
+
+    fn(1, 2)  # calls fn
+
+.. container:: toggle
+
+    .. code-block:: python
+
+        Module(
+            body=[
+                SimpleStatementLine(
+                    body=[
+                        Expr(
+                            value=Call(
+                                func=Name(
+                                    value='fn',
+                                    lpar=[],
+                                    rpar=[],
+                                ),
+                                args=[
+                                    Arg(
+                                        value=Integer(
+                                            value='1',
+                                            lpar=[],
+                                            rpar=[],
+                                        ),
+                                        keyword=None,
+                                        equal=MaybeSentinel.DEFAULT,
+                                        comma=Comma(
+                                            whitespace_before=SimpleWhitespace(
+                                                value='',
+                                            ),
+                                            whitespace_after=SimpleWhitespace(
+                                                value=' ',
+                                            ),
+                                        ),
+                                        star='',
+                                        whitespace_after_star=SimpleWhitespace(
+                                            value='',
+                                        ),
+                                        whitespace_after_arg=SimpleWhitespace(
+                                            value='',
+                                        ),
+                                    ),
+                                    Arg(
+                                        value=Integer(
+                                            value='2',
+                                            lpar=[],
+                                            rpar=[],
+                                        ),
+                                        keyword=None,
+                                        equal=MaybeSentinel.DEFAULT,
+                                        comma=MaybeSentinel.DEFAULT,
+                                        star='',
+                                        whitespace_after_star=SimpleWhitespace(
+                                            value='',
+                                        ),
+                                        whitespace_after_arg=SimpleWhitespace(
+                                            value='',
+                                        ),
+                                    ),
+                                ],
+                                lpar=[],
+                                rpar=[],
+                                whitespace_after_func=SimpleWhitespace(
+                                    value='',
+                                ),
+                                whitespace_before_args=SimpleWhitespace(
+                                    value='',
+                                ),
+                            ),
+                            semicolon=MaybeSentinel.DEFAULT,
+                        ),
+                    ],
+                    leading_lines=[],
+                    trailing_whitespace=TrailingWhitespace(
+                        whitespace=SimpleWhitespace(
+                            value='  ',
+                        ),
+                        comment=Comment(
+                            value='# calls fn',
+                        ),
+                        newline=Newline(
+                            value=None,
+                        ),
+                    ),
+                ),
+            ],
+            header=[],
+            footer=[],
+            encoding='utf-8',
+            default_indent='    ',
+            default_newline='\n',
+            has_trailing_newline=True,
+        )
+
+.. graphviz::
+
+    digraph libcst {
+        layout=dot;
+        rankdir=TB;
+        splines=line;
+        ranksep=0.5;
+        nodesep=1.0;
+        dpi=300;
+        bgcolor=transparent;
+        node [
+            style=filled,
+            color="#fb8d3f",
+            fontcolor="#4b4f54",
+            fillcolor="#fdd2b3",
+            fontname="Source Code Pro Semibold",
+            penwidth="2",
+            group=main,
+        ];
+        edge [
+            color="#999999",
+            fontcolor="#4b4f54",
+            fontname="Source Code Pro Semibold",
+            fontsize=12,
+            penwidth=2,
+        ];
+        Module [label="Module"];
+        SimpleStatementLine [label="SimpleStatementLine"];
+        Expr [label="Expr"];
+        Call [label="Call"];
+        Name [label="Name"];
+        NameValue [label=" 'fn' ", color="#3e99ed", fillcolor="#b8d9f8", shape=box];
+        Arg1 [label="Arg"];
+        Integer1 [label="Integer"];
+        Integer1Value [label=" '1' ", color="#3e99ed", fillcolor="#b8d9f8", shape=box];
+        Comma [label="Comma"];
+        SimpleWhitespace2 [label="SimpleWhitespace", color="#777777", fillcolor="#eeeeee"];
+        SimpleWhitespace2Value [label=" ' ' ", color="#777777", fillcolor="#cccccc", shape=box];
+        Arg2 [label="Arg"];
+        Integer2 [label="Integer"];
+        Integer2Value [label=" '2' ", color="#3e99ed", fillcolor="#b8d9f8", shape=box];
+        TrailingWhitespace [label="TrailingWhitespace", color="#777777", fillcolor="#eeeeee"];
+        SimpleWhitespace1 [label="SimpleWhitespace", color="#777777", fillcolor="#eeeeee"];
+        SimpleWhitespace1Value [label=" '  ' ", color="#777777", fillcolor="#cccccc", shape=box];
+        Comment1 [label="Comment", color="#777777", fillcolor="#eeeeee"];
+        Comment1Value [label=" '# calls fn' ", color="#777777", fillcolor="#cccccc", shape=box];
+
+        Module -> SimpleStatementLine [label="body[0]"];
+        SimpleStatementLine -> Expr [label="body[0]"];
+        Expr -> Call [label="value"];
+        Call -> Name [label="func"];
+        Name -> NameValue [label="value"];
+        Call -> Arg1 [label="args[0]"];
+        Arg1 -> Integer1 [label="value"];
+        Integer1 -> Integer1Value [label="value"];
+        Arg1 -> Comma [label="comma"];
+        Comma -> SimpleWhitespace2 [label="whitespace_after"];
+        SimpleWhitespace2 -> SimpleWhitespace2Value [label="value"];
+        Call -> Arg2 [label="args[1]"];
+        Arg2 -> Integer2 [label="value"];
+        Integer2 -> Integer2Value [label="value"];
+        SimpleStatementLine -> TrailingWhitespace [label="trailing_whitespace"];
+        TrailingWhitespace -> SimpleWhitespace1 [label="whitespace"];
+        SimpleWhitespace1 -> SimpleWhitespace1Value [label="value"];
+        TrailingWhitespace -> Comment1 [label="comment"];
+        Comment1 -> Comment1Value [label="value"];
+    }
+
+LibCST preserves whitespace by parsing it using an internal whitespace parser and assigning it to relevant nodes. This allows for much more granular whitespace ownership and greatly reduces the amount of work necessary to perform complex manipulations. Additionally, it is fully typed. A node's children are well-defined and match the semantics of Python.
+
+However, this does come with some downsides.
+
+- It is more difficult to implement tools that focus almost exclusively on whitespace on top of LibCST instead of lib2to3. For example, `Black <https://github.com/ambv/black>`_ would need to modify whitespace nodes instead of prefix strings, making its implementation much more complex.
+- The equivalent AST for a Python module will usually be simpler. We must preserve whitespace ownership by assigning it to nodes that make the most sense which requires us to introduce nodes such as :class:`~libcst.Comma`.
+- Parsing with LibCST will always be slower than Python's AST due to the extra work needed to assign whitespace correctly.
+
+Nevertheless, we think that the trade-offs made in LibCST are worthwhile and offer a great deal of flexibility and power.


### PR DESCRIPTION
## Summary

Fixed README and Why LibCST printed example as it was out of date.
Unrolled README example into Why LibCST section to decouple since this page explicitly uses "fn(1, 2)" snippet and the readme is going to change.
Added justification and pros/cons to LibCST.
Added graphviz to render the non-default parts of LibCST tree (identical to how we render non-default parts of the AST).

## Test Plan

tox