### PR TITLE
Add metadata documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,7 +17,8 @@ LibCST
 
    why_libcst
    motivation
-   usage
+   tutorial
+   Metadata Tutorial <metadata_tutorial>
    parser
    nodes
    visitors

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,6 +21,7 @@ LibCST
    parser
    nodes
    visitors
+   metadata
 
 
 Indices and tables

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -1,16 +1,44 @@
+.. _libcst-metadata:
+
 Metadata
 ========
 
-.. autoclass:: libcst.BatchableCSTVisitor
-.. autofunction:: libcst.visit_batched
+LibCST ships with a metadata interface that defines a standardized way to
+associate nodes in a CST with arbitrary metadata. The metadata interface is
+designed to be declarative and type safe.
+
+Providing Metadata
+------------------
+
+Metadata is generated through provider classes that can be declared as a dependency
+by a subclass of :class:`~libcst.MetadataDependent`. These providers are then
+resolved automatically using methods provided by :class:`~libcst.MetadataWrapper`.
 
 .. autoclass:: libcst.BaseMetadataProvider
 .. autoclass:: libcst.VisitorMetadataProvider
 .. autoclass:: libcst.BatchableMetadataProvider
 
-.. autoclass:: libcst._MetadataDepedent
+Accessing Metadata
+------------------
+
+.. autoclass:: libcst.MetadataDependent
+
+.. autoclass:: libcst.MetadataWrapper
+
+Position Metadata
+-----------------
+
+Position (line and column numbers) metadata are accessible through the metadata
+interface by declaring the one of the following providers as a dependency. For
+most cases, :class:`~libcst.SytacticPositionProvider` is what you probably want.
 
 .. autoclass:: libcst.BasicPositionProvider
 .. autoclass:: libcst.SyntacticPositionProvider
 
-.. autoclass:: libcst.MetadataWrapper
+Accessing position metadata through the :class:`~libcst.MetadataDepedent`
+interface will return a :class:`~libcst.CodeRange` object.
+
+.. autoclass:: libcst.CodeRange
+	:members:
+.. autoclass:: libcst.CodePosition
+	:members:

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -7,8 +7,9 @@ LibCST ships with a metadata interface that defines a standardized way to
 associate nodes in a CST with arbitrary metadata while maintaining the immutability
 of the tree. The metadata interface is designed to be declarative and type safe.
 Here's a quick example of using the metadata interface to get line and column
-numbers of nodes:
+numbers of nodes through the :class:`~libcst.SyntacticPositionProvider`:
 
+.. _libcst-metadata-position-example:
 .. code-block:: python
 
     class NamePrinter(cst.CSTVisitor):
@@ -21,17 +22,24 @@ numbers of nodes:
     wrapper = cst.MetadataWrapper(cst.parse_module("x = 1"))
     result = wrapper.visit(NamePrinter())  # should print "x found at line 1, column 0"
 
+More examples of using the metadata interface can be found on the
+:doc:`Metadata Tutorial <metadata_tutorial>`.
+
 Accessing Metadata
 ------------------
 
-Metadata providers are declared as dependencies by a :class:`~libcst.MetadataDependent`
-or any of its subclasses and will be computed automatically whenever visited
-by a :class:`~libcst.MetadataWrapper`. Alternatively, you can use 
-:func:`~libcst.MetadataWrapper.resolve` or :func:`~libcst.MetadataWrapper.resolve_many`
-in the wrapper to generate and access metadata directly.
+To work with metadata you need to wrap a module with a :class:`~libcst.MetadataWrapper`.
+The wrapper provides a :func:`~libcst.MetadataWrapper.resolve` function and a
+:func:`~libcst.MetadataWrapper.resolve_many` function to generate metadata.
+
+.. autoclass:: libcst.MetadataWrapper
+
+If you're working with visitors, which extend :class:`~libcst.MetadataDependent`, 
+metadata dependencies will be automatically computed when visited by a 
+:class:`~libcst.MetadataWrapper` and are accessible through
+:func:`~libcst.MetadataDependent.get_metadata`
 
 .. autoclass:: libcst.MetadataDependent
-.. autoclass:: libcst.MetadataWrapper
 
 Providing Metadata
 ------------------
@@ -39,10 +47,16 @@ Providing Metadata
 Metadata is generated through provider classes that can be declared as a dependency
 by a subclass of :class:`~libcst.MetadataDependent`. These providers are then
 resolved automatically using methods provided by :class:`~libcst.MetadataWrapper`.
+In most cases, you should extend :class:`~libcst.BatchableMetadataProvider` when
+writing a provider, unless you have a particular reason to not to use a
+batchable visitor. Only extend from :class:`~libcst.BaseMetadataProvider` if
+your provider does not use the visitor pattern for computing metadata for a tree.
 
 .. autoclass:: libcst.BaseMetadataProvider
-.. autoclass:: libcst.VisitorMetadataProvider
 .. autoclass:: libcst.BatchableMetadataProvider
+.. autoclass:: libcst.VisitorMetadataProvider
+
+.. _libcst-metadata-position:
 
 Position Metadata
 -----------------
@@ -51,7 +65,8 @@ Position (line and column numbers) metadata are accessible through the metadata
 interface by declaring the one of the following providers as a dependency. For
 most cases, :class:`~libcst.SyntacticPositionProvider` is what you probably want.
 Accessing position metadata through the :class:`~libcst.MetadataDepedent`
-interface will return a :class:`~libcst.CodeRange` object.
+interface will return a :class:`~libcst.CodeRange` object. See
+:ref:`the above example<libcst-metadata-position-example>`.
 
 .. autoclass:: libcst.BasicPositionProvider
 .. autoclass:: libcst.SyntacticPositionProvider

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -16,7 +16,6 @@ resolve methods is used. Alternatively, you can use one of the visit methods in
 the wrapper when working with visitors.
 
 .. autoclass:: libcst.MetadataDependent
-
 .. autoclass:: libcst.MetadataWrapper
 
 Providing Metadata
@@ -36,12 +35,11 @@ Position Metadata
 Position (line and column numbers) metadata are accessible through the metadata
 interface by declaring the one of the following providers as a dependency. For
 most cases, :class:`~libcst.SytacticPositionProvider` is what you probably want.
+Accessing position metadata through the :class:`~libcst.MetadataDepedent`
+interface will return a :class:`~libcst.CodeRange` object.
 
 .. autoclass:: libcst.BasicPositionProvider
 .. autoclass:: libcst.SyntacticPositionProvider
-
-Accessing position metadata through the :class:`~libcst.MetadataDepedent`
-interface will return a :class:`~libcst.CodeRange` object.
 
 .. autoclass:: libcst.CodeRange
     :members:

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -1,0 +1,16 @@
+Metadata
+========
+
+.. autoclass:: libcst.BatchableCSTVisitor
+.. autofunction:: libcst.visit_batched
+
+.. autoclass:: libcst.BaseMetadataProvider
+.. autoclass:: libcst.VisitorMetadataProvider
+.. autoclass:: libcst.BatchableMetadataProvider
+
+.. autoclass:: libcst._MetadataDepedent
+
+.. autoclass:: libcst.BasicPositionProvider
+.. autoclass:: libcst.SyntacticPositionProvider
+
+.. autoclass:: libcst.MetadataWrapper

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -6,14 +6,29 @@ Metadata
 LibCST ships with a metadata interface that defines a standardized way to
 associate nodes in a CST with arbitrary metadata while maintaining the immutability
 of the tree. The metadata interface is designed to be declarative and type safe.
+Here's a quick example of using the metadata interface to get line and column
+numbers of nodes:
+
+.. code-block:: python
+
+    class NamePrinter(cst.CSTVisitor):
+        METADATA_DEPENDENCIES = (cst.SyntacticPositionProvider,)
+
+        def visit_Name(self, node: cst.Name) -> None:
+            pos = self.get_metadata(cst.SyntacticPositionProvider, node).start
+            print(f"{node.value} found at line {pos.line}, column {pos.column}")
+
+    wrapper = cst.MetadataWrapper(cst.parse_module("x = 1"))
+    result = wrapper.visit(NamePrinter())  # should print "x found at line 1, column 0"
 
 Accessing Metadata
 ------------------
 
 Metadata providers are declared as dependencies by a :class:`~libcst.MetadataDependent`
-or any of its subclasses and will be computed automatically whenever one of the
-resolve methods is used. Alternatively, you can use one of the visit methods in
-the wrapper when working with visitors.
+or any of its subclasses and will be computed automatically whenever visited
+by a :class:`~libcst.MetadataWrapper`. Alternatively, you can use 
+:func:`~libcst.MetadataWrapper.resolve` or :func:`~libcst.MetadataWrapper.resolve_many`
+in the wrapper to generate and access metadata directly.
 
 .. autoclass:: libcst.MetadataDependent
 .. autoclass:: libcst.MetadataWrapper
@@ -34,7 +49,7 @@ Position Metadata
 
 Position (line and column numbers) metadata are accessible through the metadata
 interface by declaring the one of the following providers as a dependency. For
-most cases, :class:`~libcst.SytacticPositionProvider` is what you probably want.
+most cases, :class:`~libcst.SyntacticPositionProvider` is what you probably want.
 Accessing position metadata through the :class:`~libcst.MetadataDepedent`
 interface will return a :class:`~libcst.CodeRange` object.
 
@@ -42,6 +57,4 @@ interface will return a :class:`~libcst.CodeRange` object.
 .. autoclass:: libcst.SyntacticPositionProvider
 
 .. autoclass:: libcst.CodeRange
-    :members:
 .. autoclass:: libcst.CodePosition
-    :members:

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -4,8 +4,8 @@ Metadata
 ========
 
 LibCST ships with a metadata interface that defines a standardized way to
-associate nodes in a CST with arbitrary metadata. The metadata interface is
-designed to be declarative and type safe.
+associate nodes in a CST with arbitrary metadata while maintaining the immutability
+of the tree. The metadata interface is designed to be declarative and type safe.
 
 Accessing Metadata
 ------------------
@@ -45,24 +45,3 @@ interface will return a :class:`~libcst.CodeRange` object.
     :members:
 .. autoclass:: libcst.CodePosition
     :members:
-
-Usage
------
-
-Here's an example of a visitor that prints out the starting position of every
-:class:`~libcst.Name` node.
-
-.. code-block:: python
-
-    import libcst as cst
-
-    class NamePrinter(cst.CSTVisitor):
-        METADATA_DEPENDENCIES = (cst.SyntacticPositionProvider,)
-
-        def visit_Name(self, node: cst.Name) -> None:
-            pos = self.get_metadata(cst.SyntacticPositionProvider, node).start
-            print(f"{node.value} found at line {pos.line}, column {pos.column}")
-
-    module = cst.parse_module("x = 1")
-    wrapper = cst.MetadataWrapper(module)
-    wrapper.visit(NamePrinter())  # should print "x found at line 1, column 0"

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -7,6 +7,18 @@ LibCST ships with a metadata interface that defines a standardized way to
 associate nodes in a CST with arbitrary metadata. The metadata interface is
 designed to be declarative and type safe.
 
+Accessing Metadata
+------------------
+
+Metadata providers are declared as dependencies by a :class:`~libcst.MetadataDependent`
+or any of its subclasses and will be computed automatically whenever one of the
+resolve methods is used. Alternatively, you can use one of the visit methods in
+the wrapper when working with visitors.
+
+.. autoclass:: libcst.MetadataDependent
+
+.. autoclass:: libcst.MetadataWrapper
+
 Providing Metadata
 ------------------
 
