### PR TITLE
Hypothesis Fixes

### DIFF
--- a/libcst/_nodes/_statement.py
+++ b/libcst/_nodes/_statement.py
@@ -1107,11 +1107,17 @@ class ImportFrom(BaseSmallStatement):
                 )
 
     def _validate_whitespace(self) -> None:
-        if self.whitespace_after_from.empty:
+        if self.whitespace_after_from.empty and not self.relative:
             raise CSTValidationError("Must have at least one space after from.")
-        if self.whitespace_before_import.empty:
+        if self.whitespace_before_import.empty and not (
+            self.relative and self.module is None
+        ):
             raise CSTValidationError("Must have at least one space before import.")
-        if self.whitespace_after_import.empty and self.lpar is None:
+        if (
+            self.whitespace_after_import.empty
+            and self.lpar is None
+            and not isinstance(self.names, ImportStar)
+        ):
             raise CSTValidationError("Must have at least one space after import.")
 
     def _validate(self) -> None:

--- a/libcst/_parser/_detect_config.py
+++ b/libcst/_parser/_detect_config.py
@@ -74,6 +74,7 @@ def detect_config(
     *,
     partial: PartialParserConfig,
     detect_trailing_newline: bool,
+    detect_default_newline: bool,
 ) -> ConfigDetectionResult:
     """
     Computes a ParserConfig given the current source code to be parsed and a partial
@@ -93,7 +94,11 @@ def detect_config(
 
     partial_default_newline = partial.default_newline
     default_newline = (
-        _detect_default_newline(source_str)
+        (
+            _detect_default_newline(source_str)
+            if detect_default_newline
+            else _FALLBACK_DEFAULT_NEWLINE
+        )
         if isinstance(partial_default_newline, AutoConfig)
         else partial_default_newline
     )

--- a/libcst/_parser/_entrypoints.py
+++ b/libcst/_parser/_entrypoints.py
@@ -32,9 +32,13 @@ def _parse(
     config: PartialParserConfig,
     *,
     detect_trailing_newline: bool,
+    detect_default_newline: bool,
 ) -> CSTNode:
     detection_result = detect_config(
-        source, partial=config, detect_trailing_newline=detect_trailing_newline
+        source,
+        partial=config,
+        detect_trailing_newline=detect_trailing_newline,
+        detect_default_newline=detect_default_newline,
     )
     validate_grammar()
     grammar = get_grammar()
@@ -66,7 +70,13 @@ def parse_module(
     bytes you access the serialized code using :class:`~libcst.Module`'s bytes
     attribute.
     """
-    result = _parse("file_input", source, config, detect_trailing_newline=True)
+    result = _parse(
+        "file_input",
+        source,
+        config,
+        detect_trailing_newline=True,
+        detect_default_newline=True,
+    )
     assert isinstance(result, Module)
     return result
 
