### PR TITLE
Don't run isort and black when running unit tests with tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,6 @@ deps =
     -rrequirements.txt
     -rrequirements-dev.txt
 commands =
-    isort --recursive libcst/
-    black libcst/
     python -m unittest
 
 [testenv:lint]


### PR DESCRIPTION
## Summary
See title. Note this means there is no way to actually perform an auto-format with tox (there doesn't seem to be a way to easily exclude an environment when just running `tox`). If we think easy access to running auto-formatting is more important than decoupling tests from isort and black then we can ignore this pull request.

## Test Plan
Ran tox.