@@ -17,13 +29,6 @@ resolved automatically using methods provided by :class:`~libcst.MetadataWrapper
 .. autoclass:: libcst.BaseMetadataProvider
 .. autoclass:: libcst.VisitorMetadataProvider
 .. autoclass:: libcst.BatchableMetadataProvider
-
-Accessing Metadata
-------------------
-
-.. autoclass:: libcst.MetadataDependent
-
-.. autoclass:: libcst.MetadataWrapper
 
 Position Metadata
 -----------------
@@ -39,6 +44,27 @@ Accessing position metadata through the :class:`~libcst.MetadataDepedent`
 interface will return a :class:`~libcst.CodeRange` object.
 
 .. autoclass:: libcst.CodeRange
-	:members:
+    :members:
 .. autoclass:: libcst.CodePosition
-	:members:
+    :members:
+
+Usage
+-----
+
+Here's an example of a visitor that prints out the starting position of every
+:class:`~libcst.Name` node.
+
+.. code-block:: python
+
+    import libcst as cst
+
+    class NamePrinter(cst.CSTVisitor):
+        METADATA_DEPENDENCIES = (cst.SyntacticPositionProvider,)
+
+        def visit_Name(self, node: cst.Name) -> None:
+            pos = self.get_metadata(cst.SyntacticPositionProvider, node).start
+            print(f"{node.value} found at line {pos.line}, column {pos.column}")
+
+    module = cst.parse_module("x = 1")
+    wrapper = cst.MetadataWrapper(module)
+    wrapper.visit(NamePrinter())  # should print "x found at line 1, column 0"

--- a/docs/source/metadata_tutorial.ipynb
+++ b/docs/source/metadata_tutorial.ipynb
@@ -1,0 +1,79 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "=====================\n",
+    "Working with Metadata\n",
+    "=====================\n",
+    "LibCST handles node metadata in a somewhat unusal manner in order to maintain the immutability of the tree. See :doc:`Metadata <metadata>` for the complete documentation. Here's an example of a provider that lablels marks nodes as function parameters that is used by a visitor that prints all names that are function parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import libcst as cst\n",
+    "\n",
+    "\n",
+    "class IsParamProvider(cst.BatchableMetadataProvider[bool]):\n",
+    "    \"\"\"\n",
+    "    Marks Name nodes found as a parameter to a function.\n",
+    "    \"\"\"\n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "        self.is_param = False\n",
+    "    \n",
+    "    def visit_Param(self, node: cst.Param) -> None:\n",
+    "        # Mark the child Name node as a parameter \n",
+    "        self.set_metadata(node.name, True)\n",
+    "        \n",
+    "    def visit_Name(self, node: cst.Name) -> None:\n",
+    "        # Mark all other Name nodes as not parameters\n",
+    "        if not self.get_metadata(type(self), node, False):\n",
+    "            self.set_metadata(node, False)\n",
+    "\n",
+    "\n",
+    "class ParamPrinter(cst.CSTVisitor):\n",
+    "    METADATA_DEPENDENCIES = (IsParamProvider, cst.SyntacticPositionProvider,)\n",
+    "\n",
+    "    def visit_Name(self, node: cst.Name) -> None:\n",
+    "        # Only print out names that are parameters\n",
+    "        if self.get_metadata(IsParamProvider, node):\n",
+    "            pos = self.get_metadata(cst.SyntacticPositionProvider, node).start\n",
+    "            print(f\"{node.value} found at line {pos.line}, column {pos.column}\")\n",
+    "\n",
+    "\n",
+    "wrapper = cst.MetadataWrapper(cst.parse_module(\"def foo(x):\\n    y = 1\\n    return x + y\"))\n",
+    "result = wrapper.visit(ParamPrinter())"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Raw Cell Format",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2+"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/source/metadata_tutorial.ipynb
+++ b/docs/source/metadata_tutorial.ipynb
@@ -9,7 +9,13 @@
     "=====================\n",
     "Working with Metadata\n",
     "=====================\n",
-    "LibCST handles node metadata in a somewhat unusal manner in order to maintain the immutability of the tree. See :doc:`Metadata <metadata>` for the complete documentation. Here's an example of a provider that lablels marks nodes as function parameters that is used by a visitor that prints all names that are function parameters."
+    "LibCST handles node metadata in a somewhat unusal manner in order to maintain the immutability of the tree. See :doc:`Metadata <metadata>` for the complete documentation. \n",
+    "\n",
+    "Providing Metadata\n",
+    "==================\n",
+    "While it's possible to write visitors that gather metadata from a tree ad hoc, using the provider interface gives you the advantage of being able to use dependency declaration to automatically run your providers in other visitors and type safety. For most cases, you'll want to extend :class:`~libcst.BatchableMetadataProvider` as providers that extend from that class can be resolved more efficiently in batches.\n",
+    "\n",
+    "Here's an example of a simple metadata provider that marks :class:`~libcst.Name` nodes that are function parameters:"
    ]
   },
   {
@@ -36,9 +42,60 @@
     "    def visit_Name(self, node: cst.Name) -> None:\n",
     "        # Mark all other Name nodes as not parameters\n",
     "        if not self.get_metadata(type(self), node, False):\n",
-    "            self.set_metadata(node, False)\n",
+    "            self.set_metadata(node, False)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "Line and Column Metadata\n",
+    "------------------------\n",
+    "LibCST ships with two built-in providers for line and column metadata. See :ref:`Position Metadata<libcst-metadata-position>` for more information.\n",
     "\n",
+    "Accessing Metadata\n",
+    "==================\n",
+    "Once you have a provider, the metadata interface gives you two primary ways of working with your providers. The first is using the resolve methods provided by :class:`~libcst.MetadataWrapper` and the second is through declaring metadata dependencies on a :class:`~libcst.CSTTransformer` or :class:`~libcst.CSTVisitor`.\n",
     "\n",
+    "Using the :class:`~libcst.MetadataWrapper`\n",
+    "------------------------------------------\n",
+    "The metadata wrapper class provides a way to associate metadata with a module as well as a simple inteface to run providers. Here's an example of using a wrapper with the provider we just wrote:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "module = cst.parse_module(\"x\")\n",
+    "wrapper = cst.MetadataWrapper(module)\n",
+    "\n",
+    "isparam = wrapper.resolve(IsParamProvider)\n",
+    "x_name_node = wrapper.module.body[0].body[0].value\n",
+    "\n",
+    "print(isparam[x_name_node])  # should print False"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "Using Dependency Declaration\n",
+    "----------------------------\n",
+    "The visitors that ship with LibCST can declare metadata providers as dependencies that will be run automatically when visited by a wrapper. Here is a visitor that prints all names that are function parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "class ParamPrinter(cst.CSTVisitor):\n",
     "    METADATA_DEPENDENCIES = (IsParamProvider, cst.SyntacticPositionProvider,)\n",
     "\n",
@@ -49,7 +106,8 @@
     "            print(f\"{node.value} found at line {pos.line}, column {pos.column}\")\n",
     "\n",
     "\n",
-    "wrapper = cst.MetadataWrapper(cst.parse_module(\"def foo(x):\\n    y = 1\\n    return x + y\"))\n",
+    "module = cst.parse_module(\"def foo(x):\\n    y = 1\\n    return x + y\")\n",
+    "wrapper = cst.MetadataWrapper(module)\n",
     "result = wrapper.visit(ParamPrinter())"
    ]
   }

--- a/docs/source/tutorial.ipynb
+++ b/docs/source/tutorial.ipynb
@@ -6,16 +6,15 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "===== \n",
-    "Usage\n",
-    "=====\n",
+    "========\n",
+    "Tutorial\n",
+    "========\n",
     "\n",
     "LibCST provides helpers to parse source code string as concrete syntax tree. In order to perform static analysis to identify patterns in the tree or modify the tree programmatically, we can use visitor pattern to traverse the tree. In this tutorial, we demonstrate a common three-step-workflow to build an automated refactoring (codemod) application:\n",
     "\n",
     "1. `Parse Source Code <#Parse-Source-Code>`_\n",
     "2. `Build Visitor or Transformer <#Build-Visitor-or-Transformer>`_\n",
     "3. `Generate Source Code <#Generate-Source-Code>`_\n",
-    "4. `Work with Metadata <#Working with Metadata>`_\n",
     "\n",
     "Parse Source Code\n",
     "=================\n",
@@ -24,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -36,41 +35,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "BinaryOperation(\n",
-       "    left=Integer(\n",
-       "        value='1',\n",
-       "        lpar=[],\n",
-       "        rpar=[],\n",
-       "    ),\n",
-       "    operator=Add(\n",
-       "        whitespace_before=SimpleWhitespace(\n",
-       "            value=' ',\n",
-       "        ),\n",
-       "        whitespace_after=SimpleWhitespace(\n",
-       "            value=' ',\n",
-       "        ),\n",
-       "    ),\n",
-       "    right=Integer(\n",
-       "        value='2',\n",
-       "        lpar=[],\n",
-       "        rpar=[],\n",
-       "    ),\n",
-       "    lpar=[],\n",
-       "    rpar=[],\n",
-       ")"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import libcst as cst\n",
     "\n",
@@ -90,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,61 +191,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "class PythonToken(Token):\n",
-      "    def __repr__(self) -> str:\n",
-      "        return ('TokenInfo(type=%s, string=%r, start_pos=%r, prefix=%r)' %\n",
-      "                self._replace(type=self.type.name))\n",
-      "\n",
-      "def tokenize(code: str, version_info: PythonVersionInfo, start_pos: Tuple[int, int] = (1, 0)\n",
-      ") -> Generator[PythonToken, None, None]:\n",
-      "    \"\"\"Generate tokens from a the source code (string).\"\"\"\n",
-      "    lines = split_lines(code, keepends=True)\n",
-      "    return tokenize_lines(lines, version_info, start_pos=start_pos)\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(modified_tree.code)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "--- \n",
-      "+++ \n",
-      "@@ -1,10 +1,11 @@\n",
-      " \n",
-      " class PythonToken(Token):\n",
-      "-    def __repr__(self):\n",
-      "+    def __repr__(self) -> str:\n",
-      "         return ('TokenInfo(type=%s, string=%r, start_pos=%r, prefix=%r)' %\n",
-      "                 self._replace(type=self.type.name))\n",
-      " \n",
-      "-def tokenize(code, version_info, start_pos=(1, 0)):\n",
-      "+def tokenize(code: str, version_info: PythonVersionInfo, start_pos: Tuple[int, int] = (1, 0)\n",
-      "+) -> Generator[PythonToken, None, None]:\n",
-      "     \"\"\"Generate tokens from a the source code (string).\"\"\"\n",
-      "     lines = split_lines(code, keepends=True)\n",
-      "     return tokenize_lines(lines, version_info, start_pos=start_pos)\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Use difflib to show the changes to verify type annotations were added as expected.\n",
     "import difflib\n",
@@ -301,50 +225,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "if not modified_tree.deep_equals(source_tree):\n",
     "    ...  # write to file"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {
-    "raw_mimetype": "text/restructuredtext"
-   },
-   "source": [
-    "Work with Metadata\n",
-    "==================\n",
-    "LibCST handles node metadata in a somewhat unusal manner in order to maintain the immutability of the tree. See :doc:`Metadata <metadata>` for the complete documentation. Here's an example of a visitor that prints out the starting position of every :class:`~libcst.Name` node."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "x found at line 1, column 0\n"
-     ]
-    }
-   ],
-   "source": [
-    "import libcst as cst\n",
-    "\n",
-    "class NamePrinter(cst.CSTVisitor):\n",
-    "    METADATA_DEPENDENCIES = (cst.SyntacticPositionProvider,)\n",
-    "\n",
-    "    def visit_Name(self, node: cst.Name) -> None:\n",
-    "        pos = self.get_metadata(cst.SyntacticPositionProvider, node).start\n",
-    "        print(f\"{node.value} found at line {pos.line}, column {pos.column}\")\n",
-    "\n",
-    "wrapper = cst.MetadataWrapper(cst.parse_module(\"x = 1\"))\n",
-    "result = wrapper.visit(NamePrinter())  # should print \"x found at line 1, column 0\""
    ]
   }
  ],

--- a/docs/source/usage.ipynb
+++ b/docs/source/usage.ipynb
@@ -15,6 +15,7 @@
     "1. `Parse Source Code <#Parse-Source-Code>`_\n",
     "2. `Build Visitor or Transformer <#Build-Visitor-or-Transformer>`_\n",
     "3. `Generate Source Code <#Generate-Source-Code>`_\n",
+    "4. `Work with Metadata <#Working with Metadata>`_\n",
     "\n",
     "Parse Source Code\n",
     "=================\n",
@@ -23,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -35,9 +36,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "BinaryOperation(\n",
+       "    left=Integer(\n",
+       "        value='1',\n",
+       "        lpar=[],\n",
+       "        rpar=[],\n",
+       "    ),\n",
+       "    operator=Add(\n",
+       "        whitespace_before=SimpleWhitespace(\n",
+       "            value=' ',\n",
+       "        ),\n",
+       "        whitespace_after=SimpleWhitespace(\n",
+       "            value=' ',\n",
+       "        ),\n",
+       "    ),\n",
+       "    right=Integer(\n",
+       "        value='2',\n",
+       "        lpar=[],\n",
+       "        rpar=[],\n",
+       "    ),\n",
+       "    lpar=[],\n",
+       "    rpar=[],\n",
+       ")"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import libcst as cst\n",
     "\n",
@@ -57,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,13 +127,13 @@
    "source": [
     "Build Visitor or Transformer\n",
     "============================\n",
-    "For traversing and modifying the tree, LibCST provides Visitor and Transformer similar to the `ast module <https://docs.python.org/3/library/ast.html#ast.NodeVisitor>`_. To implement a visitor (read only) or transformer (read/write), simply implement a subclass of :class:`~libcst.CSTVisitor` or :class:`~libcst.CSTTransformer` (see :doc:`Visitors <visitors>` for more detail).\n",
+    "For traversing and modifying the tree, LibCST provides Visitor and Transformer classes similar to the `ast module <https://docs.python.org/3/library/ast.html#ast.NodeVisitor>`_. To implement a visitor (read only) or transformer (read/write), simply implement a subclass of :class:`~libcst.CSTVisitor` or :class:`~libcst.CSTTransformer` (see :doc:`Visitors <visitors>` for more detail).\n",
     "In the typing example, we need to implement a visitor to collect typing annotation from the stub tree and a transformer to copy the annotation to the function signature. In the visitor, we implement ``visit_FunctionDef`` to collect annotations. Later in the transformer, we implement ``leave_FunctionDef`` to add the collected annotations."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,18 +224,61 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "class PythonToken(Token):\n",
+      "    def __repr__(self) -> str:\n",
+      "        return ('TokenInfo(type=%s, string=%r, start_pos=%r, prefix=%r)' %\n",
+      "                self._replace(type=self.type.name))\n",
+      "\n",
+      "def tokenize(code: str, version_info: PythonVersionInfo, start_pos: Tuple[int, int] = (1, 0)\n",
+      ") -> Generator[PythonToken, None, None]:\n",
+      "    \"\"\"Generate tokens from a the source code (string).\"\"\"\n",
+      "    lines = split_lines(code, keepends=True)\n",
+      "    return tokenize_lines(lines, version_info, start_pos=start_pos)\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "print(modified_tree.code)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- \n",
+      "+++ \n",
+      "@@ -1,10 +1,11 @@\n",
+      " \n",
+      " class PythonToken(Token):\n",
+      "-    def __repr__(self):\n",
+      "+    def __repr__(self) -> str:\n",
+      "         return ('TokenInfo(type=%s, string=%r, start_pos=%r, prefix=%r)' %\n",
+      "                 self._replace(type=self.type.name))\n",
+      " \n",
+      "-def tokenize(code, version_info, start_pos=(1, 0)):\n",
+      "+def tokenize(code: str, version_info: PythonVersionInfo, start_pos: Tuple[int, int] = (1, 0)\n",
+      "+) -> Generator[PythonToken, None, None]:\n",
+      "     \"\"\"Generate tokens from a the source code (string).\"\"\"\n",
+      "     lines = split_lines(code, keepends=True)\n",
+      "     return tokenize_lines(lines, version_info, start_pos=start_pos)\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# Use difflib to show the changes to verify type annotations were added as expected.\n",
     "import difflib\n",
@@ -225,12 +301,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
     "if not modified_tree.deep_equals(source_tree):\n",
     "    ...  # write to file"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "Work with Metadata\n",
+    "==================\n",
+    "LibCST handles node metadata in a somewhat unusal manner in order to maintain the immutability of the tree. See :doc:`Metadata <metadata>` for the complete documentation. Here's an example of a visitor that prints out the starting position of every :class:`~libcst.Name` node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x found at line 1, column 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import libcst as cst\n",
+    "\n",
+    "class NamePrinter(cst.CSTVisitor):\n",
+    "    METADATA_DEPENDENCIES = (cst.SyntacticPositionProvider,)\n",
+    "\n",
+    "    def visit_Name(self, node: cst.Name) -> None:\n",
+    "        pos = self.get_metadata(cst.SyntacticPositionProvider, node).start\n",
+    "        print(f\"{node.value} found at line {pos.line}, column {pos.column}\")\n",
+    "\n",
+    "wrapper = cst.MetadataWrapper(cst.parse_module(\"x = 1\"))\n",
+    "result = wrapper.visit(NamePrinter())  # should print \"x found at line 1, column 0\""
    ]
   }
  ],
