### PR TITLE
Patch _MetadataDependent to not be an ABC until Pyre is fixed

### DIFF
--- a/libcst/metadata/dependent.py
+++ b/libcst/metadata/dependent.py
@@ -5,7 +5,6 @@
 
 # pyre-strict
 import inspect
-from abc import ABC
 from contextlib import contextmanager
 from typing import (
     TYPE_CHECKING,
@@ -34,7 +33,9 @@ _T = TypeVar("_T")
 _UNDEFINED_DEFAULT = object()
 
 
-class _MetadataDependent(ABC):
+# TODO: this class should be an ABC but we're waiting on Pyre to fix a bug to
+# add this functionality back
+class _MetadataDependent:
     """
     Base class for all types that declare required metadata dependencies.
 


### PR DESCRIPTION
## Summary
Pyre doesn't handle inheriting from an ABC that implements __init__ properly right now so we're temporarily removing ABC from _MetadataDependent until Pyre is patched.

## Test Plan
Run tox.
