### PR TITLE
Add docs for MaybeSentinel and RemovalSentinel

### DIFF
--- a/docs/source/nodes.rst
+++ b/docs/source/nodes.rst
@@ -391,3 +391,8 @@ Nodes that encapsulate pure whitespace.
 .. autoclass:: libcst.SimpleWhitespace
 .. autoclass:: libcst.TrailingWhitespace
 .. autoclass:: libcst.BaseParenthesizableWhitespace
+
+Maybe Sentinel
+--------------
+
+.. autoclass:: libcst.MaybeSentinel

--- a/docs/source/visitors.rst
+++ b/docs/source/visitors.rst
@@ -3,6 +3,7 @@ Visitors
 
 .. autoclass:: libcst.CSTVisitor
 .. autoclass:: libcst.CSTTransformer
+.. autoclass:: libcst.RemovalSentinel
 
 Visit and Leave Helper Functions
 --------------------------------

--- a/libcst/_maybe_sentinel.py
+++ b/libcst/_maybe_sentinel.py
@@ -9,9 +9,48 @@ from enum import Enum, auto
 
 class MaybeSentinel(Enum):
     """
-    A MaybeSentinal value is used as the default constructor for some attributes to
-    denote that on generating code we should optionally include this element in order
-    to generate valid code.
+    A :class:`MaybeSentinel` value is used as the default value for some attributes to
+    denote that when generating code (when :attr:`Module.code` is evaluated) we should
+    optionally include this element in order to generate valid code.
+
+    :class:`MaybeSentinel` is only used for "syntactic trivia" that most users shouldn't
+    care much about anyways, like commas, semicolons, and whitespace.
+
+    For example, a function call's :attr:`Arg.comma` value defaults to
+    :attr:`MaybeSentinel.DEFAULT`. A comma is required after every argument, except for
+    the last one. If a comma is required and :attr:`Arg.comma` is a
+    :class:`MaybeSentinel`, one is inserted.
+
+    This makes manual node construction easier, but it also means that we safely add
+    arguments to a preexisting function call without manually fixing the commas:
+
+    >>> import libcst as cst
+    >>> fn_call = cst.parse_expression("fn(1, 2)")
+    >>> new_fn_call = fn_call.with_changes(
+    ...     args=[*fn_call.args, cst.Arg(cst.Integer("3"))]
+    ... )
+    >>> dummy_module = cst.parse_module("")  # we need to use Module.code_for_node
+    >>> dummy_module.code_for_node(fn_call)
+    'fn(1, 2)'
+    >>> dummy_module.code_for_node(new_fn_call)
+    'fn(1, 2, 3)'
+
+    Notice that a comma was automatically inserted after the second argument. Since the
+    original second argument had no comma, it was initialized to
+    :attr:`MaybeSentinel.DEFAULT`. During the code generation of the second argument, a
+    comma was inserted to ensure that the resulting code is valid.
+
+    .. warning::
+       While this sentinel is used in place of nodes, it is not a :class:`CSTNode`, and
+       will not be visited by a :class:`CSTVisitor`.
+
+    Some other libraries, like `RedBaron`_, take other approaches to this problem.
+    RedBaron's tree is mutable (LibCST's tree is immutable), and so they're able to
+    solve this problem with `"proxy lists"
+    <http://redbaron.pycqa.org/en/latest/proxy_list.html>`_. Both approaches come with
+    different sets of tradeoffs.
+
+    .. _RedBaron: http://redbaron.pycqa.org/en/latest/index.html
     """
 
     DEFAULT = auto()

--- a/libcst/_removal_sentinel.py
+++ b/libcst/_removal_sentinel.py
@@ -5,8 +5,8 @@
 
 # pyre-strict
 """
-Used and re-exported by visitor. This is hoisted into a separate module to avoid some
-circular dependencies in the definition of CSTNode.
+Used by visitors. This is hoisted into a separate module to avoid some circular
+dependencies in the definition of CSTNode.
 """
 
 from enum import Enum, auto
@@ -14,23 +14,22 @@ from enum import Enum, auto
 
 class RemovalSentinel(Enum):
     """
-    A RemovalSentinel value should be returned by a `on_leave` method when we want to
-    remove that child from its parent.
+    A :attr:`RemovalSentinel.REMOVE` value should be returned by a
+    :meth:`CSTTransformer.on_leave` method when we want to remove that child from its
+    parent.
 
-    The parent's _visit_and_replace_children method should make a best-effort to remove
-    the child, but may raise an exception when removing the child doesn't make sense, or
-    could change the semantics in an unexpected way. E.g. a function with no name
-    doesn't make sense.
+    The parent node should make a best-effort to remove the child, but may raise an
+    exception when removing the child doesn't make sense, or could change the semantics
+    in an unexpected way. E.g. a function with no name doesn't make sense.
 
     In we can't automatically remove the child, the developer should instead remove the
-    child by constructing a new parent in the parent's on_leave call.
+    child by constructing a new parent in the parent's :meth:`~CSTTransformer.on_leave`
+    call.
 
-    We use this instead of `None` to force developers to be more explicit about
-    deletions, because `None` is the default return value for a function with no return
-    statement.
-
-    In the future, we may extend this to support other forms of removal, but that's
-    unlikely.
+    We use this instead of ``None`` to force developers to be explicit about deletions.
+    Because ``None`` is the default return value for a function with no return
+    statement, it would be too easy to accidentally delete nodes from the tree by
+    forgetting to return a value.
     """
 
     REMOVE = auto()

--- a/libcst/_visitors.py
+++ b/libcst/_visitors.py
@@ -61,9 +61,9 @@ class CSTTransformer(_MetadataDependent):
         on the ``updated_node`` so as to not overwrite changes made by child
         visits.
 
-        Returning a :class:`~libcst.RemovalSentinel` indicates that the node
-        should be removed from its parent. This is not always possible, and
-        may raise an exception if this node is required.
+        Returning :attr:`RemovalSentinel.REMOVE` indicates that the node should be
+        removed from its parent. This is not always possible, and may raise an
+        exception if this node is required.
         """
         leave_func = getattr(self, f"leave_{type(original_node).__name__}", None)
         if leave_func is not None:


### PR DESCRIPTION
## Summary

These were referred to by other parts of the documentation, and provide
core parts of our functionality, so we should have explicit
documentation for them.

## Test Plan

https://1371-200896124-gh.circle-artifacts.com/0/doc/nodes.html#maybe-sentinel
https://1371-200896124-gh.circle-artifacts.com/0/doc/visitors.html#libcst.RemovalSentinel