@@ -251,7 +365,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.2+"
   }
  },
  "nbformat": 4,

--- a/docs/source/visitors.rst
+++ b/docs/source/visitors.rst
@@ -43,3 +43,14 @@ An example Python REPL using the above visitor is as follows::
     >>> _ = demo.visit(FooingAround())
     'abc'
     '123'
+
+
+Batched Visitors
+----------------
+
+A batchable visitor classs is provided to facilitate performing operations that
+can be performed in parallel in a single traversal over a CST. An example of this
+is :ref:`metadata computation<libcst-metadata>`.
+
+.. autoclass:: libcst.BatchableCSTVisitor
+.. autofunction:: libcst.visit_batched

--- a/docs/source/visitors.rst
+++ b/docs/source/visitors.rst
@@ -48,7 +48,7 @@ An example Python REPL using the above visitor is as follows::
 Batched Visitors
 ----------------
 
-A batchable visitor classs is provided to facilitate performing operations that
+A batchable visitor class is provided to facilitate performing operations that
 can be performed in parallel in a single traversal over a CST. An example of this
 is :ref:`metadata computation<libcst-metadata>`.
 

--- a/libcst/__init__.py
+++ b/libcst/__init__.py
@@ -190,7 +190,7 @@ from libcst.metadata.base_provider import (
     BatchableMetadataProvider,
     VisitorMetadataProvider,
 )
-from libcst.metadata.dependent import _MetadataDependent
+from libcst.metadata.dependent import MetadataDependent
 from libcst.metadata.position_provider import (
     BasicPositionProvider,
     SyntacticPositionProvider,
@@ -384,7 +384,7 @@ __all__ = [
     "BaseMetadataProvider",
     "BatchableMetadataProvider",
     "VisitorMetadataProvider",
-    "_MetadataDependent",
+    "MetadataDependent",
     "BasicPositionProvider",
     "SyntacticPositionProvider",
     "MetadataWrapper",

--- a/libcst/__init__.py
+++ b/libcst/__init__.py
@@ -185,6 +185,17 @@ from libcst._parser._entrypoints import parse_expression, parse_module, parse_st
 from libcst._parser._types.config import PartialParserConfig
 from libcst._removal_sentinel import RemovalSentinel
 from libcst._visitors import CSTNodeT, CSTTransformer, CSTVisitor, CSTVisitorT
+from libcst.metadata.base_provider import (
+    BaseMetadataProvider,
+    BatchableMetadataProvider,
+    VisitorMetadataProvider,
+)
+from libcst.metadata.dependent import _MetadataDependent
+from libcst.metadata.position_provider import (
+    BasicPositionProvider,
+    SyntacticPositionProvider,
+)
+from libcst.metadata.wrapper import MetadataWrapper
 
 
 __all__ = [
@@ -370,4 +381,11 @@ __all__ = [
     "ParenthesizedWhitespace",
     "SimpleWhitespace",
     "TrailingWhitespace",
+    "BaseMetadataProvider",
+    "BatchableMetadataProvider",
+    "VisitorMetadataProvider",
+    "_MetadataDependent",
+    "BasicPositionProvider",
+    "SyntacticPositionProvider",
+    "MetadataWrapper",
 ]

--- a/libcst/_batched_visitor.py
+++ b/libcst/_batched_visitor.py
@@ -8,7 +8,6 @@ import inspect
 from typing import (
     TYPE_CHECKING,
     Callable,
-    Collection,
     Iterable,
     List,
     Mapping,
@@ -33,13 +32,17 @@ _VisitorMethodCollection = Mapping[str, List[VisitorMethod]]
 
 class BatchableCSTVisitor(CSTTypedVisitorFunctions, _MetadataDependent):
     """
-    Extend this class for each type of batched operation you want to perform.
+    The low-level base visitor class for traversing a CST as part of a batched
+    set of traversals. This should be used in conjunction with the
+    :func:`~libcst.visit_batched` method or the
+    :func:`~libcst.MetadataWrapper.visit_batched` method to visit a tree.
+    Instances of this class cannot modify the tree.
     """
 
     def get_visitors(self) -> Mapping[str, VisitorMethod]:
         """
-        Returns a mapping of all the visit_* and leave_* methods defined by
-        this visitor, excluding all empty stubs.
+        Returns a mapping of all the ``visit_<Type[CSTNode]>`` and ``leave_<Type[CSTNode]>``
+        methods defined by this visitor, excluding all empty stubs.
         """
 
         methods = inspect.getmembers(
@@ -60,18 +63,22 @@ class BatchableCSTVisitor(CSTTypedVisitorFunctions, _MetadataDependent):
 
 def visit_batched(
     node: CSTNodeT,
-    visitors: Iterable[BatchableCSTVisitor],
+    batchable_visitors: Iterable[BatchableCSTVisitor],
     before_visit: Optional[VisitorMethod] = None,
     after_leave: Optional[VisitorMethod] = None,
 ) -> CSTNodeT:
     """
-    Returns the result of running all visitors [visitors] over [node].
+    Do a batched traversal over ``node`` with all ``visitors``.
 
-    [before_visit] and [after_leave] are provided as optional hooks to
-    execute before visit_* and after leave_* methods are executed by the
-    batched visitor.
+    ``before_visit`` and ``after_leave`` are provided as optional hooks to
+    execute before the ``visit_<Type[CSTNode]>`` and ``leave_<Type[CSTNode]>``
+    methods from each visitor in ``visitor`` are executed by the batched visitor.
+
+    This function does not handle metadata dependency resolution for ``visitors``.
+    See :func:`~libcst.MetadataWrapper.visit_batched` for batched traversal with
+    metadata dependency resolution.
     """
-    visitor_methods = _get_visitor_methods(visitors)
+    visitor_methods = _get_visitor_methods(batchable_visitors)
     batched_visitor = _BatchedCSTVisitor(
         visitor_methods, before_visit=before_visit, after_leave=after_leave
     )
@@ -81,6 +88,10 @@ def visit_batched(
 def _get_visitor_methods(
     batchable_visitors: Iterable[BatchableCSTVisitor]
 ) -> _VisitorMethodCollection:
+    """
+    Gather all ``visit_<Type[CSTNode]>`` and ``leave_<Type[CSTNode]>`` methods
+    from ``batchabled_visitors``.
+    """
     visitor_methods: MutableMapping[str, List[VisitorMethod]] = {}
     for bv in batchable_visitors:
         for name, fn in bv.get_visitors().items():
@@ -88,17 +99,10 @@ def _get_visitor_methods(
     return visitor_methods
 
 
-def _get_visitor_dependencies(
-    batchable_visitors: Iterable[BatchableCSTVisitor]
-) -> Collection["ProviderT"]:
-    dependencies = set()
-    for visitor in batchable_visitors:
-        dependencies.update(visitor.METADATA_DEPENDENCIES)
-
-    return dependencies
-
-
 class _BatchedCSTVisitor(CSTVisitor):
+    """
+    Internal visitor class to perform batched traversal over a tree.
+    """
 
     visitor_methods: _VisitorMethodCollection
     before_visit: Optional[VisitorMethod]

--- a/libcst/_batched_visitor.py
+++ b/libcst/_batched_visitor.py
@@ -18,7 +18,7 @@ from typing import (
 
 from libcst._typed_visitor_base import CSTTypedVisitorFunctions
 from libcst._visitors import CSTNodeT, CSTVisitor
-from libcst.metadata.dependent import _MetadataDependent
+from libcst.metadata.dependent import MetadataDependent
 
 
 if TYPE_CHECKING:
@@ -30,12 +30,13 @@ VisitorMethod = Callable[["CSTNode"], None]
 _VisitorMethodCollection = Mapping[str, List[VisitorMethod]]
 
 
-class BatchableCSTVisitor(CSTTypedVisitorFunctions, _MetadataDependent):
+class BatchableCSTVisitor(CSTTypedVisitorFunctions, MetadataDependent):
     """
     The low-level base visitor class for traversing a CST as part of a batched
     set of traversals. This should be used in conjunction with the
-    :func:`~libcst.visit_batched` method or the
-    :func:`~libcst.MetadataWrapper.visit_batched` method to visit a tree.
+    :func:`~libcst.visit_batched` function or the
+    :func:`~libcst.MetadataWrapper.visit_batched` method from
+    :class:`~libcst.MetadataWrapper` to visit a tree.
     Instances of this class cannot modify the tree.
     """
 
@@ -75,8 +76,9 @@ def visit_batched(
     methods from each visitor in ``visitor`` are executed by the batched visitor.
 
     This function does not handle metadata dependency resolution for ``visitors``.
-    See :func:`~libcst.MetadataWrapper.visit_batched` for batched traversal with
-    metadata dependency resolution.
+    See :func:`~libcst.MetadataWrapper.visit_batched` from 
+    :class:`~libcst.MetadataWrapper` for batched traversal with metadata dependency
+    resolution.
     """
     visitor_methods = _get_visitor_methods(batchable_visitors)
     batched_visitor = _BatchedCSTVisitor(

--- a/libcst/_nodes/_internal.py
+++ b/libcst/_nodes/_internal.py
@@ -19,8 +19,8 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    overload,
     cast,
+    overload,
 )
 
 from libcst._add_slots import add_slots

--- a/libcst/_nodes/_internal.py
+++ b/libcst/_nodes/_internal.py
@@ -20,6 +20,7 @@ from typing import (
     TypeVar,
     Union,
     overload,
+    cast,
 )
 
 from libcst._add_slots import add_slots
@@ -57,8 +58,10 @@ class CodePosition:
 @add_slots
 @dataclass(frozen=True)
 class CodeRange:
+    # pyre-ignore[13]: Uninitialized attribute
     #: Starting position of a node.
     start: CodePosition
+    # pyre-ignore[13]: Uninitialized attribute
     #: Ending position of a node.
     end: CodePosition
 
@@ -71,12 +74,14 @@ class CodeRange:
         ...
 
     def __init__(self, start: _CodePositionT, end: _CodePositionT) -> None:
-        if isinstance(start, CodePosition):
-            object.__setattr__(self, "start", start)
-            object.__setattr__(self, "end", end)
-        else:
+        if isinstance(start, tuple) and isinstance(end, tuple):
             object.__setattr__(self, "start", CodePosition(start[0], start[1]))
             object.__setattr__(self, "end", CodePosition(end[0], end[1]))
+        else:
+            start = cast(CodePosition, start)
+            end = cast(CodePosition, end)
+            object.__setattr__(self, "start", start)
+            object.__setattr__(self, "end", end)
 
 
 @dataclass(frozen=False)

--- a/libcst/_nodes/_internal.py
+++ b/libcst/_nodes/_internal.py
@@ -48,14 +48,18 @@ NEWLINE_RE: Pattern[str] = re.compile(r"\r\n?|\n")
 @add_slots
 @dataclass(frozen=True)
 class CodePosition:
+    #: Line numbers are 1-indexed.
     line: int
+    #: Column numbers are 0-indexed.
     column: int
 
 
 @add_slots
 @dataclass(frozen=True)
 class CodeRange:
+    #: Starting position of a node.
     start: CodePosition
+    #: Ending position of a node.
     end: CodePosition
 
     @overload
@@ -73,10 +77,6 @@ class CodeRange:
         else:
             object.__setattr__(self, "start", CodePosition(start[0], start[1]))
             object.__setattr__(self, "end", CodePosition(end[0], end[1]))
-
-    @classmethod
-    def create(cls, start: Tuple[int, int], end: Tuple[int, int]) -> "CodeRange":
-        return CodeRange(CodePosition(start[0], start[1]), CodePosition(end[0], end[1]))
 
 
 @dataclass(frozen=False)

--- a/libcst/_nodes/_internal.py
+++ b/libcst/_nodes/_internal.py
@@ -19,6 +19,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    overload,
 )
 
 from libcst._add_slots import add_slots
@@ -56,6 +57,22 @@ class CodePosition:
 class CodeRange:
     start: CodePosition
     end: CodePosition
+
+    @overload
+    def __init__(self, start: CodePosition, end: CodePosition) -> None:
+        ...
+
+    @overload
+    def __init__(self, start: Tuple[int, int], end: Tuple[int, int]) -> None:
+        ...
+
+    def __init__(self, start: _CodePositionT, end: _CodePositionT) -> None:
+        if isinstance(start, CodePosition):
+            object.__setattr__(self, "start", start)
+            object.__setattr__(self, "end", end)
+        else:
+            object.__setattr__(self, "start", CodePosition(start[0], start[1]))
+            object.__setattr__(self, "end", CodePosition(end[0], end[1]))
 
     @classmethod
     def create(cls, start: Tuple[int, int], end: Tuple[int, int]) -> "CodeRange":

--- a/libcst/_nodes/_module.py
+++ b/libcst/_nodes/_module.py
@@ -136,8 +136,9 @@ class Module(CSTNode):
         indentation and newline formats.
 
         By default, this also generates syntactic line and column metadata for each
-        node. Passing BasicPositionProvider will generate basic line and column
-        metadata instead.
+        node. Passing :class:`~libcst.BasicPositionProvider` will generate basic
+        line and column metadata instead. See :ref:`Metadata<libcst-metadata>`
+        for more information.
         """
 
         from libcst.metadata.position_provider import SyntacticPositionProvider

--- a/libcst/_nodes/tests/test_assert.py
+++ b/libcst/_nodes/tests/test_assert.py
@@ -42,7 +42,7 @@ class AssertConstructionTest(CSTNodeTest):
                 ),
                 "code": "assert(True)",
                 "parser": None,
-                "expected_position": CodeRange.create((1, 0), (1, 12)),
+                "expected_position": CodeRange((1, 0), (1, 12)),
             },
             # Whitespace rendering test
             {
@@ -57,7 +57,7 @@ class AssertConstructionTest(CSTNodeTest):
                 ),
                 "code": 'assert  True  ,  "Value should be true"',
                 "parser": None,
-                "expected_position": CodeRange.create((1, 0), (1, 39)),
+                "expected_position": CodeRange((1, 0), (1, 39)),
             },
         )
     )

--- a/libcst/_nodes/tests/test_assign.py
+++ b/libcst/_nodes/tests/test_assign.py
@@ -23,7 +23,7 @@ class AssignTest(CSTNodeTest):
                 ),
                 "code": "foo = 5",
                 "parser": None,
-                "expected_position": CodeRange.create((1, 0), (1, 7)),
+                "expected_position": CodeRange((1, 0), (1, 7)),
             },
             # Multiple targets creation
             {
@@ -36,7 +36,7 @@ class AssignTest(CSTNodeTest):
                 ),
                 "code": "foo = bar = 5",
                 "parser": None,
-                "expected_position": CodeRange.create((1, 0), (1, 13)),
+                "expected_position": CodeRange((1, 0), (1, 13)),
             },
             # Whitespace test for creating nodes
             {
@@ -52,7 +52,7 @@ class AssignTest(CSTNodeTest):
                 ),
                 "code": "foo=5",
                 "parser": None,
-                "expected_position": CodeRange.create((1, 0), (1, 5)),
+                "expected_position": CodeRange((1, 0), (1, 5)),
             },
             # Simple assignment parser case.
             {
@@ -132,14 +132,14 @@ class AnnAssignTest(CSTNodeTest):
                 ),
                 "code": "foo: str = 5",
                 "parser": None,