@@ -83,7 +93,13 @@ def parse_statement(
     (there's nowhere to store it on the statement node).
     """
     # use detect_trailing_newline to insert a newline
-    result = _parse("stmt_input", source, config, detect_trailing_newline=True)
+    result = _parse(
+        "stmt_input",
+        source,
+        config,
+        detect_trailing_newline=True,
+        detect_default_newline=False,
+    )
     assert isinstance(result, (SimpleStatementLine, BaseCompoundStatement))
     return result
 
@@ -95,6 +111,12 @@ def parse_expression(
     Accepts an expression on a single line. Leading and trailing whitespace is not
     valid (there's nowhere to store it on the expression node).
     """
-    result = _parse("expression_input", source, config, detect_trailing_newline=False)
+    result = _parse(
+        "expression_input",
+        source,
+        config,
+        detect_trailing_newline=False,
+        detect_default_newline=False,
+    )
     assert isinstance(result, BaseExpression)
     return result

--- a/libcst/_parser/_entrypoints.py
+++ b/libcst/_parser/_entrypoints.py
@@ -63,10 +63,10 @@ def parse_module(
     Accepts an entire python module, including all leading and trailing whitespace.
 
     If source is ``bytes``, the encoding will be inferred and preserved. If
-    the source is a ``string``, we will default to assuming UTF-8 if the module
-    is rendered back out as bytes. It is recommended that when calling
-    :func:`~libcst.parse_module` with a string you access the serialized code
-    using :class:`~libcst.Module`'s code attribute, and when calling it with
+    the source is a ``string``, we will default to assuming UTF-8 encoding if the
+    module is rendered back out to source as bytes. It is recommended that when
+    calling :func:`~libcst.parse_module` with a string you access the serialized
+    code using :class:`~libcst.Module`'s code attribute, and when calling it with
     bytes you access the serialized code using :class:`~libcst.Module`'s bytes
     attribute.
     """
@@ -86,11 +86,17 @@ def parse_statement(
 ) -> Union[SimpleStatementLine, BaseCompoundStatement]:
     """
     Accepts a statement followed by a trailing newline. If a trailing newline is not
-    provided, one will be added.
+    provided, one will be added. :func:`parse_statement` is provided mainly as a
+    convenience function to generate semi-complex trees from code snippetes. If you
+    need to represent a statement exactly, including all leading/trailing comments,
+    you should instead use :func:`parse_module`.
 
     Leading comments and trailing comments (on the same line) are accepted, but
     whitespace (or anything else) after the statement's trailing newline is not valid
-    (there's nowhere to store it on the statement node).
+    (there's nowhere to store it on the statement node). Note that since there is
+    nowhere to store leading and trailing comments/empty lines, code rendered out
+    from a parsed statement using ``cst.Module([]).code_for_node(statement)`` will
+    not include leading/trailing comments.
     """
     # use detect_trailing_newline to insert a newline
     result = _parse(
@@ -110,6 +116,10 @@ def parse_expression(
     """
     Accepts an expression on a single line. Leading and trailing whitespace is not
     valid (there's nowhere to store it on the expression node).
+    :func:`parse_expression` is provided mainly as a convenience function to generate
+    semi-complex trees from code snippets. If you need to represent an expression
+    exactly, including all leading/trailing comments, you should instead use
+    :func:`parse_module`.
     """
     result = _parse(
         "expression_input",

--- a/libcst/_parser/_whitespace_parser.py
+++ b/libcst/_parser/_whitespace_parser.py
@@ -153,9 +153,13 @@ def _parse_empty_line(
     speculative_state = State(
         state.line, state.column, state.absolute_indent, state.is_parenthesized
     )
-    indent = _parse_indent(
-        config, speculative_state, override_absolute_indent=override_absolute_indent
-    )
+    try:
+        indent = _parse_indent(
+            config, speculative_state, override_absolute_indent=override_absolute_indent
+        )
+    except Exception:
+        # We aren't on a new line, speculative parsing failed
+        return None
     whitespace = parse_simple_whitespace(config, speculative_state)
     comment = _parse_comment(config, speculative_state)
     newline = _parse_newline(config, speculative_state)

--- a/libcst/_parser/tests/test_detect_config.py
+++ b/libcst/_parser/tests/test_detect_config.py
@@ -18,6 +18,7 @@ class TestDetectConfig(UnitTest):
                 "source": b"",
                 "partial": PartialParserConfig(),
                 "detect_trailing_newline": True,
+                "detect_default_newline": True,
                 "expected_config": ParserConfig(
                     lines=["\n", ""],
                     encoding="utf-8",
@@ -30,8 +31,22 @@ class TestDetectConfig(UnitTest):
                 "source": b"",
                 "partial": PartialParserConfig(),
                 "detect_trailing_newline": False,
+                "detect_default_newline": True,
                 "expected_config": ParserConfig(
                     lines=[""],  # the trailing newline isn't inserted
+                    encoding="utf-8",
+                    default_indent="    ",
+                    default_newline="\n",
+                    has_trailing_newline=False,
+                ),
+            },
+            "detect_default_newline_disabled": {
+                "source": b"pass\r",
+                "partial": PartialParserConfig(),
+                "detect_trailing_newline": False,
+                "detect_default_newline": False,
+                "expected_config": ParserConfig(
+                    lines=["pass\r", ""],  # the trailing newline isn't inserted
                     encoding="utf-8",
                     default_indent="    ",
                     default_newline="\n",
@@ -42,6 +57,7 @@ class TestDetectConfig(UnitTest):
                 "source": b"first_line\r\n\nsomething\n",
                 "partial": PartialParserConfig(),
                 "detect_trailing_newline": True,
+                "detect_default_newline": True,
                 "expected_config": ParserConfig(
                     lines=["first_line\r\n", "\n", "something\n", ""],
                     encoding="utf-8",
@@ -54,6 +70,7 @@ class TestDetectConfig(UnitTest):
                 "source": b"first_line\r\nsecond_line\r\n",
                 "partial": PartialParserConfig(default_newline="\n"),
                 "detect_trailing_newline": True,
+                "detect_default_newline": True,
                 "expected_config": ParserConfig(
                     lines=["first_line\r\n", "second_line\r\n", ""],
                     encoding="utf-8",
@@ -66,6 +83,7 @@ class TestDetectConfig(UnitTest):
                 "source": b"if test:\n\t  something\n",
                 "partial": PartialParserConfig(),
                 "detect_trailing_newline": True,
+                "detect_default_newline": True,
                 "expected_config": ParserConfig(
                     lines=["if test:\n", "\t  something\n", ""],
                     encoding="utf-8",
@@ -78,6 +96,7 @@ class TestDetectConfig(UnitTest):
                 "source": b"if test:\n\t  something\n",
                 "partial": PartialParserConfig(default_indent="      "),
                 "detect_trailing_newline": True,
+                "detect_default_newline": True,
                 "expected_config": ParserConfig(
                     lines=["if test:\n", "\t  something\n", ""],
                     encoding="utf-8",
@@ -90,6 +109,7 @@ class TestDetectConfig(UnitTest):
                 "source": b"#!/usr/bin/python3\n# -*- coding: latin-1 -*-\npass\n",
                 "partial": PartialParserConfig(),
                 "detect_trailing_newline": True,
+                "detect_default_newline": True,
                 "expected_config": ParserConfig(
                     lines=[
                         "#!/usr/bin/python3\n",
@@ -107,6 +127,7 @@ class TestDetectConfig(UnitTest):
                 "source": b"#!/usr/bin/python3\n# -*- coding: latin-1 -*-\npass\n",
                 "partial": PartialParserConfig(encoding="us-ascii"),
                 "detect_trailing_newline": True,
+                "detect_default_newline": True,
                 "expected_config": ParserConfig(
                     lines=[
                         "#!/usr/bin/python3\n",
@@ -124,6 +145,7 @@ class TestDetectConfig(UnitTest):
                 "source": "#!/usr/bin/python3\n# -*- coding: latin-1 -*-\npass\n",
                 "partial": PartialParserConfig(),
                 "detect_trailing_newline": True,
+                "detect_default_newline": True,
                 "expected_config": ParserConfig(
                     lines=[
                         "#!/usr/bin/python3\n",
@@ -141,6 +163,7 @@ class TestDetectConfig(UnitTest):
                 "source": b"\xff\xfet\x00e\x00s\x00t\x00",
                 "partial": PartialParserConfig(encoding="utf-16"),
                 "detect_trailing_newline": True,
+                "detect_default_newline": True,
                 "expected_config": ParserConfig(
                     lines=["test\n", ""],
                     encoding="utf-16",
@@ -157,11 +180,15 @@ class TestDetectConfig(UnitTest):
         source: Union[str, bytes],
         partial: PartialParserConfig,
         detect_trailing_newline: bool,
+        detect_default_newline: bool,
         expected_config: ParserConfig,
     ) -> None:
         self.assertEqual(
             detect_config(
-                source, partial=partial, detect_trailing_newline=detect_trailing_newline
+                source,
+                partial=partial,
+                detect_trailing_newline=detect_trailing_newline,
+                detect_default_newline=detect_default_newline,
             ).config,
             expected_config,
         )


### PR DESCRIPTION
## Summary

This PR contains a series of diffs that address various bugs in LibCST found by Hypothesis. After this stack, at least locally, I can run the Hypothesis suite using `tox -e fuzz` with no errors. I'm pretty sure that fixing `parse_statement` to default to always using `\n` necessitates a way to grab a `PartialParserConfig` out of a parsed `Module`, but I didn't include that convenience attribute in this PR since it is somewhat separate.

## Test Plan

`tox` as well as `tox -e fuzz`.