### PR TITLE
Allow Annotation to contain any BaseExpression

### DIFF
--- a/libcst/_nodes/_expression.py
+++ b/libcst/_nodes/_expression.py
@@ -1291,7 +1291,7 @@ class Annotation(CSTNode):
 
     #: The annotation's value itself. This is the part of the annotation after the
     #: colon or arrow.
-    annotation: Union[Name, Attribute, BaseString, Subscript]
+    annotation: Union[BaseExpression]
 
     whitespace_before_indicator: Union[
         BaseParenthesizableWhitespace, MaybeSentinel


### PR DESCRIPTION
## Summary

An `Annotation` can contain any `BaseExpression`, not just the short
list of types we had listed.

For example, this is valid syntax:

    val: 1 + 2 = None

## Test Plan

```
pyre check
```