-                "expected_position": CodeRange.create((1, 0), (1, 12)),
+                "expected_position": CodeRange((1, 0), (1, 12)),
             },
             # Annotation creation without assignment
             {
                 "node": cst.AnnAssign(cst.Name("foo"), cst.Annotation(cst.Name("str"))),
                 "code": "foo: str",
                 "parser": None,
-                "expected_position": CodeRange.create((1, 0), (1, 8)),
+                "expected_position": CodeRange((1, 0), (1, 8)),
             },
             # Complex annotation creation
             {
@@ -152,7 +152,7 @@ class AnnAssignTest(CSTNodeTest):
                 ),
                 "code": "foo: Optional[str] = 5",
                 "parser": None,
-                "expected_position": CodeRange.create((1, 0), (1, 22)),
+                "expected_position": CodeRange((1, 0), (1, 22)),
             },
             # Simple assignment parser case.
             {
@@ -231,7 +231,7 @@ class AnnAssignTest(CSTNodeTest):
                 ),
                 "code": "foo :  Optional[str]  =  5",
                 "parser": None,
-                "expected_position": CodeRange.create((1, 0), (1, 26)),
+                "expected_position": CodeRange((1, 0), (1, 26)),
             },
             {
                 "node": cst.SimpleStatementLine(
@@ -292,7 +292,7 @@ class AugAssignTest(CSTNodeTest):
                 ),
                 "code": "foo += 5",
                 "parser": None,
-                "expected_position": CodeRange.create((1, 0), (1, 8)),
+                "expected_position": CodeRange((1, 0), (1, 8)),
             },
             {
                 "node": cst.AugAssign(
@@ -314,7 +314,7 @@ class AugAssignTest(CSTNodeTest):
                 ),
                 "code": "foo  <<=  5",
                 "parser": None,
-                "expected_position": CodeRange.create((1, 0), (1, 11)),
+                "expected_position": CodeRange((1, 0), (1, 11)),
             },
             # Simple assignment parser case.
             {

--- a/libcst/_nodes/tests/test_atom.py
+++ b/libcst/_nodes/tests/test_atom.py
@@ -31,7 +31,7 @@ class AtomTest(CSTNodeTest):
                 ),
                 "code": "(test)",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 1), (1, 5)),
+                "expected_position": CodeRange((1, 1), (1, 5)),
             },
             # Decimal integers
             {
@@ -104,7 +104,7 @@ class AtomTest(CSTNodeTest):
                 ),
                 "code": "(123)",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 1), (1, 4)),
+                "expected_position": CodeRange((1, 1), (1, 4)),
             },
             # Non-exponent floats
             {
@@ -199,7 +199,7 @@ class AtomTest(CSTNodeTest):
                 ),
                 "code": "(123.4)",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 1), (1, 6)),
+                "expected_position": CodeRange((1, 1), (1, 6)),
             },
             # Imaginary numbers
             {
@@ -233,7 +233,7 @@ class AtomTest(CSTNodeTest):
                 ),
                 "code": "(123.4j)",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 1), (1, 7)),
+                "expected_position": CodeRange((1, 1), (1, 7)),
             },
             # Simple elipses
             {
@@ -247,7 +247,7 @@ class AtomTest(CSTNodeTest):
                 "node": cst.Ellipsis(lpar=(cst.LeftParen(),), rpar=(cst.RightParen(),)),
                 "code": "(...)",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 1), (1, 4)),
+                "expected_position": CodeRange((1, 1), (1, 4)),
             },
             # Simple strings
             {
@@ -301,7 +301,7 @@ class AtomTest(CSTNodeTest):
                 ),
                 "code": '(rb"test")',
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 1), (1, 9)),
+                "expected_position": CodeRange((1, 1), (1, 9)),
             },
             # Test that _safe_to_use_with_word_operator allows no space around quotes
             {
@@ -537,7 +537,7 @@ class AtomTest(CSTNodeTest):
                 ),
                 "code": '(f"")',
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 1), (1, 4)),
+                "expected_position": CodeRange((1, 1), (1, 4)),
             },
             # Concatenated strings
             {
@@ -601,7 +601,7 @@ class AtomTest(CSTNodeTest):
                 ),
                 "code": '( "ab" "c" )',
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 2), (1, 10)),
+                "expected_position": CodeRange((1, 2), (1, 10)),
             },
         )
     )
@@ -619,7 +619,7 @@ class AtomTest(CSTNodeTest):
                 ),
                 "code": "{today:%B %d, %Y}",
                 "parser": None,
-                "expected_position": CodeRange.create((1, 0), (1, 17)),
+                "expected_position": CodeRange((1, 0), (1, 17)),
             },
         )
     )

--- a/libcst/_nodes/tests/test_attribute.py
+++ b/libcst/_nodes/tests/test_attribute.py
@@ -20,7 +20,7 @@ class AttributeTest(CSTNodeTest):
                 "node": cst.Attribute(cst.Name("foo"), cst.Name("bar")),
                 "code": "foo.bar",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 0), (1, 7)),
+                "expected_position": CodeRange((1, 0), (1, 7)),
             },
             # Parenthesized attribute access
             {
@@ -32,7 +32,7 @@ class AttributeTest(CSTNodeTest):
                 ),
                 "code": "(foo.bar)",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 1), (1, 8)),
+                "expected_position": CodeRange((1, 1), (1, 8)),
             },
             # Make sure that spacing works
             {
@@ -48,7 +48,7 @@ class AttributeTest(CSTNodeTest):
                 ),
                 "code": "( foo . bar )",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 2), (1, 11)),
+                "expected_position": CodeRange((1, 2), (1, 11)),
             },
         )
     )

--- a/libcst/_nodes/tests/test_await.py
+++ b/libcst/_nodes/tests/test_await.py
@@ -39,7 +39,7 @@ class AwaitTest(CSTNodeTest):
                 ),
                 "code": "( await  test )",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 2), (1, 13)),
+                "expected_position": CodeRange((1, 2), (1, 13)),
             },
         )
     )

--- a/libcst/_nodes/tests/test_binary_op.py
+++ b/libcst/_nodes/tests/test_binary_op.py
@@ -140,7 +140,7 @@ class BinaryOperationTest(CSTNodeTest):
                 ),
                 "code": "( foo  *  bar )",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 2), (1, 13)),
+                "expected_position": CodeRange((1, 2), (1, 13)),
             },
         )
     )

--- a/libcst/_nodes/tests/test_boolean_op.py
+++ b/libcst/_nodes/tests/test_boolean_op.py
@@ -61,7 +61,7 @@ class BooleanOperationTest(CSTNodeTest):
                 ),
                 "code": "(foo)or(bar)",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 0), (1, 12)),
+                "expected_position": CodeRange((1, 0), (1, 12)),
             },
             # Make sure that spacing works
             {

--- a/libcst/_nodes/tests/test_call.py
+++ b/libcst/_nodes/tests/test_call.py
@@ -438,7 +438,7 @@ class CallTest(CSTNodeTest):
                 ),
                 "code": "( foo ( pos1 ,  *  list1, kw1=1, ** dict1 ) )",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 2), (1, 43)),
+                "expected_position": CodeRange((1, 2), (1, 43)),
             },
             # Test args
             {
@@ -451,7 +451,7 @@ class CallTest(CSTNodeTest):
                 ),
                 "code": "*  list1, ",
                 "parser": None,
-                "expected_position": CodeRange.create((1, 0), (1, 8)),
+                "expected_position": CodeRange((1, 0), (1, 8)),
             },
         )
     )

--- a/libcst/_nodes/tests/test_classdef.py
+++ b/libcst/_nodes/tests/test_classdef.py
@@ -22,7 +22,7 @@ class ClassDefCreationTest(CSTNodeTest):
                     cst.Name("Foo"), cst.SimpleStatementSuite((cst.Pass(),))
                 ),
                 "code": "class Foo: pass\n",
-                "expected_position": CodeRange.create((1, 0), (1, 15)),
+                "expected_position": CodeRange((1, 0), (1, 15)),
             },
             {
                 "node": cst.ClassDef(
@@ -64,7 +64,7 @@ class ClassDefCreationTest(CSTNodeTest):
                     ),
                 ),
                 "code": "class Foo(metaclass = Bar): pass\n",
-                "expected_position": CodeRange.create((1, 0), (1, 32)),
+                "expected_position": CodeRange((1, 0), (1, 32)),
             },
             # Iterator expansion render test
             {
@@ -293,7 +293,7 @@ class ClassDefParserTest(CSTNodeTest):
                     rpar=cst.RightParen(),
                 ),
                 "code": "@foo\nclass Foo(): pass\n",
-                "expected_position": CodeRange.create((2, 0), (2, 17)),
+                "expected_position": CodeRange((2, 0), (2, 17)),
             },
             {
                 "node": cst.ClassDef(
@@ -329,7 +329,7 @@ class ClassDefParserTest(CSTNodeTest):
                     rpar=cst.RightParen(),
                 ),
                 "code": "\n# leading comment 1\n@foo\n# leading comment 2\n@bar\n# leading comment 3\n@baz\n# class comment\nclass Foo(): pass\n",
-                "expected_position": CodeRange.create((9, 0), (9, 17)),
+                "expected_position": CodeRange((9, 0), (9, 17)),
             },
         )
     )

--- a/libcst/_nodes/tests/test_comparison.py
+++ b/libcst/_nodes/tests/test_comparison.py
@@ -153,7 +153,7 @@ class ComparisonTest(CSTNodeTest):
                     ),
                 ),
                 "baz == (foo not in bar)",
-                CodeRange.create((1, 0), (1, 23)),
+                CodeRange((1, 0), (1, 23)),
             ),
             (
                 cst.Comparison(
@@ -168,7 +168,7 @@ class ComparisonTest(CSTNodeTest):
                     ),
                 ),
                 "a > b > c",
-                CodeRange.create((1, 0), (1, 9)),
+                CodeRange((1, 0), (1, 9)),
             ),
             # Is safe to use with word operators if it's leading/trailing children are
             (

--- a/libcst/_nodes/tests/test_del.py
+++ b/libcst/_nodes/tests/test_del.py
@@ -19,7 +19,7 @@ class DelTest(CSTNodeTest):
                 "node": cst.SimpleStatementLine([cst.Del(cst.Name("abc"))]),
                 "code": "del abc\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (1, 7)),
+                "expected_position": CodeRange((1, 0), (1, 7)),
             },
             {
                 "node": cst.SimpleStatementLine(
@@ -32,7 +32,7 @@ class DelTest(CSTNodeTest):
                 ),
                 "code": "del   abc\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (1, 9)),
+                "expected_position": CodeRange((1, 0), (1, 9)),
             },
             {
                 "node": cst.SimpleStatementLine(
@@ -47,7 +47,7 @@ class DelTest(CSTNodeTest):
                 ),
                 "code": "del(abc)\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (1, 8)),
+                "expected_position": CodeRange((1, 0), (1, 8)),
             },
             {
                 "node": cst.SimpleStatementLine(
@@ -55,7 +55,7 @@ class DelTest(CSTNodeTest):
                 ),
                 "code": "del abc;\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (1, 7)),
+                "expected_position": CodeRange((1, 0), (1, 7)),
             },
         )
     )

--- a/libcst/_nodes/tests/test_dict.py
+++ b/libcst/_nodes/tests/test_dict.py
@@ -20,20 +20,20 @@ class DictTest(CSTNodeTest):
                 "node": cst.Dict([]),
                 "code": "{}",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 0), (1, 2)),
+                "expected_position": CodeRange((1, 0), (1, 2)),
             },
             # one-element dict, sentinel comma value
             {
                 "node": cst.Dict([cst.DictElement(cst.Name("k"), cst.Name("v"))]),
                 "code": "{k: v}",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 0), (1, 6)),
+                "expected_position": CodeRange((1, 0), (1, 6)),
             },
             {
                 "node": cst.Dict([cst.StarredDictElement(cst.Name("expanded"))]),
                 "code": "{**expanded}",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 0), (1, 12)),
