### PR TITLE
[doc] improve metadata docs.

### DIFF
--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -1,7 +1,12 @@
 .. _libcst-metadata:
 
+========
 Metadata
 ========
+
+-------------
+Metadata APIs
+-------------
 
 LibCST ships with a metadata interface that defines a standardized way to
 associate nodes in a CST with arbitrary metadata while maintaining the immutability
@@ -57,6 +62,10 @@ your provider does not use the visitor pattern for computing metadata for a tree
 .. autoclass:: libcst.VisitorMetadataProvider
 
 .. _libcst-metadata-position:
+
+------------------
+Metadata Providers
+------------------
 
 Position Metadata
 -----------------

--- a/libcst/metadata/expression_context_provider.py
+++ b/libcst/metadata/expression_context_provider.py
@@ -13,6 +13,9 @@ from libcst.metadata.base_provider import BatchableMetadataProvider
 
 
 class ExpressionContext(Enum):
+    """Used in :class:`ExpressionContextProvider` to represent context of a variable
+    reference. """
+
     #: Load the value of a variable reference.
     #:
     #: >>> libcst.MetadataWrapper(libcst.parse_module("a")).resolve(libcst.ExpressionContextProvider)


### PR DESCRIPTION
## Summary
- add subtitles (metadata APIs and metadata Providers) to metadata doc to make it more readable.
- add docstring to `ExpressionContext`.

## Test Plan
![image](https://user-images.githubusercontent.com/3840867/63888036-eb346b00-c992-11e9-880d-1413274a2074.png)

