### PR TITLE
[CI] add test coverage run and codecov integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,8 @@ jobs:
     steps:
       - tox:
           env: "py37"
+      - tox:
+          env: "coverage"
 
   test-36:
     docker:
@@ -88,3 +90,4 @@ jobs:
     steps:
       - tox:
           env: "py36"
+

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ docs/build/
 dist/
 docs/source/.ipynb_checkpoints/
 build/
+.coverage

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,6 @@
 black==19.3b0
+codecov==2.0.15
+coverage==4.5.4
 flake8==3.7.8
 git+https://github.com/jimmylai/sphinx.git@slots_type_annotation
 isort==4.3.20

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,8 @@ setuptools.setup(
     extras_require={
         "dev": [
             "black",
+            "codecov",
+            "coverage",
             "isort",
             "flake8",
             "jupyter",

--- a/tox.ini
+++ b/tox.ini
@@ -31,3 +31,15 @@ commands =
     flake8
     isort -y -q
     black libcst/
+
+[testenv:coverage]
+deps =
+    -rrequirements.txt
+    -rrequirements-dev.txt
+passenv =
+    CI
+    CIRCLECI
+    CIRCLE_*
+commands =
+    coverage run setup.py test
+    codecov


### PR DESCRIPTION
## Summary
codecov is a code test coverage platform and it's free for open source.
https://codecov.io/#features


## Test Plan
https://circleci.com/gh/Instagram/LibCST/1526?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
![image](https://user-images.githubusercontent.com/3840867/63286421-dc500900-c26c-11e9-9115-f0f578a0fd41.png)

https://codecov.io/gh/Instagram/LibCST/src/cc244fc93327c615007ba1bdfee30f2309bbe08b/setup.py
![image](https://user-images.githubusercontent.com/3840867/63286536-1e794a80-c26d-11e9-934a-b97cca3e2582.png)