+                "expected_position": CodeRange((1, 0), (1, 12)),
             },
             # two-element dict, sentinel comma value
             {
@@ -45,7 +45,7 @@ class DictTest(CSTNodeTest):
                 ),
                 "code": "{k1: v1, k2: v2}",
                 "parser": None,
-                "expected_position": CodeRange.create((1, 0), (1, 16)),
+                "expected_position": CodeRange((1, 0), (1, 16)),
             },
             # custom whitespace between brackets
             {
@@ -60,7 +60,7 @@ class DictTest(CSTNodeTest):
                 ),
                 "code": "{\tk: v\t\t}",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 0), (1, 9)),
+                "expected_position": CodeRange((1, 0), (1, 9)),
             },
             # with parenthesis
             {
@@ -71,7 +71,7 @@ class DictTest(CSTNodeTest):
                 ),
                 "code": "({k: v})",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 1), (1, 7)),
+                "expected_position": CodeRange((1, 1), (1, 7)),
             },
             # starred element
             {
@@ -83,7 +83,7 @@ class DictTest(CSTNodeTest):
                 ),
                 "code": "{**one, **two}",
                 "parser": None,
-                "expected_position": CodeRange.create((1, 0), (1, 14)),
+                "expected_position": CodeRange((1, 0), (1, 14)),
             },
             # custom comma on DictElement
             {
@@ -92,7 +92,7 @@ class DictTest(CSTNodeTest):
                 ),
                 "code": "{k: v,}",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 0), (1, 7)),
+                "expected_position": CodeRange((1, 0), (1, 7)),
             },
             # custom comma on StarredDictElement
             {
@@ -101,7 +101,7 @@ class DictTest(CSTNodeTest):
                 ),
                 "code": "{**expanded,}",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 0), (1, 13)),
+                "expected_position": CodeRange((1, 0), (1, 13)),
             },
             # custom whitespace on DictElement
             {
@@ -117,7 +117,7 @@ class DictTest(CSTNodeTest):
                 ),
                 "code": "{k\t:\t\tv}",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 0), (1, 8)),
+                "expected_position": CodeRange((1, 0), (1, 8)),
             },
             # custom whitespace on StarredDictElement
             {
@@ -134,7 +134,7 @@ class DictTest(CSTNodeTest):
                 ),
                 "code": "{k: v,**  expanded}",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 0), (1, 19)),
+                "expected_position": CodeRange((1, 0), (1, 19)),
             },
             # missing spaces around dict is always okay
             {

--- a/libcst/_nodes/tests/test_dict_comp.py
+++ b/libcst/_nodes/tests/test_dict_comp.py
@@ -24,7 +24,7 @@ class DictCompTest(CSTNodeTest):
                 ),
                 "code": "{k: v for a in b}",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 0), (1, 17)),
+                "expected_position": CodeRange((1, 0), (1, 17)),
             },
             # custom whitespace around colon
             {
@@ -37,7 +37,7 @@ class DictCompTest(CSTNodeTest):
                 ),
                 "code": "{k\t:\t\tv for a in b}",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 0), (1, 19)),
+                "expected_position": CodeRange((1, 0), (1, 19)),
             },
             # custom whitespace inside braces
             {
@@ -54,7 +54,7 @@ class DictCompTest(CSTNodeTest):
                 ),
                 "code": "{\tk: v for a in b\t\t}",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 0), (1, 20)),
+                "expected_position": CodeRange((1, 0), (1, 20)),
             },
             # parenthesis
             {
@@ -67,7 +67,7 @@ class DictCompTest(CSTNodeTest):
                 ),
                 "code": "({k: v for a in b})",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 1), (1, 18)),
+                "expected_position": CodeRange((1, 1), (1, 18)),
             },
             # missing spaces around DictComp is always okay
             {
@@ -92,7 +92,7 @@ class DictCompTest(CSTNodeTest):
                 ),
                 "code": "{a: b for c in{d: e for f in g}if h}",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 0), (1, 36)),
+                "expected_position": CodeRange((1, 0), (1, 36)),
             },
             # no whitespace before `for` clause
             {
@@ -107,7 +107,7 @@ class DictCompTest(CSTNodeTest):
                 ),
                 "code": "{k: (v)for a in b}",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 0), (1, 18)),
+                "expected_position": CodeRange((1, 0), (1, 18)),
             },
         ]
     )

--- a/libcst/_nodes/tests/test_else.py
+++ b/libcst/_nodes/tests/test_else.py
@@ -18,7 +18,7 @@ class ElseTest(CSTNodeTest):
             {
                 "node": cst.Else(cst.SimpleStatementSuite((cst.Pass(),))),
                 "code": "else: pass\n",
-                "expected_position": CodeRange.create((1, 0), (1, 10)),
+                "expected_position": CodeRange((1, 0), (1, 10)),
             },
             {
                 "node": cst.Else(
@@ -26,7 +26,7 @@ class ElseTest(CSTNodeTest):
                     whitespace_before_colon=cst.SimpleWhitespace("  "),
                 ),
                 "code": "else  : pass\n",
-                "expected_position": CodeRange.create((1, 0), (1, 12)),
+                "expected_position": CodeRange((1, 0), (1, 12)),
             },
         )
     )

--- a/libcst/_nodes/tests/test_for.py
+++ b/libcst/_nodes/tests/test_for.py
@@ -73,7 +73,7 @@ class ForTest(CSTNodeTest):
                 ),
                 "code": "    for target in iter():\n        pass\n",
                 "parser": None,
-                "expected_position": CodeRange.create((1, 4), (2, 12)),
+                "expected_position": CodeRange((1, 4), (2, 12)),
             },
             # leading_lines
             {
@@ -93,7 +93,7 @@ class ForTest(CSTNodeTest):
                 ),
                 "code": "# leading comment\nfor target in iter():\n    pass\n# else comment\nelse:\n    pass\n",
                 "parser": None,
-                "expected_position": CodeRange.create((2, 0), (6, 8)),
+                "expected_position": CodeRange((2, 0), (6, 8)),
             },
             # Weird spacing rules
             {
@@ -113,7 +113,7 @@ class ForTest(CSTNodeTest):
                 ),
                 "code": "for(target)in(iter()): pass\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (1, 27)),
+                "expected_position": CodeRange((1, 0), (1, 27)),
             },
             # Whitespace
             {
@@ -128,7 +128,7 @@ class ForTest(CSTNodeTest):
                 ),
                 "code": "for  target  in  iter()  : pass\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (1, 31)),
+                "expected_position": CodeRange((1, 0), (1, 31)),
             },
         )
     )

--- a/libcst/_nodes/tests/test_funcdef.py
+++ b/libcst/_nodes/tests/test_funcdef.py
@@ -34,7 +34,7 @@ class FunctionDefCreationTest(CSTNodeTest):
                     returns=cst.Annotation(cst.Name("str")),
                 ),
                 "code": "def foo() -> str: pass\n",
-                "expected_position": CodeRange.create((1, 0), (1, 22)),
+                "expected_position": CodeRange((1, 0), (1, 22)),
             },
             # Async function definition.
             {
@@ -56,7 +56,7 @@ class FunctionDefCreationTest(CSTNodeTest):
                     returns=cst.Annotation(cst.Name("int")),
                 ),
                 "code": "async def foo() -> int: pass\n",
-                "expected_position": CodeRange.create((1, 0), (1, 28)),
+                "expected_position": CodeRange((1, 0), (1, 28)),
             },
             # Test basic positional params
             {
@@ -419,7 +419,7 @@ class FunctionDefCreationTest(CSTNodeTest):
                     ),
                 ),
                 "code": "@bar('123')\n@baz('456')\ndef foo(): pass\n",
-                "expected_position": CodeRange.create((3, 0), (3, 15)),
+                "expected_position": CodeRange((3, 0), (3, 15)),
             },
             # Test indentation
             {
@@ -446,7 +446,7 @@ class FunctionDefCreationTest(CSTNodeTest):
                     ),
                 ),
                 "code": "    @bar\n    def foo():\n        pass\n",
-                "expected_position": CodeRange.create((2, 4), (3, 12)),
+                "expected_position": CodeRange((2, 4), (3, 12)),
             },
             # Leading lines
             {
@@ -459,7 +459,7 @@ class FunctionDefCreationTest(CSTNodeTest):
                     ),
                 ),
                 "code": "# leading comment\ndef foo(): pass\n",
-                "expected_position": CodeRange.create((2, 0), (2, 15)),
+                "expected_position": CodeRange((2, 0), (2, 15)),
             },
             # Inner whitespace
             {
@@ -500,7 +500,7 @@ class FunctionDefCreationTest(CSTNodeTest):
                     body=cst.SimpleStatementSuite((cst.Pass(),)),
                 ),
                 "code": "\n# What an amazing decorator\n@ bar (  )\n# What a great function\nasync  def  foo  (  )  ->  str : pass\n",
-                "expected_position": CodeRange.create((5, 0), (5, 37)),
+                "expected_position": CodeRange((5, 0), (5, 37)),
             },
             # Decorators and annotations
             {
@@ -513,7 +513,7 @@ class FunctionDefCreationTest(CSTNodeTest):
                     ),
                 ),
                 "code": "@ bar (  )\n",
-                "expected_position": CodeRange.create((1, 0), (1, 10)),
+                "expected_position": CodeRange((1, 0), (1, 10)),
             },
             # Parameters
             {
@@ -544,12 +544,12 @@ class FunctionDefCreationTest(CSTNodeTest):
                     ),
                 ),
                 "code": 'first, second, third = 1.0, fourth = 1.5, *params: str, bar: str = "one", baz: int, biz: str = "two"',
-                "expected_position": CodeRange.create((1, 0), (1, 100)),
+                "expected_position": CodeRange((1, 0), (1, 100)),
             },
             {
                 "node": cst.Param(cst.Name("third"), star="", default=cst.Float("1.0")),
                 "code": "third = 1.0",
-                "expected_position": CodeRange.create((1, 0), (1, 5)),
+                "expected_position": CodeRange((1, 0), (1, 5)),
             },
             {
                 "node": cst.Param(
@@ -558,7 +558,7 @@ class FunctionDefCreationTest(CSTNodeTest):
                     whitespace_after_star=cst.SimpleWhitespace(" "),
                 ),
                 "code": "* third",
-                "expected_position": CodeRange.create((1, 0), (1, 7)),
+                "expected_position": CodeRange((1, 0), (1, 7)),
             },
         )
     )

--- a/libcst/_nodes/tests/test_global.py
+++ b/libcst/_nodes/tests/test_global.py
@@ -42,7 +42,7 @@ class GlobalConstructionTest(CSTNodeTest):
                     whitespace_after_global=cst.SimpleWhitespace("  "),
                 ),
                 "code": "global  a  ,  b",
-                "expected_position": CodeRange.create((1, 0), (1, 15)),
+                "expected_position": CodeRange((1, 0), (1, 15)),
             },
         )
     )

--- a/libcst/_nodes/tests/test_if.py
+++ b/libcst/_nodes/tests/test_if.py
@@ -23,7 +23,7 @@ class IfTest(CSTNodeTest):
                 ),
                 "code": "if conditional: pass\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (1, 20)),
+                "expected_position": CodeRange((1, 0), (1, 20)),
             },
             # else clause
             {
@@ -34,7 +34,7 @@ class IfTest(CSTNodeTest):
                 ),
                 "code": "if conditional: pass\nelse: pass\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (2, 10)),
+                "expected_position": CodeRange((1, 0), (2, 10)),
             },
             # elif clause
             {
@@ -49,7 +49,7 @@ class IfTest(CSTNodeTest):
                 ),
                 "code": "if conditional: pass\nelif other_conditional: pass\nelse: pass\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (3, 10)),
+                "expected_position": CodeRange((1, 0), (3, 10)),
             },
             # indentation
             {
@@ -63,7 +63,7 @@ class IfTest(CSTNodeTest):
                 ),
                 "code": "    if conditional: pass\n    else: pass\n",
                 "parser": None,
-                "expected_position": CodeRange.create((1, 4), (2, 14)),
+                "expected_position": CodeRange((1, 4), (2, 14)),
             },
             # with an indented body
             {
@@ -76,7 +76,7 @@ class IfTest(CSTNodeTest):
                 ),
                 "code": "    if conditional:\n        pass\n",
                 "parser": None,
-                "expected_position": CodeRange.create((1, 4), (2, 12)),
+                "expected_position": CodeRange((1, 4), (2, 12)),
             },
             # leading_lines
             {
@@ -89,7 +89,7 @@ class IfTest(CSTNodeTest):
                 ),
                 "code": "# leading comment\nif conditional: pass\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((2, 0), (2, 20)),
+                "expected_position": CodeRange((2, 0), (2, 20)),
             },
             # whitespace before/after test and else
             {
@@ -105,7 +105,7 @@ class IfTest(CSTNodeTest):
                 ),
                 "code": "if   conditional  : pass\nelse : pass\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (2, 11)),
+                "expected_position": CodeRange((1, 0), (2, 11)),
             },
             # empty lines between if/elif/else clauses, not captured by the suite.
             {
@@ -124,7 +124,7 @@ class IfTest(CSTNodeTest):
                 ),
                 "code": "if test_a: pass\n\nelif test_b: pass\n\nelse: pass\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (5, 10)),
+                "expected_position": CodeRange((1, 0), (5, 10)),
             },
         )
     )

--- a/libcst/_nodes/tests/test_ifexp.py
+++ b/libcst/_nodes/tests/test_ifexp.py
@@ -50,7 +50,7 @@ class IfExpTest(CSTNodeTest):
                     ),
                 ),
                 "(foo)if(bar)else(baz)",
-                CodeRange.create((1, 0), (1, 21)),
+                CodeRange((1, 0), (1, 21)),
             ),
             # Make sure that spacing works
             (
@@ -66,7 +66,7 @@ class IfExpTest(CSTNodeTest):
                     rpar=(cst.RightParen(whitespace_before=cst.SimpleWhitespace(" ")),),
                 ),
                 "( foo  if  bar  else  baz )",
