### PR TITLE
Drop metadata compatibility

### DIFF
--- a/libcst/_batched_visitor.py
+++ b/libcst/_batched_visitor.py
@@ -53,7 +53,7 @@ class BatchableCSTVisitor(CSTTypedVisitorFunctions, _MetadataDependent):
 
         # TODO: verify all visitor methods reference valid node classes.
         # for name, __ in methods:
-        #     pass
+        #     ...
 
         return dict(methods)
 
@@ -71,7 +71,10 @@ def visit_batched(
     execute before visit_* and after leave_* methods are executed by the
     batched visitor.
     """
-    batched_visitor = make_batched(visitors, before_visit, after_leave)
+    visitor_methods = _get_visitor_methods(visitors)
+    batched_visitor = _BatchedCSTVisitor(
+        visitor_methods, before_visit=before_visit, after_leave=after_leave
+    )
     return cast(CSTNodeT, node.visit(batched_visitor))
 
 
@@ -93,24 +96,6 @@ def _get_visitor_dependencies(
         dependencies.update(visitor.METADATA_DEPENDENCIES)
 
     return dependencies
-
-
-def make_batched(
-    visitors: Iterable[BatchableCSTVisitor],
-    before_visit: Optional[VisitorMethod] = None,
-    after_leave: Optional[VisitorMethod] = None,
-) -> "_BatchedCSTVisitor":
-    """
-    Make a batched visitor out of [visitors].
-
-    [before_visit] and [after_leave] are provided as optional hooks to
-    execute before visit_* and after leave_* methods are executed by the
-    batched visitor.
-    """
-    visitor_methods = _get_visitor_methods(visitors)
-    return _BatchedCSTVisitor(
-        visitor_methods, before_visit=before_visit, after_leave=after_leave
-    )
 
 
 class _BatchedCSTVisitor(CSTVisitor):

--- a/libcst/_batched_visitor.py
+++ b/libcst/_batched_visitor.py
@@ -63,7 +63,6 @@ def visit_batched(
     visitors: Iterable[BatchableCSTVisitor],
     before_visit: Optional[VisitorMethod] = None,
     after_leave: Optional[VisitorMethod] = None,
-    use_compatible: bool = True,  # TODO: remove this
 ) -> CSTNodeT:
     """
     Returns the result of running all visitors [visitors] over [node].
@@ -72,32 +71,8 @@ def visit_batched(
     execute before visit_* and after leave_* methods are executed by the
     batched visitor.
     """
-    # TODO: remove compatiblity hack
-    if use_compatible:
-        from libcst._nodes._module import Module
-
-        if isinstance(node, Module):
-            from contextlib import ExitStack
-            from libcst.metadata.wrapper import MetadataWrapper
-
-            wrapper = MetadataWrapper(node)
-            with ExitStack() as stack:
-                # Resolve dependencies of visitors
-                for v in visitors:
-                    stack.enter_context(v.resolve(wrapper))
-
-                batched_visitor = make_batched(visitors, before_visit, after_leave)
-                return cast(
-                    CSTNodeT,
-                    wrapper.module.visit(batched_visitor, use_compatible=False),
-                )
-
-        batched_visitor = make_batched(visitors, before_visit, after_leave)
-        return cast(CSTNodeT, node.visit(batched_visitor))
-    # end compatible
-
     batched_visitor = make_batched(visitors, before_visit, after_leave)
-    return cast(CSTNodeT, node.visit(batched_visitor, use_compatible=False))
+    return cast(CSTNodeT, node.visit(batched_visitor))
 
 
 def _get_visitor_methods(

--- a/libcst/_nodes/_internal.py
+++ b/libcst/_nodes/_internal.py
@@ -138,10 +138,6 @@ class BasicCodegenState(CodegenState):
         if node not in self.provider._computed:
             self.provider._computed[node] = position
 
-        # TODO: remove this
-        if type(self.provider) not in node._metadata:
-            node._metadata[type(self.provider)] = position
-
 
 class SyntacticCodegenState(BasicCodegenState):
     """
@@ -164,20 +160,13 @@ class SyntacticCodegenState(BasicCodegenState):
 
             # Override with positions hoisted from child nodes if provided
             start = (
-                start_node._metadata[type(self.provider)].start
+                self.provider._computed[start_node].start
                 if start_node is not None
                 else start
             )
-            end = (
-                end_node._metadata[type(self.provider)].end
-                if end_node is not None
-                else end
-            )
+            end = self.provider._computed[end_node].end if end_node is not None else end
 
             self.provider._computed[node] = CodeRange(start, end)
-
-            # TODO: remove this
-            node._metadata[type(self.provider)] = CodeRange(start, end)
 
 
 def visit_required(

--- a/libcst/_nodes/_module.py
+++ b/libcst/_nodes/_module.py
@@ -80,24 +80,14 @@ class Module(CSTNode):
             has_trailing_newline=self.has_trailing_newline,
         )
 
-    def visit(
-        self: _ModuleSelfT, visitor: CSTVisitorT, use_compatible: bool = True
-    ) -> _ModuleSelfT:
+    def visit(self: _ModuleSelfT, visitor: CSTVisitorT) -> _ModuleSelfT:
         """
         Returns the result of running a visitor over this module.
 
         :class:`Module` overrides the default visitor entry point to resolve metadata
         dependencies declared by 'visitor'.
         """
-        # TODO: remove compatibility hack
-        if use_compatible:
-            from libcst.metadata.wrapper import MetadataWrapper
-
-            wrapper = MetadataWrapper(self)
-            result = wrapper.visit(visitor)
-        else:
-            result = super(Module, self).visit(visitor)
-
+        result = super(Module, self).visit(visitor)
         if isinstance(result, RemovalSentinel):
             return self.with_changes(body=(), header=(), footer=())
         else:  # is a Module

--- a/libcst/_nodes/tests/base.py
+++ b/libcst/_nodes/tests/base.py
@@ -100,11 +100,6 @@ class CSTNodeTest(UnitTest):
         if provider is not None:
             self.assertEqual(provider._computed[node], expected_position)
 
-            # TODO: remove this
-            self.assertEqual(
-                node._metadata[SyntacticPositionProvider], expected_position
-            )
-
     def __assert_children_match_codegen(self, node: cst.CSTNode) -> None:
         children = node.children
         codegen_children = self.__derive_children_from_codegen(node)

--- a/libcst/_nodes/tests/test_internal.py
+++ b/libcst/_nodes/tests/test_internal.py
@@ -79,11 +79,6 @@ class InternalTest(UnitTest):
             state.provider._computed[node], CodeRange.create((1, 0), (1, 6))
         )
 
-        # TODO: remove this
-        self.assertEqual(
-            node._metadata[BasicPositionProvider], CodeRange.create((1, 0), (1, 6))
-        )
-
     def test_syntactic_position(self) -> None:
         # create a dummy node
         node = cst.Pass()
@@ -102,9 +97,4 @@ class InternalTest(UnitTest):
         # check syntactic position ignores whitespace
         self.assertEqual(
             state.provider._computed[node], CodeRange.create((1, 1), (1, 5))
-        )
-
-        # TODO: remove this
-        self.assertEqual(
-            node._metadata[SyntacticPositionProvider], CodeRange.create((1, 1), (1, 5))
         )

--- a/libcst/_nodes/tests/test_module.py
+++ b/libcst/_nodes/tests/test_module.py
@@ -144,9 +144,6 @@ class ModuleTest(CSTNodeTest):
 
         self.assertEqual(provider._computed[module], expected)
 
-        # TODO: remove this
-        self.assertEqual(module._metadata[SyntacticPositionProvider], expected)
-
     def cmp_position(
         self, actual: CodeRange, start: Tuple[int, int], end: Tuple[int, int]
     ) -> None:

--- a/libcst/metadata/_resolver.py
+++ b/libcst/metadata/_resolver.py
@@ -21,6 +21,9 @@ if TYPE_CHECKING:
 def _gather_providers(
     providers: Collection[ProviderT], gathered: MutableSet[ProviderT]
 ) -> MutableSet[ProviderT]:
+    """
+    Recursively gathers all the given providers and their dependencies.
+    """
     for P in providers:
         if P not in gathered:
             gathered.add(P)
@@ -30,8 +33,8 @@ def _gather_providers(
 
 def _resolve_impl(wrapper: "MetadataWrapper", providers: Collection[ProviderT]) -> None:
     """
-    Returns a copy of the module that contains all metadata dependencies
-    declared by the visitor.
+    Updates the _metadata map on wrapper with metadata from the given providers
+    as well as their dependencies.
     """
     providers = set(providers) - set(wrapper._metadata.keys())
     remaining = _gather_providers(providers, set())

--- a/libcst/metadata/base_provider.py
+++ b/libcst/metadata/base_provider.py
@@ -18,7 +18,6 @@ from typing import (
 )
 
 from libcst._batched_visitor import BatchableCSTVisitor
-from libcst._exceptions import MetadataException
 from libcst._visitors import CSTVisitor
 from libcst.metadata.dependent import (
     _T as _MetadataT,
@@ -49,18 +48,6 @@ class BaseMetadataProvider(_MetadataDependent, Generic[_T]):
         super().__init__()
         self._computed = {}
 
-    # TODO: remove this
-    def _run(self, module: "_ModuleT") -> "_ModuleT":
-        """
-        Returns the given module with metadata from this provider.
-
-        This is a hook for metadata runner and should not be called directly.
-        Any implementation of this method should not handle any dependencies
-        declared by this provider and should not have any side effects besides
-        setting metadata computed by this provider.
-        """
-        ...
-
     def _gen(self, wrapper: "MetadataWrapper") -> Mapping["CSTNode", _T]:
         """
         Returns the given module with metadata from this provider.
@@ -86,7 +73,6 @@ class BaseMetadataProvider(_MetadataDependent, Generic[_T]):
         """
         Maps the given node to a metadata value.
         """
-        node._metadata[type(self)] = value  # TODO: remove this
         self._computed[node] = value
 
     def get_metadata(
@@ -112,28 +98,14 @@ class VisitorMetadataProvider(CSTVisitor, BaseMetadataProvider[_T]):
     Extend this to compute metadata with a non-batchable visitor.
     """
 
-    # TODO: remove this
-    def _run(self, module: "_ModuleT") -> "_ModuleT":
-        """
-        Returns the given module with metadata from this provider.
-        """
-        return module.visit(self, use_compatible=False)
-
     def _gen_impl(self, module: "_ModuleT") -> None:
-        module.visit(self, use_compatible=False)
+        module.visit(self)
 
 
 class BatchableMetadataProvider(BatchableCSTVisitor, BaseMetadataProvider[_T]):
     """
     Extend this to compute metadata with a batchable visitor.
     """
-
-    # TODO: remove this
-    def _run(self, module: "_ModuleT") -> "_ModuleT":
-        """
-        Batchable providers are resolved using [_run_batchable].
-        """
-        raise MetadataException("BatchableMetadataProvider cannot be called directly.")
 
     def _gen_impl(self, module: "Module") -> None:
         """

--- a/libcst/metadata/base_provider.py
+++ b/libcst/metadata/base_provider.py
@@ -42,6 +42,7 @@ class BaseMetadataProvider(_MetadataDependent, Generic[_T]):
     Abstract base class for all metadata providers.
     """
 
+    # Cache of metadata computed by this provider
     _computed: MutableMapping["CSTNode", _T]
 
     def __init__(self) -> None:
@@ -50,7 +51,7 @@ class BaseMetadataProvider(_MetadataDependent, Generic[_T]):
 
     def _gen(self, wrapper: "MetadataWrapper") -> Mapping["CSTNode", _T]:
         """
-        Returns the given module with metadata from this provider.
+        Returns metadata mapping for this provider on wrapper.
 
         This is a hook for metadata resolver and should not be called directly.
         """
@@ -71,7 +72,7 @@ class BaseMetadataProvider(_MetadataDependent, Generic[_T]):
 
     def set_metadata(self, node: "CSTNode", value: _T) -> None:
         """
-        Maps the given node to a metadata value.
+        Map a given node to a metadata value.
         """
         self._computed[node] = value
 
@@ -109,7 +110,7 @@ class BatchableMetadataProvider(BatchableCSTVisitor, BaseMetadataProvider[_T]):
 
     def _gen_impl(self, module: "Module") -> None:
         """
-        Batchables providers are run through _run_batchable] so no
+        Batchables providers are resolved through _gen_batchable] so no
         implementation should be provided in _gen_impl.
         """
         pass
@@ -121,11 +122,9 @@ def _gen_batchable(
     providers: Iterable[BatchableMetadataProvider[Any]],
 ) -> Mapping[ProviderT, Mapping["CSTNode", object]]:
     """
-    Returns the given module with metadata from the given batchable providers.
-
-    Does not compute dependencies declared by providers.
+    Returns map of metadata mappings from the given batchable providers on 
+    wrapper.
     """
-    # Resolve metadata dependencies and do batched visit
     wrapper.visit_batched(providers)
 
     # Make immutable metadata mapping

--- a/libcst/metadata/position_provider.py
+++ b/libcst/metadata/position_provider.py
@@ -16,19 +16,10 @@ PositionProvider = Union["BasicPositionProvider", "SyntacticPositionProvider"]
 
 class BasicPositionProvider(BaseMetadataProvider[CodeRange]):
     """
-    Generates basic line and column metadata. Basic position is
-    defined by the start and ending bounds of a node including all whitespace
+    Generates basic line and column metadata. Basic position is defined by the
+    start and ending bounds of a node including all whitespace
     owned by that node.
     """
-
-    # TODO: remove this
-    def _run(self, module: _ModuleT) -> _ModuleT:
-        """
-        Override default generate behavior as position information is
-        calculated through codegen instead of a standard visitor.
-        """
-        module.code_for_node(module, provider=self)
-        return module
 
     def _gen_impl(self, module: _ModuleT) -> None:
         module.code_for_node(module, provider=self)
@@ -36,7 +27,7 @@ class BasicPositionProvider(BaseMetadataProvider[CodeRange]):
 
 class SyntacticPositionProvider(BasicPositionProvider):
     """
-    Generates Syntactic line and column metadata. Syntactic position is
-    defined by the start and ending bounds of a node ignoring most instances
-    of leading and trailing whitespace when it is not syntactically significant.
+    Generates Syntactic line and column metadata. Syntactic position is defined
+    by the start and ending bounds of a node ignoring most instances of leading
+    and trailing whitespace when it is not syntactically significant.
     """

--- a/libcst/metadata/tests/test_metadata_provider.py
+++ b/libcst/metadata/tests/test_metadata_provider.py
@@ -14,6 +14,7 @@ from libcst.metadata.base_provider import (
     BatchableMetadataProvider,
     VisitorMetadataProvider,
 )
+from libcst.metadata.wrapper import MetadataWrapper
 from libcst.testing.utils import UnitTest
 
 
@@ -56,7 +57,7 @@ class MetadataProviderTest(UnitTest):
                 test.assertEqual(self.get_metadata(DependentProvider, node), 2)
 
         module = parse_module("pass")
-        module.visit(DependentVisitor())
+        MetadataWrapper(module).visit(DependentVisitor())
 
     def test_batched_provider(self) -> None:
         """
@@ -89,7 +90,7 @@ class MetadataProviderTest(UnitTest):
                 test.assertEqual(self.get_metadata(BatchedProviderB, node), "a")
 
         module = parse_module("pass")
-        module.visit(DependentVisitor())
+        MetadataWrapper(module).visit(DependentVisitor())
 
         # Check that each batchable visitor is only called once
         mock.visited_a.assert_called_once()
@@ -166,7 +167,7 @@ class MetadataProviderTest(UnitTest):
                 test.assertEqual(self.get_metadata(DependentProvider, node), 5)
 
         module = parse_module("pass")
-        module.visit(DependentVisitor())
+        MetadataWrapper(module).visit(DependentVisitor())
 
         # Check each visitor is called once
         mock.visited_simple.assert_called_once()
@@ -195,7 +196,7 @@ class MetadataProviderTest(UnitTest):
                 test_runner.assertEqual(self.get_metadata(SimpleProvider, node), 1)
 
         module = parse_module("pass")
-        module.visit(VisitorB())
+        MetadataWrapper(module).visit(VisitorB())
 
         # Check each visitor is called once
         mock.visited_simple.assert_called_once()
@@ -225,7 +226,7 @@ class MetadataProviderTest(UnitTest):
             METADATA_DEPENDENCIES = (ProviderC,)
 
         module = parse_module("pass")
-        module.visit(Visitor())
+        MetadataWrapper(module).visit(Visitor())
 
         # Check each visitor is called once
         mock.visited_a.assert_called_once()
@@ -256,7 +257,7 @@ class MetadataProviderTest(UnitTest):
             METADATA_DEPENDENCIES = (ProviderC,)
 
         module = parse_module("pass")
-        module.visit(VisitorA())
+        MetadataWrapper(module).visit(VisitorA())
 
         # Check each visitor is called once
         mock.visited_a.assert_called_once()
@@ -324,7 +325,7 @@ class MetadataProviderTest(UnitTest):
         with self.assertRaisesRegex(
             KeyError, "ProviderB is not declared as a dependency from AVisitor"
         ):
-            cst.Module([]).visit(AVisitor())
+            MetadataWrapper(cst.Module([])).visit(AVisitor())
 
     def test_circular_dependency(self) -> None:
         """
@@ -342,4 +343,4 @@ class MetadataProviderTest(UnitTest):
         with self.assertRaisesRegex(
             MetadataException, "Detected circular dependencies in ProviderA"
         ):
-            cst.Module([]).visit(BadVisitor())
+            MetadataWrapper(cst.Module([])).visit(BadVisitor())

--- a/libcst/metadata/tests/test_position_provider.py
+++ b/libcst/metadata/tests/test_position_provider.py
@@ -6,7 +6,7 @@
 # pyre-strict
 import libcst as cst
 from libcst import CodeRange, parse_module
-from libcst._batched_visitor import BatchableCSTVisitor, visit_batched
+from libcst._batched_visitor import BatchableCSTVisitor
 from libcst._visitors import CSTTransformer
 from libcst.metadata.position_provider import SyntacticPositionProvider
 from libcst.metadata.wrapper import MetadataWrapper
@@ -20,7 +20,6 @@ class PositionProviderTest(UnitTest):
             SimpleProvider -> 1
             DependentProvider - > 2
         """
-
         test = self
 
         class DependentVisitor(CSTTransformer):
@@ -29,10 +28,6 @@ class PositionProviderTest(UnitTest):
             def visit_Pass(self, node: cst.Pass) -> None:
                 range = self.get_metadata(SyntacticPositionProvider, node)
                 test.assertEqual(range, CodeRange.create((1, 0), (1, 4)))
-
-        # TODO: remove compatibility test
-        module = parse_module("pass")
-        module.visit(DependentVisitor())
 
         wrapper = MetadataWrapper(parse_module("pass"))
         wrapper.visit(DependentVisitor())
@@ -46,9 +41,6 @@ class PositionProviderTest(UnitTest):
             def visit_Pass(self, node: cst.Pass) -> None:
                 range = self.get_metadata(SyntacticPositionProvider, node)
                 test.assertEqual(range, CodeRange.create((1, 0), (1, 4)))
-
-        # TODO: remove compatibility test
-        visit_batched(parse_module("pass"), [ABatchable()])
 
         wrapper = MetadataWrapper(parse_module("pass"))
         wrapper.visit_batched([ABatchable()])

--- a/libcst/metadata/wrapper.py
+++ b/libcst/metadata/wrapper.py
@@ -53,7 +53,8 @@ class MetadataWrapper:
         self, provider: Type["BaseMetadataProvider[_T]"]
     ) -> Mapping["CSTNode", _T]:
         """
-        Returns a copy of a node-metadata map.
+        Resolves all the given metadata provider on the wrapped module and
+        returns a copy of the metadata mapping.
         """
         if provider in self._metadata:
             metadata = self._metadata[provider]
@@ -67,8 +68,10 @@ class MetadataWrapper:
         self, providers: Collection["ProviderT"]
     ) -> Mapping["ProviderT", Mapping["CSTNode", object]]:
         """
-        Returns a copy of the internal map of provider to
-        node-metadata maps.
+        Resolves all the given metadata providers on the wrapped module and
+        returns a copy of the map of metadata mappings.
+
+        The returned map containing only metadata from the given providers.
         """
         _resolve_impl(self, providers)
 
@@ -79,8 +82,6 @@ class MetadataWrapper:
         """
         Convenience function for visitors to resolve metadata before
         performing a visit pass.
-
-        This basically hoists existing behavior out of Module.visit.
         """
         with visitor.resolve(self):
             return self.module.visit(visitor)
@@ -91,6 +92,10 @@ class MetadataWrapper:
         before_visit: Optional[VisitorMethod] = None,
         after_leave: Optional[VisitorMethod] = None,
     ) -> "CSTNode":
+        """
+        Convenience function for visitors to resolve metadata before
+        performing a batched visit pass.
+        """
         with ExitStack() as stack:
             # Resolve dependencies of visitors
             for v in visitors:

--- a/libcst/metadata/wrapper.py
+++ b/libcst/metadata/wrapper.py
@@ -83,7 +83,7 @@ class MetadataWrapper:
         This basically hoists existing behavior out of Module.visit.
         """
         with visitor.resolve(self):
-            return self.module.visit(visitor, use_compatible=False)
+            return self.module.visit(visitor)
 
     def visit_batched(
         self,
@@ -96,6 +96,4 @@ class MetadataWrapper:
             for v in visitors:
                 stack.enter_context(v.resolve(self))
 
-            return visit_batched(
-                self.module, visitors, before_visit, after_leave, use_compatible=False
-            )
+            return visit_batched(self.module, visitors, before_visit, after_leave)


### PR DESCRIPTION
## Summary
Removes compatibility hacks left in while porting code dependent on the old metadata API. This means when a node visits a visitor the metadata resolver will not be run and no deep clone will be performed. Metadata computation is now solely handled by the MetadataWrapper class.

## Test Plan
Ran tox.