### PR TITLE
update dependent package version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,9 @@ setuptools.setup(
     python_requires=">=3.6",
     install_requires=[
         "dataclasses; python_version < '3.7'",
-        "parso",
-        "typing_extensions",
-        "typing_inspect",
+        "parso >= 0.3.0",
+        "typing_extensions >= 3.7.2",
+        "typing_inspect >= 0.3.1",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
## Summary
Update minimum dependent package version in setup.py.
Find the version candidates from pypi https://pypi.org/project/typing-inspect/#history
Then try and test to see if all tests passed.

## Test Plan
Run `python setup.py test`
```
----------------------------------------------------------------------
Ran 1014 tests in 4.071s

OK
```