-                CodeRange.create((1, 2), (1, 25)),
+                CodeRange((1, 2), (1, 25)),
             ),
         )
     )

--- a/libcst/_nodes/tests/test_import.py
+++ b/libcst/_nodes/tests/test_import.py
@@ -55,7 +55,7 @@ class ImportCreateTest(CSTNodeTest):
                     )
                 ),
                 "code": "import foo.bar, foo.baz",
-                "expected_position": CodeRange.create((1, 0), (1, 23)),
+                "expected_position": CodeRange((1, 0), (1, 23)),
             },
             # Import with an alias
             {
@@ -141,7 +141,7 @@ class ImportCreateTest(CSTNodeTest):
                     whitespace_after_import=cst.SimpleWhitespace("  "),
                 ),
                 "code": "import  foo . bar  as  baz ,  unittest  as  ut",
-                "expected_position": CodeRange.create((1, 0), (1, 46)),
+                "expected_position": CodeRange((1, 0), (1, 46)),
             },
         )
     )
@@ -389,13 +389,13 @@ class ImportFromCreateTest(CSTNodeTest):
                     ),
                 ),
                 "code": "from foo import bar,baz,",
-                "expected_position": CodeRange.create((1, 0), (1, 23)),
+                "expected_position": CodeRange((1, 0), (1, 23)),
             },
             # Star import statement
             {
                 "node": cst.ImportFrom(module=cst.Name("foo"), names=cst.ImportStar()),
                 "code": "from foo import *",
-                "expected_position": CodeRange.create((1, 0), (1, 17)),
+                "expected_position": CodeRange((1, 0), (1, 17)),
             },
             # Simple relative import statement
             {
@@ -436,7 +436,7 @@ class ImportFromCreateTest(CSTNodeTest):
                     rpar=cst.RightParen(),
                 ),
                 "code": "from foo import (bar as baz)",
-                "expected_position": CodeRange.create((1, 0), (1, 28)),
+                "expected_position": CodeRange((1, 0), (1, 28)),
             },
             # Verify whitespace works everywhere.
             {
@@ -481,7 +481,7 @@ class ImportFromCreateTest(CSTNodeTest):
                     whitespace_after_import=cst.SimpleWhitespace("  "),
                 ),
                 "code": "from   .  . foo  import  ( bar  as  baz ,  unittest  as  ut )",
-                "expected_position": CodeRange.create((1, 0), (1, 61)),
+                "expected_position": CodeRange((1, 0), (1, 61)),
             },
         )
     )

--- a/libcst/_nodes/tests/test_internal.py
+++ b/libcst/_nodes/tests/test_internal.py
@@ -75,9 +75,7 @@ class InternalTest(UnitTest):
         state.record_position(node, CodeRange(start, end))
 
         # check whitespace is correctly recorded
-        self.assertEqual(
-            state.provider._computed[node], CodeRange.create((1, 0), (1, 6))
-        )
+        self.assertEqual(state.provider._computed[node], CodeRange((1, 0), (1, 6)))
 
     def test_syntactic_position(self) -> None:
         # create a dummy node
@@ -95,6 +93,4 @@ class InternalTest(UnitTest):
         state.record_position(node, CodeRange(start, end))
 
         # check syntactic position ignores whitespace
-        self.assertEqual(
-            state.provider._computed[node], CodeRange.create((1, 1), (1, 5))
-        )
+        self.assertEqual(state.provider._computed[node], CodeRange((1, 1), (1, 5)))

--- a/libcst/_nodes/tests/test_lambda.py
+++ b/libcst/_nodes/tests/test_lambda.py
@@ -139,7 +139,7 @@ class LambdaCreationTest(CSTNodeTest):
                     cst.Integer("5"),
                 ),
                 'lambda first, second, third = 1.0, fourth = 1.5, *, bar = "one", baz, biz = "two": 5',
-                CodeRange.create((1, 0), (1, 84)),
+                CodeRange((1, 0), (1, 84)),
             ),
             # Test star_arg
             (
@@ -225,7 +225,7 @@ class LambdaCreationTest(CSTNodeTest):
                     rpar=(cst.RightParen(whitespace_before=cst.SimpleWhitespace(" ")),),
                 ),
                 "( lambda  : 5 )",
-                CodeRange.create((1, 2), (1, 13)),
+                CodeRange((1, 2), (1, 13)),
             ),
         )
     )

--- a/libcst/_nodes/tests/test_list.py
+++ b/libcst/_nodes/tests/test_list.py
@@ -39,7 +39,7 @@ class ListTest(CSTNodeTest):
                 ),
                 "code": "[\tsingle_element    ]",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 0), (1, 21)),
+                "expected_position": CodeRange((1, 0), (1, 21)),
             },
             # two-element list, sentinel comma value
             {
@@ -58,7 +58,7 @@ class ListTest(CSTNodeTest):
                 ),
                 "code": "([one])",
                 "parser": None,
-                "expected_position": CodeRange.create((1, 1), (1, 6)),
+                "expected_position": CodeRange((1, 1), (1, 6)),
             },
             # starred element
             {
@@ -70,7 +70,7 @@ class ListTest(CSTNodeTest):
                 ),
                 "code": "[*one, *two]",
                 "parser": None,
-                "expected_position": CodeRange.create((1, 0), (1, 12)),
+                "expected_position": CodeRange((1, 0), (1, 12)),
             },
             # missing spaces around list, always okay
             {

--- a/libcst/_nodes/tests/test_module.py
+++ b/libcst/_nodes/tests/test_module.py
@@ -118,22 +118,16 @@ class ModuleTest(CSTNodeTest):
 
     @data_provider(
         {
-            "empty": {"code": "", "expected": CodeRange.create((1, 0), (1, 0))},
-            "empty_with_newline": {
-                "code": "\n",
-                "expected": CodeRange.create((1, 0), (2, 0)),
-            },
+            "empty": {"code": "", "expected": CodeRange((1, 0), (1, 0))},
+            "empty_with_newline": {"code": "\n", "expected": CodeRange((1, 0), (2, 0))},
             "empty_program_with_comments": {
                 "code": "# 2345",
-                "expected": CodeRange.create((1, 0), (2, 0)),
+                "expected": CodeRange((1, 0), (2, 0)),
             },
-            "simple_pass": {
-                "code": "pass\n",
-                "expected": CodeRange.create((1, 0), (2, 0)),
-            },
+            "simple_pass": {"code": "pass\n", "expected": CodeRange((1, 0), (2, 0))},
             "simple_pass_with_header_footer": {
                 "code": "# header\npass # trailing\n# footer\n",
-                "expected": CodeRange.create((1, 0), (4, 0)),
+                "expected": CodeRange((1, 0), (4, 0)),
             },
         }
     )
@@ -147,7 +141,7 @@ class ModuleTest(CSTNodeTest):
     def cmp_position(
         self, actual: CodeRange, start: Tuple[int, int], end: Tuple[int, int]
     ) -> None:
-        self.assertEqual(actual, CodeRange.create(start, end))
+        self.assertEqual(actual, CodeRange(start, end))
 
     def test_function_position(self) -> None:
         module = parse_module("def foo():\n    pass")

--- a/libcst/_nodes/tests/test_nonlocal.py
+++ b/libcst/_nodes/tests/test_nonlocal.py
@@ -28,7 +28,7 @@ class NonlocalConstructionTest(CSTNodeTest):
                     (cst.NameItem(cst.Name("a")), cst.NameItem(cst.Name("b")))
                 ),
                 "code": "nonlocal a, b",
-                "expected_position": CodeRange.create((1, 0), (1, 13)),
+                "expected_position": CodeRange((1, 0), (1, 13)),
             },
             # Whitespace rendering test
             {
@@ -46,7 +46,7 @@ class NonlocalConstructionTest(CSTNodeTest):
                     whitespace_after_nonlocal=cst.SimpleWhitespace("  "),
                 ),
                 "code": "nonlocal  a  ,  b",
-                "expected_position": CodeRange.create((1, 0), (1, 17)),
+                "expected_position": CodeRange((1, 0), (1, 17)),
             },
         )
     )

--- a/libcst/_nodes/tests/test_number.py
+++ b/libcst/_nodes/tests/test_number.py
@@ -22,7 +22,7 @@ class NumberTest(CSTNodeTest):
                 cst.UnaryOperation(operator=cst.Minus(), expression=cst.Integer("5")),
                 "-5",
                 parse_expression,
-                CodeRange.create((1, 0), (1, 2)),
+                CodeRange((1, 0), (1, 2)),
             ),
             # In parenthesis
             (
@@ -34,7 +34,7 @@ class NumberTest(CSTNodeTest):
                 ),
                 "(-5)",
                 parse_expression,
-                CodeRange.create((1, 1), (1, 3)),
+                CodeRange((1, 1), (1, 3)),
             ),
             (
                 cst.UnaryOperation(
@@ -47,7 +47,7 @@ class NumberTest(CSTNodeTest):
                 ),
                 "(-(5))",
                 parse_expression,
-                CodeRange.create((1, 1), (1, 5)),
+                CodeRange((1, 1), (1, 5)),
             ),
             (
                 cst.UnaryOperation(
@@ -58,7 +58,7 @@ class NumberTest(CSTNodeTest):
                 ),
                 "--5",
                 parse_expression,
-                CodeRange.create((1, 0), (1, 3)),
+                CodeRange((1, 0), (1, 3)),
             ),
             # multiple nested parenthesis
             (
@@ -69,7 +69,7 @@ class NumberTest(CSTNodeTest):
                 ),
                 "((5))",
                 parse_expression,
-                CodeRange.create((1, 2), (1, 3)),
+                CodeRange((1, 2), (1, 3)),
             ),
             (
                 cst.UnaryOperation(
@@ -84,7 +84,7 @@ class NumberTest(CSTNodeTest):
                 ),
                 "(+((5)))",
                 parse_expression,
-                CodeRange.create((1, 1), (1, 7)),
+                CodeRange((1, 1), (1, 7)),
             ),
         )
     )

--- a/libcst/_nodes/tests/test_raise.py
+++ b/libcst/_nodes/tests/test_raise.py
@@ -23,7 +23,7 @@ class RaiseConstructionTest(CSTNodeTest):
             {
                 "node": cst.Raise(cst.Call(cst.Name("Exception"))),
                 "code": "raise Exception()",
-                "expected_position": CodeRange.create((1, 0), (1, 17)),
+                "expected_position": CodeRange((1, 0), (1, 17)),
             },
             # Raise exception from cause
             {
@@ -50,7 +50,7 @@ class RaiseConstructionTest(CSTNodeTest):
                     whitespace_after_raise=cst.SimpleWhitespace(""),
                 ),
                 "code": "raise(Exception())from(cause)",
-                "expected_position": CodeRange.create((1, 0), (1, 29)),
+                "expected_position": CodeRange((1, 0), (1, 29)),
             },
             {
                 "node": cst.Raise(
@@ -61,7 +61,7 @@ class RaiseConstructionTest(CSTNodeTest):
                     ),
                 ),
                 "code": "raise Exception()from cause",
-                "expected_position": CodeRange.create((1, 0), (1, 27)),
+                "expected_position": CodeRange((1, 0), (1, 27)),
             },
             # Whitespace rendering test
             {
@@ -75,7 +75,7 @@ class RaiseConstructionTest(CSTNodeTest):
                     whitespace_after_raise=cst.SimpleWhitespace("  "),
                 ),
                 "code": "raise  Exception()  from  cause",
-                "expected_position": CodeRange.create((1, 0), (1, 31)),
+                "expected_position": CodeRange((1, 0), (1, 31)),
             },
         )
     )

--- a/libcst/_nodes/tests/test_return.py
+++ b/libcst/_nodes/tests/test_return.py
@@ -18,12 +18,12 @@ class ReturnCreateTest(CSTNodeTest):
             {
                 "node": cst.SimpleStatementLine([cst.Return()]),
                 "code": "return\n",
-                "expected_position": CodeRange.create((1, 0), (1, 6)),
+                "expected_position": CodeRange((1, 0), (1, 6)),
             },
             {
                 "node": cst.SimpleStatementLine([cst.Return(cst.Name("abc"))]),
                 "code": "return abc\n",
-                "expected_position": CodeRange.create((1, 0), (1, 10)),
+                "expected_position": CodeRange((1, 0), (1, 10)),
             },
         )
     )

--- a/libcst/_nodes/tests/test_simple_comp.py
+++ b/libcst/_nodes/tests/test_simple_comp.py
@@ -22,7 +22,7 @@ class SimpleCompTest(CSTNodeTest):
                 ),
                 "code": "(a for b in c)",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 1), (1, 13)),
+                "expected_position": CodeRange((1, 1), (1, 13)),
             },
             # simple ListComp
             {
@@ -31,7 +31,7 @@ class SimpleCompTest(CSTNodeTest):
                 ),
                 "code": "[a for b in c]",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 0), (1, 14)),
+                "expected_position": CodeRange((1, 0), (1, 14)),
             },
             # simple SetComp
             {
@@ -88,7 +88,7 @@ class SimpleCompTest(CSTNodeTest):
                 ),
                 "code": "(a for b in c if d if e if f)",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 1), (1, 28)),
+                "expected_position": CodeRange((1, 1), (1, 28)),
             },
             # nested/inner for-in clause
             {
@@ -147,7 +147,7 @@ class SimpleCompTest(CSTNodeTest):
                 ),
                 "code": "(\fa  for   b    in     c\tif\t\td\f\f)",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 2), (1, 30)),
+                "expected_position": CodeRange((1, 2), (1, 30)),
             },
             # custom whitespace around ListComp's brackets
             {
@@ -167,7 +167,7 @@ class SimpleCompTest(CSTNodeTest):
                 ),
                 "code": "(\f[\ta for b in c\t\t]\f\f)",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 2), (1, 19)),
+                "expected_position": CodeRange((1, 2), (1, 19)),
             },
             # custom whitespace around SetComp's braces
             {
@@ -230,7 +230,7 @@ class SimpleCompTest(CSTNodeTest):
                 ),
                 "code": "((a)for(b)in(c)if(d)for(e)in(f))",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 1), (1, 31)),
