### PR TITLE
Update PartialParserConfig to more clearly reflect that we only support Python 3.7 (#32)

### DIFF
--- a/libcst/_nodes/_module.py
+++ b/libcst/_nodes/_module.py
@@ -57,13 +57,19 @@ class Module(CSTNode):
     #: Any trailing whitespace/comments found after the last statement.
     footer: Sequence[EmptyLine] = ()
 
-    #: The inferred file encoding.
+    #: The file's encoding format. When parsing a ``bytes`` object, this value may be
+    #: inferred from the contents of the parsed source code. When parsing a ``str``,
+    #: this value defaults to ``"utf-8"``.
+    #:
+    #: This value affects how :attr:`bytes` encodes the source code.
     encoding: str = "utf-8"
 
-    #: The inferred indentation of the file, expressed as a series of tabs or spaces.
+    #: The indentation of the file, expressed as a series of tabs and/or spaces. This
+    #: value is inferred from the contents of the parsed source code by default.
     default_indent: str = " " * 4
 
-    #: The inferred newline of the file, expressed as either ``\n`` or ``\r\n``.
+    #: The newline of the file, expressed as ``\n``, ``\r\n``, or ``\r``. This value is
+    #: inferred from the contents of the parsed source code by default.
     default_newline: str = "\n"
 
     #: Whether the module has a trailing newline or not.

--- a/libcst/_parser/_types/config.py
+++ b/libcst/_parser/_types/config.py
@@ -87,20 +87,26 @@ class PartialParserConfig:
         # We use object.__setattr__ because the dataclass is frozen. See:
         # https://docs.python.org/3/library/dataclasses.html#frozen-instances
         # This should be safe behavior inside of `__post_init__`.
-        object.__setattr__(
-            self,
-            "parsed_python_version",
-            parse_version_string(
-                # TODO: We currently hardcode support for Py3.7 both in our grammar productions and in
-                # our tokenizer config. If we want to support multiple versions, we will need to switch
-                # on version-pinned grammar productions and also fix Parso's tokenizer to allow for
-                # 3.6 and below handling of ASYNC/AWAIT. This should be changed back to None once we
-                # support multiple versions, so that parso can derive the version from `sys.version_info`
-                "3.7"
-                if isinstance(raw_python_version, AutoConfig)
-                else raw_python_version
-            ),
+        parsed_python_version = parse_version_string(
+            # TODO: We currently hardcode support for Py3.7 both in our grammar productions and in
+            # our tokenizer config. If we want to support multiple versions, we will need to switch
+            # on version-pinned grammar productions and also fix Parso's tokenizer to allow for
+            # 3.6 and below handling of ASYNC/AWAIT. This should be changed back to None once we
+            # support multiple versions, so that parso can derive the version from `sys.version_info`
+            "3.7"
+            if isinstance(raw_python_version, AutoConfig)
+            else raw_python_version
         )
+
+        # Once we add support for more versions of Python, we can change this to detect
+        # the supported version range.
+        if parsed_python_version != PythonVersionInfo(3, 7):
+            raise ValueError(
+                "LibCST can only parse code using Python 3.7's grammar. More versions "
+                + "may be supported by future releases."
+            )
+
+        object.__setattr__(self, "parsed_python_version", parsed_python_version)
 
         encoding = self.encoding
         if not isinstance(encoding, AutoConfig):

--- a/libcst/_parser/_types/config.py
+++ b/libcst/_parser/_types/config.py
@@ -63,21 +63,47 @@ class AutoConfig(Enum):
 @add_slots
 @dataclass(frozen=True)
 class PartialParserConfig:
-    """
+    r"""
     An optional object that can be supplied to the parser entrypoints (e.g.
-    `parse_module`) to configure the parser.
+    :func:`parse_module`) to configure the parser.
 
     Unspecified fields will be inferred from the input source code or from the execution
-    environment (the current Python version).
+    environment.
+
+    >>> import libcst as cst
+    >>> tree = cst.parse_module("abc")
+    >>> tree.bytes
+    b'abc'
+    >>> # override the default utf-8 encoding
+    ... tree = cst.parse_module("abc", cst.PartialParserConfig(encoding="utf-32"))
+    >>> tree.bytes
+    b'\xff\xfe\x00\x00a\x00\x00\x00b\x00\x00\x00c\x00\x00\x00'
     """
 
-    # `python_version` only configures the tokenization/lexer right now. The grammar
-    # isn't currently versioned.
+    #: The version of Python that the input source code is expected to be syntactically
+    #: compatible with. This may be different from the Python interpreter being used to
+    #: run LibCST. For example, you can parse code as 3.7 with a CPython 3.6
+    #: interpreter.
+    #:
+    #: Currently, only Python 3.7 syntax is supported.
     python_version: Union[str, AutoConfig] = AutoConfig.token
-    # parsed_python_version is derived from python_version in __post_init__
+
+    #: A named tuple with the ``major`` and ``minor`` Python version numbers. This is
+    #: derived from :attr:`python_version` and should not be supplied to the
+    #: :class:`PartialParserConfig` constructor.
     parsed_python_version: PythonVersionInfo = field(init=False)
+
+    #: The file's encoding format. When parsing a ``bytes`` object, this value may be
+    #: inferred from the contents of the parsed source code. When parsing a ``str``,
+    #: this value defaults to ``"utf-8"``.
     encoding: Union[str, AutoConfig] = AutoConfig.token
+
+    #: The indentation of the file, expressed as a series of tabs and/or spaces. This
+    #: value is inferred from the contents of the parsed source code by default.
     default_indent: Union[str, AutoConfig] = AutoConfig.token
+
+    #: The newline of the file, expressed as ``\n``, ``\r\n``, or ``\r``. This value is
+    #: inferred from the contents of the parsed source code by default.
     default_newline: Union[str, AutoConfig] = AutoConfig.token
 
     def __post_init__(self) -> None:

--- a/libcst/_parser/_types/tests/test_config.py
+++ b/libcst/_parser/_types/tests/test_config.py
@@ -14,9 +14,8 @@ class TestConfig(UnitTest):
     @data_provider(
         {
             "empty": (lambda: PartialParserConfig(),),
-            "python_version_a": (lambda: PartialParserConfig(python_version="3"),),
-            "python_version_b": (lambda: PartialParserConfig(python_version="3.2"),),
-            "python_version_c": (lambda: PartialParserConfig(python_version="3.2.1"),),
+            "python_version_a": (lambda: PartialParserConfig(python_version="3.7"),),
+            "python_version_b": (lambda: PartialParserConfig(python_version="3.7.1"),),
             "encoding": (lambda: PartialParserConfig(encoding="latin-1"),),
             "default_indent": (lambda: PartialParserConfig(default_indent="\t    "),),
             "default_newline": (lambda: PartialParserConfig(default_newline="\r\n"),),
@@ -29,14 +28,30 @@ class TestConfig(UnitTest):
 
     @data_provider(
         {
-            "python_version": (lambda: PartialParserConfig(python_version="3.2.1.0"),),
-            "encoding": (lambda: PartialParserConfig(encoding="utf-42"),),
-            "default_indent": (lambda: PartialParserConfig(default_indent="badinput"),),
-            "default_newline": (lambda: PartialParserConfig(default_newline="\n\r"),),
+            "python_version": (
+                lambda: PartialParserConfig(python_version="3.7.1.0"),
+                "The given version is not in the right format",
+            ),
+            "python_version_unsupported": (
+                lambda: PartialParserConfig(python_version="3.6"),
+                "LibCST can only parse code using Python 3.7's grammar.",
+            ),
+            "encoding": (
+                lambda: PartialParserConfig(encoding="utf-42"),
+                "not a supported encoding",
+            ),
+            "default_indent": (
+                lambda: PartialParserConfig(default_indent="badinput"),
+                "invalid value for default_indent",
+            ),
+            "default_newline": (
+                lambda: PartialParserConfig(default_newline="\n\r"),
+                "invalid value for default_newline",
+            ),
         }
     )
     def test_invalid_partial_parser_config(
-        self, factory: Callable[[], PartialParserConfig]
+        self, factory: Callable[[], PartialParserConfig], expected_re: str
     ) -> None:
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, expected_re):
             factory()


### PR DESCRIPTION
## Summary

This PR has two parts:
1. We now raise an exception if the user tries to parse the code as anything other than 3.7.
2. The documentation has more details and should now properly reflect reality.

## Test Plan

Unit tests. Built and inspected the documentation.

https://1540-200896124-gh.circle-artifacts.com/0/doc/parser.html#libcst.PartialParserConfig
https://1540-200896124-gh.circle-artifacts.com/0/doc/nodes.html#module