### PR TITLE
Make ParserSyntaxError more generic and use it in more places

### DIFF
--- a/docs/source/parser.rst
+++ b/docs/source/parser.rst
@@ -40,3 +40,10 @@ BinaryOperation(
 .. autofunction:: libcst.parse_expression
 .. autofunction:: libcst.parse_statement
 .. autoclass:: libcst.PartialParserConfig
+
+Syntax Errors
+-------------
+
+.. autoclass:: libcst.ParserSyntaxError
+   :members: message, raw_line, raw_column, editor_line, editor_column
+   :special-members: __str__

--- a/libcst/_exceptions.py
+++ b/libcst/_exceptions.py
@@ -4,77 +4,160 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
-from typing import Iterable, Optional, Sequence, Tuple
+from enum import Enum, auto
+from typing import Any, Callable, Iterable, Optional, Sequence, Tuple, Union
 
+from parso.pgen2.generator import ReservedString
+from parso.python.token import PythonTokenTypes, TokenType
+from typing_extensions import final
+
+from libcst._parser._types.token import Token
 from libcst._tabs import expand_tabs
 
 
 _EOF_STR: str = "end of file (EOF)"
+_INDENT_STR: str = "an indent"
+_DEDENT_STR: str = "a dedent"
 _NEWLINE_CHARS: str = "\r\n"
 
 
+class EOFSentinel(Enum):
+    EOF = auto()
+
+
+def get_expected_str(
+    encountered: Union[Token, EOFSentinel],
+    expected: Union[Iterable[Union[TokenType, ReservedString]], EOFSentinel],
+) -> str:
+    if isinstance(encountered, EOFSentinel):
+        encountered_str = _EOF_STR
+    else:
+        encountered_str = repr(encountered.string)
+
+    if isinstance(expected, EOFSentinel):
+        expected_names = _EOF_STR
+    else:
+        expected_str = repr([
+            el.name if isinstance(el, TokenType) else el.value
+            for el in expected
+        ])
+
+    return f"Encountered {encountered_str}, but expected {expected_str}."
+
+
+# pyre-fixme[2]: 'Any' type isn't pyre-strict.
+def _parser_syntax_error_unpickle(kwargs: Any) -> "ParserSyntaxError":
+    return ParserSyntaxError(**kwargs)
+
+
+@final
 class ParserSyntaxError(Exception):
     """
     Contains error information about the parser tree.
     """
 
+    message: str
+
+    # An internal value used to compute `editor_column` and to pretty-print where the
+    # syntax error occurred in the code.
+    _lines: Sequence[str]
+
+    # These are internal values for the public raw_line/raw_column properties. They may
+    # get backfilled later.
+    _raw_line: int
+    _raw_column: int
+
     def __init__(
         self,
         message: str,
-        encountered: Optional[str],  # None means EOF
-        expected: Optional[Iterable[str]],  # None means EOF
-        pos: Tuple[int, int],  # (one-indexed line, zero-indexed column)
-        lines: Sequence[str],  # source code, used to generate a human-readable output
+        *,
+        lines: Sequence[str],
+        raw_line: int = -1,
+        raw_column: int = -1,
     ) -> None:
+        super(ParserSyntaxError, self).__init__(message)
         self.message = message
-        self.encountered = encountered
-        self.expected = expected
-        self.pos = pos
-        self.lines = lines
-        # Make pickling this error work
-        super(ParserSyntaxError, self).__init__(
-            message, encountered, expected, pos, lines
+        self._lines = lines
+        self._raw_line = raw_line
+        self._raw_column = raw_column
+
+    def __reduce__(
+        self
+    ) -> Tuple[Callable[..., "ParserSyntaxError"], Tuple[object, ...]]:
+        return (
+            _parser_syntax_error_unpickle,
+            (
+                {
+                    "message": self.message,
+                    "lines": self._lines,
+                    "raw_line": self._raw_line,
+                    "raw_column": self._raw_column,
+                },
+            ),
         )
 
     def __str__(self) -> str:
         """
         A human-readable error message of where the syntax error is in their code.
         """
-        if self.encountered is not None:
-            encountered_str = repr(self.encountered)
-        else:
-            encountered_str = _EOF_STR
-
-        if self.expected is not None:
-            expected_str = f"one of {repr(list(self.expected))}"
-        else:
-            expected_str = _EOF_STR
-
-        pos_line, pos_column = self.pos
-        editor_line = self.editor_line
-        editor_column = self.editor_column
-
+        context = self.context
         return (
-            f"Syntax Error: {self.message} @ {editor_line}:{editor_column}.\n"
-            + f"Encountered {encountered_str}, but expected {expected_str}.\n\n"
-            + f"{expand_tabs(self.lines[pos_line - 1]).rstrip(_NEWLINE_CHARS)}\n"
-            + f"{' ' * (editor_column - 1)}^"
+            f"Syntax Error @ {self.editor_line}:{self.editor_column}.\n"
+            + f"{self.message}"
+            + (f"\n\n{context}" if context is not None else "")
         )
+
+    def __repr__(self) -> str:
+        return (
+            f"ParserSyntaxError("
+            + f"{self.message!r}, lines=[...], raw_line={self._raw_line!r}, "
+            + f"raw_column={self._raw_column!r})"
+        )
+
+    @property
+    def context(self) -> str:
+        displayed_line = self.editor_line
+        displayed_column = self.editor_column
+
+        formatted_source_line = expand_tabs(self._lines[displayed_line - 1]).rstrip(
+            _NEWLINE_CHARS
+        )
+        # fmt: off
+        return (
+            f"{formatted_source_line}\n"
+            + f"{' ' * (displayed_column - 1)}^"
+        )
+        # fmt: on
+
+    @property
+    def raw_line(self) -> int:
+        # Internally we might initialize _raw_line to -1 when we don't know the line
+        # number yet. This should never be exposed to the user, because we should
+        # backfill this before the user can access it.
+        assert self._raw_line >= 1, "ParserSyntaxError was not fully initialized"
+        return self._raw_line
+
+    @property
+    def raw_column(self) -> int:
+        # Internally we might initialize _raw_line to -1 when we don't know the line
+        # number yet.
+        assert self._raw_column >= 0, "ParserSyntaxError was not fully initialized"
+        return self._raw_column
 
     @property
     def editor_line(self) -> int:
         """
         The one-indexed line in the user's editor.
         """
-        return self.pos[0]  # the line in pos is already one-indexed.
+        return self.raw_line  # raw_line is already one-indexed.
 
     @property
     def editor_column(self) -> int:
         """
         The one-indexed column in the user's editor, assuming tabs expand to 1-8 spaces.
         """
-        pos_line, pos_column = self.pos
-        tab_adjusted_column = len(expand_tabs(self.lines[pos_line - 1][:pos_column]))
+        prefix_str = self._lines[self.raw_line - 1][: self.raw_column]
+        tab_adjusted_column = len(expand_tabs(prefix_str))
         # Text editors use a one-indexed column, so we need to add one to our
         # zero-indexed column to get a human-readable result.
         return tab_adjusted_column + 1

--- a/libcst/_parser/_conversions/expression.py
+++ b/libcst/_parser/_conversions/expression.py
@@ -11,6 +11,7 @@ from tokenize import (
     Intnumber as INTNUMBER_RE,
 )
 
+from libcst._exceptions import ParserSyntaxError
 from libcst._maybe_sentinel import MaybeSentinel
 from libcst._nodes._expression import (
     Arg,
@@ -400,7 +401,7 @@ def convert_comp_op(
                 ),
             )
         else:
-            # TODO: Make this a ParserSyntaxError
+            # this should be unreachable
             raise Exception(f"Unexpected token '{op.string}'!")
     else:
         # A two-token comparison
@@ -431,7 +432,7 @@ def convert_comp_op(
                 ),
             )
         else:
-            # TODO: Make this a ParserSyntaxError
+            # this should be unreachable
             raise Exception(f"Unexpected token '{leftcomp.string} {rightcomp.string}'!")
 
 
@@ -1247,8 +1248,10 @@ def _convert_dict(
         possible_comp_for = None if len(children) < 4 else children[3]
     if isinstance(possible_comp_for, CompFor):
         if is_first_starred:
-            # TODO: Make this a ParserSyntaxError
-            raise Exception("dict unpacking cannot be used in dict comprehension")
+            raise ParserSyntaxError(
+                "dict unpacking cannot be used in dict comprehension",
+                lines=config.lines,
+            )
         return _convert_dict_comp(config, children)
 
     children_iter = iter(children)

--- a/libcst/_parser/_conversions/expression.py
+++ b/libcst/_parser/_conversions/expression.py
@@ -11,7 +11,7 @@ from tokenize import (
     Intnumber as INTNUMBER_RE,
 )
 
-from libcst._exceptions import ParserSyntaxError
+from libcst._exceptions import PartialParserSyntaxError
 from libcst._maybe_sentinel import MaybeSentinel
 from libcst._nodes._expression import (
     Arg,
@@ -1248,9 +1248,8 @@ def _convert_dict(
         possible_comp_for = None if len(children) < 4 else children[3]
     if isinstance(possible_comp_for, CompFor):
         if is_first_starred:
-            raise ParserSyntaxError(
-                "dict unpacking cannot be used in dict comprehension",
-                lines=config.lines,
+            raise PartialParserSyntaxError(
+                "dict unpacking cannot be used in dict comprehension"
             )
         return _convert_dict_comp(config, children)
 

--- a/libcst/_parser/_conversions/params.py
+++ b/libcst/_parser/_conversions/params.py
@@ -5,7 +5,7 @@
 
 from typing import Any, List, Optional, Sequence, Union
 
-from libcst._exceptions import ParserSyntaxError
+from libcst._exceptions import PartialParserSyntaxError
 from libcst._maybe_sentinel import MaybeSentinel
 from libcst._nodes._expression import Annotation, Name, Param, Parameters, ParamStar
 from libcst._nodes._op import AssignEqual, Comma
@@ -67,10 +67,9 @@ def convert_argslist(config: ParserConfig, children: Sequence[Any]) -> Any:
             else:
                 # Example code:
                 #     def fn(first=None, second): ...
-                # This code is reachable, so we should use a ParserSyntaxError.
-                raise ParserSyntaxError(
-                    "Cannot have a non-default argument following a default argument.",
-                    lines=config.lines,
+                # This code is reachable, so we should use a PartialParserSyntaxError.
+                raise PartialParserSyntaxError(
+                    "Cannot have a non-default argument following a default argument."
                 )
         elif (
             isinstance(param.star, str)
@@ -143,9 +142,8 @@ def convert_argslist(config: ParserConfig, children: Sequence[Any]) -> Any:
                 #
                 # It's not valid to construct a ParamStar object without a comma, so we
                 # need to catch the non-comma case separately.
-                raise ParserSyntaxError(
-                    "Named (keyword) arguments must follow a bare *.",
-                    lines=config.lines,
+                raise PartialParserSyntaxError(
+                    "Named (keyword) arguments must follow a bare *."
                 )
             else:
                 current = add_param(current, parameter)
@@ -172,8 +170,8 @@ def convert_argslist(config: ParserConfig, children: Sequence[Any]) -> Any:
         #
         # The case where there's no trailing comma is already handled by this point, so
         # this conditional is only for the case where we have a trailing comma.
-        raise ParserSyntaxError(
-            "Named (keyword) arguments must follow a bare *.", lines=config.lines
+        raise PartialParserSyntaxError(
+            "Named (keyword) arguments must follow a bare *."
         )
 
     return Parameters(

--- a/libcst/_parser/_conversions/statement.py
+++ b/libcst/_parser/_conversions/statement.py
@@ -5,6 +5,7 @@
 
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Type
 
+from libcst._exceptions import ParserSyntaxError
 from libcst._maybe_sentinel import MaybeSentinel
 from libcst._nodes._expression import (
     Annotation,
@@ -1173,8 +1174,9 @@ def convert_classdef(config: ParserConfig, children: Sequence[Any]) -> Any:
             if current_arg is keywords and (
                 arg.star == "*" or (arg.star == "" and arg.keyword is None)
             ):
-                # TODO: Need a real syntax error here
-                raise Exception("Syntax error!")
+                raise ParserSyntaxError(
+                    "Positional argument follows keyword argument.", lines=config.lines
+                )
             current_arg.append(arg)
 
         return ClassDef(

--- a/libcst/_parser/_conversions/statement.py
+++ b/libcst/_parser/_conversions/statement.py
@@ -5,7 +5,7 @@
 
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Type
 
-from libcst._exceptions import ParserSyntaxError
+from libcst._exceptions import PartialParserSyntaxError
 from libcst._maybe_sentinel import MaybeSentinel
 from libcst._nodes._expression import (
     Annotation,
@@ -1174,8 +1174,8 @@ def convert_classdef(config: ParserConfig, children: Sequence[Any]) -> Any:
             if current_arg is keywords and (
                 arg.star == "*" or (arg.star == "" and arg.keyword is None)
             ):
-                raise ParserSyntaxError(
-                    "Positional argument follows keyword argument.", lines=config.lines
+                raise PartialParserSyntaxError(
+                    "Positional argument follows keyword argument."
                 )
             current_arg.append(arg)
 

--- a/libcst/_parser/_wrapped_tokenize.py
+++ b/libcst/_parser/_wrapped_tokenize.py
@@ -113,19 +113,17 @@ def _convert_token(  # noqa: C901: too complex
     ct_start_pos = curr_token.start_pos
     if ct_type is _ERRORTOKEN:
         raise ParserSyntaxError(
-            message="invalid token",
-            encountered=ct_string,
-            expected=["TOKEN"],
-            pos=curr_token.start_pos,
+            f"{ct_string!r} is not a valid token.",
             lines=state.lines,
+            raw_line=ct_start_pos[0],
+            raw_column=ct_start_pos[1],
         )
     if ct_type is _ERROR_DEDENT:
         raise ParserSyntaxError(
-            message="inconsistent indentation",
-            encountered=next_token.string if next_token is not None else None,
-            expected=["DEDENT"],
-            pos=curr_token.start_pos,
+            "Inconsistent indentation. Expected a dedent.",
             lines=state.lines,
+            raw_line=ct_start_pos[0],
+            raw_column=ct_start_pos[1],
         )
 
     # Compute relative indent changes for indent/dedent nodes

--- a/libcst/_parser/tests/test_parse_errors.py
+++ b/libcst/_parser/tests/test_parse_errors.py
@@ -96,10 +96,70 @@ class ParseErrorsTest(UnitTest):
                 dedent(
                     """
                     Syntax Error @ 1:19.
-                    Internal error: dict unpacking cannot be used in dict comprehension
+                    dict unpacking cannot be used in dict comprehension
 
                     {**el for el in []}
                                       ^
+                    """
+                ).strip(),
+            ),
+            "convert_nonterminal__arglist_non_default_after_default": (
+                lambda: cst.parse_statement("def fn(first=None, second): ..."),
+                dedent(
+                    """
+                    Syntax Error @ 1:26.
+                    Cannot have a non-default argument following a default argument.
+
+                    def fn(first=None, second): ...
+                                             ^
+                    """
+                ).strip(),
+            ),
+            "convert_nonterminal__arglist_trailing_param_star_without_comma": (
+                lambda: cst.parse_statement("def fn(abc, *): ..."),
+                dedent(
+                    """
+                    Syntax Error @ 1:14.
+                    Named (keyword) arguments must follow a bare *.
+
+                    def fn(abc, *): ...
+                                 ^
+                    """
+                ).strip(),
+            ),
+            "convert_nonterminal__arglist_trailing_param_star_with_comma": (
+                lambda: cst.parse_statement("def fn(abc, *,): ..."),
+                dedent(
+                    """
+                    Syntax Error @ 1:15.
+                    Named (keyword) arguments must follow a bare *.
+
+                    def fn(abc, *,): ...
+                                  ^
+                    """
+                ).strip(),
+            ),
+            "convert_nonterminal__class_arg_positional_after_keyword": (
+                lambda: cst.parse_statement("class Cls(first=None, second): ..."),
+                dedent(
+                    """
+                    Syntax Error @ 2:1.
+                    Positional argument follows keyword argument.
+
+                    class Cls(first=None, second): ...
+                                                      ^
+                    """
+                ).strip(),
+            ),
+            "convert_nonterminal__class_arg_positional_expansion_after_keyword": (
+                lambda: cst.parse_statement("class Cls(first=None, *second): ..."),
+                dedent(
+                    """
+                    Syntax Error @ 2:1.
+                    Positional argument follows keyword argument.
+
+                    class Cls(first=None, *second): ...
+                                                       ^
                     """
                 ).strip(),
             ),

--- a/libcst/_parser/tests/test_parse_errors.py
+++ b/libcst/_parser/tests/test_parse_errors.py
@@ -1,0 +1,113 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from textwrap import dedent
+from typing import Callable
+
+import libcst as cst
+from libcst.testing.utils import UnitTest, data_provider
+
+
+class ParseErrorsTest(UnitTest):
+    @data_provider(
+        {
+            # _wrapped_tokenize raises these exceptions
+            "wrapped_tokenize__invalid_token": (
+                lambda: cst.parse_module("'"),
+                dedent(
+                    """
+                    Syntax Error @ 1:1.
+                    "'" is not a valid token.
+
+                    '
+                    ^
+                    """
+                ).strip(),
+            ),
+            "wrapped_tokenize__expected_dedent": (
+                lambda: cst.parse_module("if False:\n    pass\n  pass"),
+                dedent(
+                    """
+                    Syntax Error @ 3:1.
+                    Inconsistent indentation. Expected a dedent.
+
+                      pass
+                    ^
+                    """
+                ).strip(),
+            ),
+            "wrapped_tokenize__mismatched_braces": (
+                lambda: cst.parse_module("abcd)"),
+                dedent(
+                    """
+                    Syntax Error @ 1:5.
+                    Encountered a closing brace without a matching opening brace.
+
+                    abcd)
+                        ^
+                    """
+                ).strip(),
+            ),
+            # _base_parser raises these exceptions
+            "base_parser__unexpected_indent": (
+                lambda: cst.parse_module("    abcd"),
+                dedent(
+                    """
+                    Syntax Error @ 1:5.
+                    Incomplete input. Unexpectedly encountered an indent.
+
+                        abcd
+                        ^
+                    """
+                ).strip(),
+            ),
+            "base_parser__unexpected_dedent": (
+                lambda: cst.parse_module("if False:\n    (el for el\n"),
+                dedent(
+                    """
+                    Syntax Error @ 3:1.
+                    Incomplete input. Encountered a dedent, but expected 'in'.
+
+                        (el for el
+                                  ^
+                    """
+                ).strip(),
+            ),
+            "base_parser__multiple_possibilities": (
+                lambda: cst.parse_module("try: pass"),
+                dedent(
+                    """
+                    Syntax Error @ 2:1.
+                    Incomplete input. Encountered end of file (EOF), but expected 'except', or 'finally'.
+
+                    try: pass
+                             ^
+                    """
+                ).strip(),
+            ),
+            # conversion functions raise these exceptions.
+            # `_base_parser` is responsible for attaching location information.
+            "convert_nonterminal__dict_unpacking": (
+                lambda: cst.parse_expression("{**el for el in []}"),
+                dedent(
+                    """
+                    Syntax Error @ 1:19.
+                    Internal error: dict unpacking cannot be used in dict comprehension
+
+                    {**el for el in []}
+                                      ^
+                    """
+                ).strip(),
+            ),
+        }
+    )
+    def test_parser_syntax_error_str(
+        self, parse_fn: Callable[[], object], expected: str
+    ) -> None:
+        with self.assertRaises(cst.ParserSyntaxError) as cm:
+            parse_fn()
+        self.assertEqual(str(cm.exception), expected)

--- a/libcst/_parser/tests/test_wrapped_tokenize.py
+++ b/libcst/_parser/tests/test_wrapped_tokenize.py
@@ -230,12 +230,12 @@ class WrappedTokenizeTest(UnitTest):
             self.assertIs(a.whitespace_after, b.whitespace_before)
 
     def test_errortoken(self) -> None:
-        with self.assertRaisesRegex(ParserSyntaxError, "invalid token"):
+        with self.assertRaisesRegex(ParserSyntaxError, "not a valid token"):
             # use tuple() to read everything
             # The copyright symbol isn't a valid token
             tuple(tokenize("\u00a9", _PY38))
 
     def test_error_dedent(self) -> None:
-        with self.assertRaisesRegex(ParserSyntaxError, "inconsistent indentation"):
+        with self.assertRaisesRegex(ParserSyntaxError, "Inconsistent indentation"):
             # create some inconsistent indents to generate an ERROR_DEDENT token
             tuple(tokenize("    a\n  b", _PY38))

--- a/libcst/tests/test_exceptions.py
+++ b/libcst/tests/test_exceptions.py
@@ -4,6 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
+
+import pickle
 from textwrap import dedent
 
 from libcst._exceptions import ParserSyntaxError
@@ -55,3 +57,17 @@ class ExceptionsTest(UnitTest):
         self, err: ParserSyntaxError, expected: str
     ) -> None:
         self.assertEqual(str(err), expected)
+
+    def test_pickle(self) -> None:
+        """
+        It's common to use LibCST with multiprocessing to process files in parallel.
+        Multiprocessing uses pickle by default, so we should make sure our errors can be
+        pickled/unpickled.
+        """
+        orig_exception = ParserSyntaxError(
+            "some message", lines=["abcd"], raw_line=1, raw_column=0
+        )
+        pickled_blob = pickle.dumps(orig_exception)
+        new_exception = pickle.loads(pickled_blob)
+        self.assertEqual(repr(orig_exception), repr(new_exception))
+        self.assertEqual(str(orig_exception), str(new_exception))


### PR DESCRIPTION
## Summary

`ParserSyntaxError` is a little too coupled to how pgen2 works (my fault), making some error messages bad and preventing us from using it everywhere we should.

A more detailed description of this problem is available in #24.

After refactoring `ParserSyntaxError`, this uses it in places where we should've been raising a `ParserSyntaxError`, but were raising an `Exception` instead.

## Test Plan

Unit tests!