+                "expected_position": CodeRange((1, 1), (1, 31)),
             },
             # no whitespace before/after GeneratorExp is valid
             {

--- a/libcst/_nodes/tests/test_simple_statement.py
+++ b/libcst/_nodes/tests/test_simple_statement.py
@@ -57,7 +57,7 @@ class SimpleStatementTest(CSTNodeTest):
                 ),
                 "code": "pass;continue;break\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (1, 19)),
+                "expected_position": CodeRange((1, 0), (1, 19)),
             },
             # a multi-element SimpleStatementLine, inferred semicolons
             {
@@ -117,7 +117,7 @@ class SimpleStatementTest(CSTNodeTest):
                 ),
                 "code": "(5)\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (1, 3)),
+                "expected_position": CodeRange((1, 0), (1, 3)),
             },
             {
                 "node": cst.SimpleStatementLine(
@@ -182,7 +182,7 @@ class SimpleStatementTest(CSTNodeTest):
                 ),
                 "code": '"abc" "def" "ghi"\n',
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (1, 17)),
+                "expected_position": CodeRange((1, 0), (1, 17)),
             },
             # Test parenthesis rules
             {
@@ -254,7 +254,7 @@ class SimpleStatementTest(CSTNodeTest):
                 ),
                 "code": "( (  (   ...   )  ) )\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (1, 21)),
+                "expected_position": CodeRange((1, 0), (1, 21)),
             },
             # Test parenthesis rules with expressions
             {
@@ -294,7 +294,7 @@ class SimpleStatementTest(CSTNodeTest):
                 ),
                 "code": "(\n# Wow, a comment!\n    ...\n)\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (4, 1)),
+                "expected_position": CodeRange((1, 0), (4, 1)),
             },
             # test trailing whitespace
             {
@@ -307,7 +307,7 @@ class SimpleStatementTest(CSTNodeTest):
                 ),
                 "code": "pass  # trailing comment\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (1, 4)),
+                "expected_position": CodeRange((1, 0), (1, 4)),
             },
             # test leading comment
             {
@@ -317,7 +317,7 @@ class SimpleStatementTest(CSTNodeTest):
                 ),
                 "code": "# comment\npass\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((2, 0), (2, 4)),
+                "expected_position": CodeRange((2, 0), (2, 4)),
             },
             # test indentation
             {
@@ -331,20 +331,20 @@ class SimpleStatementTest(CSTNodeTest):
                     ),
                 ),
                 "code": "    # comment\n    pass\n",
-                "expected_position": CodeRange.create((2, 4), (2, 8)),
+                "expected_position": CodeRange((2, 4), (2, 8)),
             },
             # test suite variant
             {
                 "node": cst.SimpleStatementSuite((cst.Pass(),)),
                 "code": " pass\n",
-                "expected_position": CodeRange.create((1, 1), (1, 5)),
+                "expected_position": CodeRange((1, 1), (1, 5)),
             },
             {
                 "node": cst.SimpleStatementSuite(
                     (cst.Pass(),), leading_whitespace=cst.SimpleWhitespace("")
                 ),
                 "code": "pass\n",
-                "expected_position": CodeRange.create((1, 0), (1, 4)),
+                "expected_position": CodeRange((1, 0), (1, 4)),
             },
         )
     )

--- a/libcst/_nodes/tests/test_small_statement.py
+++ b/libcst/_nodes/tests/test_small_statement.py
@@ -26,7 +26,7 @@ class SmallStatementTest(CSTNodeTest):
                     )
                 ),
                 "code": "pass  ;    ",
-                "expected_position": CodeRange.create((1, 0), (1, 4)),
+                "expected_position": CodeRange((1, 0), (1, 4)),
             },
             {"node": cst.Continue(), "code": "continue"},
             {"node": cst.Continue(semicolon=cst.Semicolon()), "code": "continue;"},
@@ -38,7 +38,7 @@ class SmallStatementTest(CSTNodeTest):
                     )
                 ),
                 "code": "continue  ;    ",
-                "expected_position": CodeRange.create((1, 0), (1, 8)),
+                "expected_position": CodeRange((1, 0), (1, 8)),
             },
             {"node": cst.Break(), "code": "break"},
             {"node": cst.Break(semicolon=cst.Semicolon()), "code": "break;"},
@@ -50,7 +50,7 @@ class SmallStatementTest(CSTNodeTest):
                     )
                 ),
                 "code": "break  ;    ",
-                "expected_position": CodeRange.create((1, 0), (1, 5)),
+                "expected_position": CodeRange((1, 0), (1, 5)),
             },
             {
                 "node": cst.Expr(
@@ -74,7 +74,7 @@ class SmallStatementTest(CSTNodeTest):
                     ),
                 ),
                 "code": "x + y  ;    ",
-                "expected_position": CodeRange.create((1, 0), (1, 5)),
+                "expected_position": CodeRange((1, 0), (1, 5)),
             },
         )
     )

--- a/libcst/_nodes/tests/test_subscript.py
+++ b/libcst/_nodes/tests/test_subscript.py
@@ -50,7 +50,7 @@ class SubscriptTest(CSTNodeTest):
                 ),
                 "foo[1:2:3, 5]",
                 False,
-                CodeRange.create((1, 0), (1, 13)),
+                CodeRange((1, 0), (1, 13)),
             ),
             # Test parsing of subscript with slice/extslice.
             (
@@ -127,7 +127,7 @@ class SubscriptTest(CSTNodeTest):
                 ),
                 "foo[::3]",
                 False,
-                CodeRange.create((1, 0), (1, 8)),
+                CodeRange((1, 0), (1, 8)),
             ),
             # Some more wild slice parsings
             (
@@ -305,15 +305,15 @@ class SubscriptTest(CSTNodeTest):
                 ),
                 "( foo [ 1 : 2 : 3 ,  5 ] )",
                 True,
-                CodeRange.create((1, 2), (1, 24)),
+                CodeRange((1, 2), (1, 24)),
             ),
             # Test Index, Slice, ExtSlice
-            (cst.Index(cst.Integer("5")), "5", False, CodeRange.create((1, 0), (1, 1))),
+            (cst.Index(cst.Integer("5")), "5", False, CodeRange((1, 0), (1, 1))),
             (
                 cst.Slice(lower=None, upper=None, second_colon=cst.Colon(), step=None),
                 "::",
                 False,
-                CodeRange.create((1, 0), (1, 2)),
+                CodeRange((1, 0), (1, 2)),
             ),
             (
                 cst.ExtSlice(
@@ -337,7 +337,7 @@ class SubscriptTest(CSTNodeTest):
                 ),
                 "1 : 2 : 3 ,  ",
                 False,
-                CodeRange.create((1, 0), (1, 9)),
+                CodeRange((1, 0), (1, 9)),
             ),
         )
     )

--- a/libcst/_nodes/tests/test_try.py
+++ b/libcst/_nodes/tests/test_try.py
@@ -29,7 +29,7 @@ class TryTest(CSTNodeTest):
                 ),
                 "code": "try: pass\nexcept: pass\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (2, 12)),
+                "expected_position": CodeRange((1, 0), (2, 12)),
             },
             # Try/except with a class
             {
@@ -59,7 +59,7 @@ class TryTest(CSTNodeTest):
                 ),
                 "code": "try: pass\nexcept Exception as exc: pass\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (2, 29)),
+                "expected_position": CodeRange((1, 0), (2, 29)),
             },
             # Try/except with multiple clauses
             {
@@ -87,7 +87,7 @@ class TryTest(CSTNodeTest):
                 + "except KeyError as e: pass\n"
                 + "except: pass\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (4, 12)),
+                "expected_position": CodeRange((1, 0), (4, 12)),
             },
             # Simple try/finally block
             {
@@ -97,7 +97,7 @@ class TryTest(CSTNodeTest):
                 ),
                 "code": "try: pass\nfinally: pass\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (2, 13)),
+                "expected_position": CodeRange((1, 0), (2, 13)),
             },
             # Simple try/except/finally block
             {
@@ -113,7 +113,7 @@ class TryTest(CSTNodeTest):
                 ),
                 "code": "try: pass\nexcept: pass\nfinally: pass\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (3, 13)),
+                "expected_position": CodeRange((1, 0), (3, 13)),
             },
             # Simple try/except/else block
             {
@@ -129,7 +129,7 @@ class TryTest(CSTNodeTest):
                 ),
                 "code": "try: pass\nexcept: pass\nelse: pass\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (3, 10)),
+                "expected_position": CodeRange((1, 0), (3, 10)),
             },
             # Simple try/except/else block/finally
             {
@@ -146,7 +146,7 @@ class TryTest(CSTNodeTest):
                 ),
                 "code": "try: pass\nexcept: pass\nelse: pass\nfinally: pass\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (4, 13)),
+                "expected_position": CodeRange((1, 0), (4, 13)),
             },
             # Verify whitespace in various locations
             {
@@ -181,7 +181,7 @@ class TryTest(CSTNodeTest):
                 ),
                 "code": "# 1\ntry : pass\n# 2\nexcept  TypeError  as  e : pass\n# 3\nelse : pass\n# 4\nfinally : pass\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((2, 0), (8, 14)),
+                "expected_position": CodeRange((2, 0), (8, 14)),
             },
             # Please don't write code like this
             {
@@ -213,7 +213,7 @@ class TryTest(CSTNodeTest):
                 + "else: pass\n"
                 + "finally: pass\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (6, 13)),
+                "expected_position": CodeRange((1, 0), (6, 13)),
             },
             # Verify indentation
             {

--- a/libcst/_nodes/tests/test_tuple.py
+++ b/libcst/_nodes/tests/test_tuple.py
@@ -88,7 +88,7 @@ class TupleTest(CSTNodeTest):
                 ),
                 "code": "(*one,*two,)",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 1), (1, 11)),
+                "expected_position": CodeRange((1, 1), (1, 11)),
             },
             # custom parenthesis on StarredElement
             {
@@ -104,7 +104,7 @@ class TupleTest(CSTNodeTest):
                 ),
                 "code": "((*abc),)",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 1), (1, 8)),
+                "expected_position": CodeRange((1, 1), (1, 8)),
             },
             # custom whitespace on StarredElement
             {
@@ -123,7 +123,7 @@ class TupleTest(CSTNodeTest):
                 ),
                 "code": "one,(*  two)",
                 "parser": parse_expression,
-                "expected_position": CodeRange.create((1, 0), (1, 12)),
+                "expected_position": CodeRange((1, 0), (1, 12)),
             },
             # missing spaces around tuple, okay with parenthesis
             {

--- a/libcst/_nodes/tests/test_unary_op.py
+++ b/libcst/_nodes/tests/test_unary_op.py
@@ -29,7 +29,7 @@ class UnaryOperationTest(CSTNodeTest):
                     rpar=(cst.RightParen(),),
                 ),
                 "(not foo)",
-                CodeRange.create((1, 1), (1, 8)),
+                CodeRange((1, 1), (1, 8)),
             ),
             (
                 cst.UnaryOperation(
@@ -39,7 +39,7 @@ class UnaryOperationTest(CSTNodeTest):
                     ),
                 ),
                 "not(foo)",
-                CodeRange.create((1, 0), (1, 8)),
+                CodeRange((1, 0), (1, 8)),
             ),
             # Make sure that spacing works
             (
@@ -50,7 +50,7 @@ class UnaryOperationTest(CSTNodeTest):
                     rpar=(cst.RightParen(whitespace_before=cst.SimpleWhitespace(" ")),),
                 ),
                 "( not  foo )",
-                CodeRange.create((1, 2), (1, 10)),
+                CodeRange((1, 2), (1, 10)),
             ),
         )
     )

--- a/libcst/_nodes/tests/test_while.py
+++ b/libcst/_nodes/tests/test_while.py
@@ -45,7 +45,7 @@ class WhileTest(CSTNodeTest):
                 ),
                 "code": "    while iter(): pass\n",
                 "parser": None,
-                "expected_position": CodeRange.create((1, 4), (1, 22)),
+                "expected_position": CodeRange((1, 4), (1, 22)),
             },
             # while an indented body
             {
@@ -58,7 +58,7 @@ class WhileTest(CSTNodeTest):
                 ),
                 "code": "    while iter():\n        pass\n",
                 "parser": None,
-                "expected_position": CodeRange.create((1, 4), (2, 12)),
+                "expected_position": CodeRange((1, 4), (2, 12)),
             },
             # leading_lines
             {
@@ -71,7 +71,7 @@ class WhileTest(CSTNodeTest):
                 ),
                 "code": "# leading comment\nwhile iter():\n    pass\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((2, 0), (3, 8)),
+                "expected_position": CodeRange((2, 0), (3, 8)),
             },
             {
                 "node": cst.While(
@@ -89,7 +89,7 @@ class WhileTest(CSTNodeTest):
                 ),
                 "code": "# leading comment\nwhile iter():\n    pass\n# else comment\nelse:\n    pass\n",
                 "parser": None,
-                "expected_position": CodeRange.create((2, 0), (6, 8)),
+                "expected_position": CodeRange((2, 0), (6, 8)),
             },
             # Weird spacing rules
             {
@@ -104,7 +104,7 @@ class WhileTest(CSTNodeTest):
                 ),
                 "code": "while(iter()): pass\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (1, 19)),
+                "expected_position": CodeRange((1, 0), (1, 19)),
             },
             # Whitespace
             {
@@ -116,7 +116,7 @@ class WhileTest(CSTNodeTest):
                 ),
                 "code": "while  iter()  : pass\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (1, 21)),
+                "expected_position": CodeRange((1, 0), (1, 21)),
             },
         )
     )

--- a/libcst/_nodes/tests/test_with.py
+++ b/libcst/_nodes/tests/test_with.py
@@ -24,7 +24,7 @@ class WithTest(CSTNodeTest):
                 ),
                 "code": "with context_mgr(): pass\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (1, 24)),
+                "expected_position": CodeRange((1, 0), (1, 24)),
             },
             # Simple async with block
             {
@@ -87,7 +87,7 @@ class WithTest(CSTNodeTest):
                 ),
                 "code": "    with context_mgr(): pass\n",
                 "parser": None,
