### PR TITLE
Add tox enviroment to run isort and black and update readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,7 +134,7 @@ to format code. To format changes to be conformant, run the following in the roo
 
 .. code-block:: shell
 
-    isort -q -y && black libcst/
+    tox -e autofix
 
 To run all tests, you'll need to install `tox <https://tox.readthedocs.io/en/latest/>`_
 and do the following in the root:

--- a/tox.ini
+++ b/tox.ini
@@ -22,3 +22,12 @@ deps =
     -rrequirements-dev.txt
 commands =
     sphinx-build docs/source/ docs/build/
+
+[testenv:autofix]
+deps =
+    -rrequirements.txt
+    -rrequirements-dev.txt
+commands =
+    flake8
+    isort -y -q
+    black libcst/


### PR DESCRIPTION
## Summary
Apparently this works... don't know what I was doing last time I tried.

## Test Plan
Ran tox and tox -e autofix.