-                "expected_position": CodeRange.create((1, 4), (1, 28)),
+                "expected_position": CodeRange((1, 4), (1, 28)),
             },
             # with an indented body
             {
@@ -100,7 +100,7 @@ class WithTest(CSTNodeTest):
                 ),
                 "code": "    with context_mgr():\n        pass\n",
                 "parser": None,
-                "expected_position": CodeRange.create((1, 4), (2, 12)),
+                "expected_position": CodeRange((1, 4), (2, 12)),
             },
             # leading_lines
             {
@@ -113,7 +113,7 @@ class WithTest(CSTNodeTest):
                 ),
                 "code": "# leading comment\nwith context_mgr(): pass\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((2, 0), (2, 24)),
+                "expected_position": CodeRange((2, 0), (2, 24)),
             },
             # Weird spacing rules
             {
@@ -132,7 +132,7 @@ class WithTest(CSTNodeTest):
                 ),
                 "code": "with(context_mgr()): pass\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (1, 25)),
+                "expected_position": CodeRange((1, 0), (1, 25)),
             },
             # Whitespace
             {
@@ -153,7 +153,7 @@ class WithTest(CSTNodeTest):
                 ),
                 "code": "with  context_mgr()  as  ctx  : pass\n",
                 "parser": parse_statement,
-                "expected_position": CodeRange.create((1, 0), (1, 36)),
+                "expected_position": CodeRange((1, 0), (1, 36)),
             },
         )
     )

--- a/libcst/_nodes/tests/test_yield.py
+++ b/libcst/_nodes/tests/test_yield.py
@@ -38,7 +38,7 @@ class YieldConstructionTest(CSTNodeTest):
                     whitespace_after_yield=cst.SimpleWhitespace(""),
                 ),
                 "yield(a)",
-                CodeRange.create((1, 0), (1, 8)),
+                CodeRange((1, 0), (1, 8)),
             ),
             (
                 cst.Yield(
@@ -74,7 +74,7 @@ class YieldConstructionTest(CSTNodeTest):
                     rpar=(cst.RightParen(whitespace_before=cst.SimpleWhitespace(" ")),),
                 ),
                 "( yield  from  bla() )",
-                CodeRange.create((1, 2), (1, 20)),
+                CodeRange((1, 2), (1, 20)),
             ),
             # From expression position tests
             (
@@ -82,7 +82,7 @@ class YieldConstructionTest(CSTNodeTest):
                     cst.Integer("5"), whitespace_after_from=cst.SimpleWhitespace(" ")
                 ),
                 "from 5",
-                CodeRange.create((1, 0), (1, 6)),
+                CodeRange((1, 0), (1, 6)),
             ),
         )
     )

--- a/libcst/_visitors.py
+++ b/libcst/_visitors.py
@@ -7,7 +7,7 @@
 from typing import TYPE_CHECKING, TypeVar, Union
 
 from libcst._removal_sentinel import RemovalSentinel
-from libcst.metadata.dependent import _MetadataDependent
+from libcst.metadata.dependent import MetadataDependent
 
 
 if TYPE_CHECKING:
@@ -19,7 +19,7 @@ CSTVisitorT = Union["CSTTransformer", "CSTVisitor"]
 CSTNodeT = TypeVar("CSTNodeT", bound="CSTNode")
 
 
-class CSTTransformer(_MetadataDependent):
+class CSTTransformer(MetadataDependent):
     """
     The low-level base visitor class for traversing a CST and creating an
     updated copy of the original CST. This should be used in conjunction with
@@ -72,7 +72,7 @@ class CSTTransformer(_MetadataDependent):
         return updated_node
 
 
-class CSTVisitor(_MetadataDependent):
+class CSTVisitor(MetadataDependent):
     """
     The low-level base visitor class for traversing a CST. This should be used in
     conjunction with the :func:`~libcst.CSTNode.visit` method on a

--- a/libcst/metadata/base_provider.py
+++ b/libcst/metadata/base_provider.py
@@ -41,6 +41,9 @@ class BaseMetadataProvider(MetadataDependent, Generic[_T]):
     """
     The low-level base class for all metadata providers. This class should be
     extended for metadata providers that are not visitor-based.
+
+    This class is generic. A subclass of ``BaseMetadataProvider[T]`` will
+    provider metadata of type ``T``.
     """
 
     #: Cache of metadata computed by this provider
@@ -102,6 +105,9 @@ class VisitorMetadataProvider(CSTVisitor, BaseMetadataProvider[_T]):
     """
     The low-level base class for all non-batchable visitor-based metadata
     providers. Inherits from :class:`~libcst.CSTVisitor`.
+
+    This class is generic. A subclass of ``VisitorMetadataProvider[T]`` will
+    provider metadata of type ``T``.
     """
 
     def _gen_impl(self, module: "_ModuleT") -> None:
@@ -112,6 +118,9 @@ class BatchableMetadataProvider(BatchableCSTVisitor, BaseMetadataProvider[_T]):
     """
     The low-level base class for all batchable visitor-based metadata providers.
     Inherits from :class:`~libcst.BatchableCSTVisitor`.
+
+    This class is generic. A subclass of ``BatchableMetadataProvider[T]`` will
+    provider metadata of type ``T``.
     """
 
     def _gen_impl(self, module: "Module") -> None:

--- a/libcst/metadata/base_provider.py
+++ b/libcst/metadata/base_provider.py
@@ -117,6 +117,8 @@ class VisitorMetadataProvider(CSTVisitor, BaseMetadataProvider[_T]):
 class BatchableMetadataProvider(BatchableCSTVisitor, BaseMetadataProvider[_T]):
     """
     The low-level base class for all batchable visitor-based metadata providers.
+    Batchable providers should be preferred when possible as they are more
+    efficient to run compared to non-batchable visitor-based providers.
     Inherits from :class:`~libcst.BatchableCSTVisitor`.
 
     This class is generic. A subclass of ``BatchableMetadataProvider[T]`` will

--- a/libcst/metadata/base_provider.py
+++ b/libcst/metadata/base_provider.py
@@ -87,6 +87,7 @@ class BaseMetadataProvider(MetadataDependent, Generic[_T]):
         """
         The same method as :func:`~libcst.MetadataDependent.get_metadata` except
         metadata is accessed from ``self._computed`` in addition to ``self.metadata``.
+        See :func:`~libcst.MetadataDependent.get_metadata`.
         """
         if key is type(self):
             if default is not _UNDEFINED_DEFAULT:
@@ -100,7 +101,7 @@ class BaseMetadataProvider(MetadataDependent, Generic[_T]):
 class VisitorMetadataProvider(CSTVisitor, BaseMetadataProvider[_T]):
     """
     The low-level base class for all non-batchable visitor-based metadata
-    providers.
+    providers. Inherits from :class:`~libcst.CSTVisitor`.
     """
 
     def _gen_impl(self, module: "_ModuleT") -> None:
@@ -110,6 +111,7 @@ class VisitorMetadataProvider(CSTVisitor, BaseMetadataProvider[_T]):
 class BatchableMetadataProvider(BatchableCSTVisitor, BaseMetadataProvider[_T]):
     """
     The low-level base class for all batchable visitor-based metadata providers.
+    Inherits from :class:`~libcst.BatchableCSTVisitor`.
     """
 
     def _gen_impl(self, module: "Module") -> None:

--- a/libcst/metadata/base_provider.py
+++ b/libcst/metadata/base_provider.py
@@ -22,7 +22,7 @@ from libcst._visitors import CSTVisitor
 from libcst.metadata.dependent import (
     _T as _MetadataT,
     _UNDEFINED_DEFAULT,
-    _MetadataDependent,
+    MetadataDependent,
 )
 
 
@@ -37,13 +37,13 @@ _T = TypeVar("_T")
 
 
 # We can't use an ABCMeta here, because of metaclass conflicts
-class BaseMetadataProvider(_MetadataDependent, Generic[_T]):
+class BaseMetadataProvider(MetadataDependent, Generic[_T]):
     """
     The low-level base class for all metadata providers. This class should be
     extended for metadata providers that are not visitor-based.
     """
 
-    # Cache of metadata computed by this provider
+    #: Cache of metadata computed by this provider
     _computed: MutableMapping["CSTNode", _T]
 
     def __init__(self) -> None:
@@ -85,8 +85,8 @@ class BaseMetadataProvider(_MetadataDependent, Generic[_T]):
         default: _MetadataT = _UNDEFINED_DEFAULT,
     ) -> _MetadataT:
         """
-        The same method as :func:`~libcst._MetadataDependent` except metadata
-        is accessed from ``self._computed`` in addition to ``self.metadata``.
+        The same method as :func:`~libcst.MetadataDependent.get_metadata` except
+        metadata is accessed from ``self._computed`` in addition to ``self.metadata``.
         """
         if key is type(self):
             if default is not _UNDEFINED_DEFAULT:

--- a/libcst/metadata/dependent.py
+++ b/libcst/metadata/dependent.py
@@ -35,17 +35,19 @@ _UNDEFINED_DEFAULT = object()
 
 # TODO: this class should be an ABC but we're waiting on Pyre to fix a bug to
 # add this functionality back
-class _MetadataDependent:
+class MetadataDependent:
     """
-    The low-level base class for all types that declare required metadata
-    dependencies.
+    The low-level base class for all classes that declare required metadata
+    dependencies. :class:`~libcst.CSTVisitor` and :class:`~libcst.CSTTransformer`
+    extend this class.
     """
 
     # pyre-ignore[4]: Attribute `metadata` of class
-    # `libcst.metadata.dependent._MetadataDependent` must have a type that
+    # `libcst.metadata.dependent.MetadataDependent` must have a type that
     # does not contain `Any`.
     metadata: Mapping["ProviderT", Mapping["CSTNode", object]]
 
+    #: The set of metadata depedencies declared by this class.
     METADATA_DEPENDENCIES: ClassVar[Collection["ProviderT"]] = ()
 
     def __init__(self) -> None:
@@ -63,7 +65,7 @@ class _MetadataDependent:
         except AttributeError:
             dependencies = set()
             for c in inspect.getmro(cls):
-                if issubclass(c, _MetadataDependent):
+                if issubclass(c, MetadataDependent):
                     dependencies.update(c.METADATA_DEPENDENCIES)
             cls._INHERITED_METADATA_DEPENDENCIES_CACHE = frozenset(dependencies)
             # pyre-fixme[16]: use a hidden attribute to cache the property
@@ -74,7 +76,7 @@ class _MetadataDependent:
         """
         Context manager that resolves all metadata dependencies declared by
         this instance of this class on ``wrapper`` and caches it for use with
-        :func:`~libcst._MetadataDependent.get_metadata`.
+        :func:`~libcst.MetadataDependent.get_metadata`.
 
         Upon exiting this context manager, the metadata cache on the instance is
         cleared.

--- a/libcst/metadata/position_provider.py
+++ b/libcst/metadata/position_provider.py
@@ -17,8 +17,7 @@ PositionProvider = Union["BasicPositionProvider", "SyntacticPositionProvider"]
 class BasicPositionProvider(BaseMetadataProvider[CodeRange]):
     """
     Generates basic line and column metadata. Basic position is defined by the
-    start and ending bounds of a node including all whitespace
-    owned by that node.
+    start and ending bounds of a node including all whitespace owned by that node.
     """
 
     def _gen_impl(self, module: _ModuleT) -> None:
@@ -27,7 +26,7 @@ class BasicPositionProvider(BaseMetadataProvider[CodeRange]):
 
 class SyntacticPositionProvider(BasicPositionProvider):
     """
-    Generates Syntactic line and column metadata. Syntactic position is defined
+    Generates syntactic line and column metadata. Syntactic position is defined
     by the start and ending bounds of a node ignoring most instances of leading
     and trailing whitespace when it is not syntactically significant.
     """

--- a/libcst/metadata/tests/test_position_provider.py
+++ b/libcst/metadata/tests/test_position_provider.py
@@ -27,7 +27,7 @@ class PositionProviderTest(UnitTest):
 
             def visit_Pass(self, node: cst.Pass) -> None:
                 range = self.get_metadata(SyntacticPositionProvider, node)
-                test.assertEqual(range, CodeRange.create((1, 0), (1, 4)))
+                test.assertEqual(range, CodeRange((1, 0), (1, 4)))
 
         wrapper = MetadataWrapper(parse_module("pass"))
         wrapper.visit(DependentVisitor())
@@ -40,7 +40,7 @@ class PositionProviderTest(UnitTest):
 
             def visit_Pass(self, node: cst.Pass) -> None:
                 range = self.get_metadata(SyntacticPositionProvider, node)
-                test.assertEqual(range, CodeRange.create((1, 0), (1, 4)))
+                test.assertEqual(range, CodeRange((1, 0), (1, 4)))
 
         wrapper = MetadataWrapper(parse_module("pass"))
         wrapper.visit_batched([ABatchable()])

--- a/libcst/metadata/wrapper.py
+++ b/libcst/metadata/wrapper.py
@@ -40,7 +40,8 @@ class MetadataWrapper:
     """
     A wrapper around a :class:`~libcst.Module` that stores associated metadata
     for that module. When a :class:`MetadataWrapper` is constructed over
-    a module, the wrapper will store a deep copy of the original module.
+    a module, the wrapper will store a deep copy of the original module. This
+    means ``MetadataWrapper(module).module == module`` is ``False``.
     """
 
     module: "Module"
@@ -85,7 +86,7 @@ class MetadataWrapper:
     def visit(self, visitor: "CSTVisitorT") -> "Module":
         """
         Convenience method to resolve metadata before performing a traversal over
-        ``self.module`` with ``visitor``. See :func:`~libcst.CSTNode.visit`.
+        ``self.module`` with ``visitor``. See :func:`~libcst.Module.visit`.
         """
         with visitor.resolve(self):
             return self.module.visit(visitor)


### PR DESCRIPTION
## Summary
Adds documentation to the metadata interface for LibCST and cleans up some internal code.

## Test Plan
Ran tox and pyre.
