### PR TITLE
Multiversion Support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ A Concrete Syntax Tree (CST) parser and serializer library for Python
 
 .. intro-start
 
-LibCST parses Python 3.7 source code as a CST tree that keeps all formatting
+LibCST parses Python 3.6 or 3.7 source code as a CST tree that keeps all formatting
 details (comments, whitespaces, parentheses, etc). It's useful for building 
 automated refactoring (codemod) applications and linters.
 

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ A Concrete Syntax Tree (CST) parser and serializer library for Python
 
 .. intro-start
 
-LibCST parses Python 3.6 or 3.7 source code as a CST tree that keeps all formatting
+LibCST parses Python 3.5, 3.6 or 3.7 source code as a CST tree that keeps all formatting
 details (comments, whitespaces, parentheses, etc). It's useful for building 
 automated refactoring (codemod) applications and linters.
 

--- a/libcst/_nodes/tests/test_for.py
+++ b/libcst/_nodes/tests/test_for.py
@@ -7,7 +7,7 @@
 from typing import Any
 
 import libcst as cst
-from libcst import CodeRange, parse_statement
+from libcst import CodeRange, PartialParserConfig, parse_statement
 from libcst._nodes.tests.base import CSTNodeTest, DummyIndentedBlock
 from libcst.testing.utils import data_provider
 
@@ -16,7 +16,6 @@ class ForTest(CSTNodeTest):
     @data_provider(
         (
             # Simple for block
-            # pyre-fixme[6]: Incompatible parameter type
             {
                 "node": cst.For(
                     cst.Name("target"),
@@ -35,7 +34,31 @@ class ForTest(CSTNodeTest):
                     asynchronous=cst.Asynchronous(),
                 ),
                 "code": "async for target in iter(): pass\n",
-                "parser": parse_statement,
+                "parser": lambda code: parse_statement(
+                    code, config=PartialParserConfig(python_version="3.7")
+                ),
+            },
+            # Python 3.6 async for block
+            {
+                "node": cst.FunctionDef(
+                    cst.Name("foo"),
+                    cst.Parameters(),
+                    cst.IndentedBlock(
+                        (
+                            cst.For(
+                                cst.Name("target"),
+                                cst.Call(cst.Name("iter")),
+                                cst.SimpleStatementSuite((cst.Pass(),)),
+                                asynchronous=cst.Asynchronous(),
+                            ),
+                        )
+                    ),
+                    asynchronous=cst.Asynchronous(),
+                ),
+                "code": "async def foo():\n    async for target in iter(): pass\n",
+                "parser": lambda code: parse_statement(
+                    code, config=PartialParserConfig(python_version="3.6")
+                ),
             },
             # For block with else
             {

--- a/libcst/_parser/_conversions/expression.py
+++ b/libcst/_parser/_conversions/expression.py
@@ -561,7 +561,8 @@ def convert_atom_expr(
     return child
 
 
-@with_production("atom_expr_await", "'await' atom_expr_trailer")
+@with_production("atom_expr_await", "'await' atom_expr_trailer", version=">=3.7")
+@with_production("atom_expr_await", "AWAIT atom_expr_trailer", version="<=3.6")
 def convert_atom_expr_await(
     config: ParserConfig, children: typing.Sequence[typing.Any]
 ) -> typing.Any:
@@ -1401,7 +1402,8 @@ def convert_sync_comp_for(
     )
 
 
-@with_production("comp_for", "['async'] sync_comp_for")
+@with_production("comp_for", "['async'] sync_comp_for", version=">=3.7")
+@with_production("comp_for", "[ASYNC] sync_comp_for", version="<=3.6")
 def convert_comp_for(
     config: ParserConfig, children: typing.Sequence[typing.Any]
 ) -> typing.Any:

--- a/libcst/_parser/_conversions/expression.py
+++ b/libcst/_parser/_conversions/expression.py
@@ -1403,7 +1403,8 @@ def convert_sync_comp_for(
 
 
 @with_production("comp_for", "['async'] sync_comp_for", version=">=3.7")
-@with_production("comp_for", "[ASYNC] sync_comp_for", version="<=3.6")
+@with_production("comp_for", "[ASYNC] sync_comp_for", version="==3.6")
+@with_production("comp_for", "sync_comp_for", version="<=3.5")
 def convert_comp_for(
     config: ParserConfig, children: typing.Sequence[typing.Any]
 ) -> typing.Any:

--- a/libcst/_parser/_conversions/params.py
+++ b/libcst/_parser/_conversions/params.py
@@ -23,6 +23,16 @@ from libcst._parser._whitespace_parser import parse_parenthesizable_whitespace
         + "[',' [tfpdef_star (',' tfpdef_assign)* [',' [tfpdef_starstar [',']]] | tfpdef_starstar [',']]]"
         + "| tfpdef_star (',' tfpdef_assign)* [',' [tfpdef_starstar [',']]] | tfpdef_starstar [','])"
     ),
+    version=">=3.6",
+)
+@with_production(  # noqa: C901: too complex
+    "typedargslist",
+    (
+        "(tfpdef_assign (',' tfpdef_assign)* "
+        + "[',' [tfpdef_star (',' tfpdef_assign)* [',' tfpdef_starstar] | tfpdef_starstar]]"
+        + "| tfpdef_star (',' tfpdef_assign)* [',' tfpdef_starstar] | tfpdef_starstar)"
+    ),
+    version="<=3.5",
 )
 @with_production(
     "varargslist",
@@ -31,6 +41,16 @@ from libcst._parser._whitespace_parser import parse_parenthesizable_whitespace
         + "[',' [vfpdef_star (',' vfpdef_assign)* [',' [vfpdef_starstar [',']]] | vfpdef_starstar [',']]]"
         + "| vfpdef_star (',' vfpdef_assign)* [',' [vfpdef_starstar [',']]] | vfpdef_starstar [','])"
     ),
+    version=">=3.6",
+)
+@with_production(
+    "varargslist",
+    (
+        "(vfpdef_assign (',' vfpdef_assign)* "
+        + "[',' [vfpdef_star (',' vfpdef_assign)* [',' vfpdef_starstar] | vfpdef_starstar]]"
+        + "| vfpdef_star (',' vfpdef_assign)* [',' vfpdef_starstar] | vfpdef_starstar)"
+    ),
+    version="<=3.5",
 )
 def convert_argslist(config: ParserConfig, children: Sequence[Any]) -> Any:
     params: List[Param] = []

--- a/libcst/_parser/_conversions/statement.py
+++ b/libcst/_parser/_conversions/statement.py
@@ -207,7 +207,14 @@ def convert_small_stmt(config: ParserConfig, children: Sequence[Any]) -> Any:
     return small_stmt_body
 
 
-@with_production("expr_stmt", "testlist_star_expr (annassign | augassign | assign* )")
+@with_production(
+    "expr_stmt",
+    "testlist_star_expr (annassign | augassign | assign* )",
+    version=">=3.6",
+)
+@with_production(
+    "expr_stmt", "testlist_star_expr (augassign | assign* )", version="<=3.5"
+)
 @with_production("yield_stmt", "yield_expr")
 def convert_expr_stmt(config: ParserConfig, children: Sequence[Any]) -> Any:
     if len(children) == 1:
@@ -255,7 +262,7 @@ def convert_expr_stmt(config: ParserConfig, children: Sequence[Any]) -> Any:
     )
 
 
-@with_production("annassign", "':' test ['=' test]")
+@with_production("annassign", "':' test ['=' test]", version=">=3.6")
 def convert_annassign(config: ParserConfig, children: Sequence[Any]) -> Any:
     if len(children) == 2:
         # Variable annotation only

--- a/libcst/_parser/_conversions/statement.py
+++ b/libcst/_parser/_conversions/statement.py
@@ -1019,7 +1019,8 @@ def _extract_async(
     return (parse_empty_lines(config, whitespace_before), asyncnode, stmt.value)
 
 
-@with_production("asyncable_funcdef", "['async'] funcdef")
+@with_production("asyncable_funcdef", "['async'] funcdef", version=">=3.7")
+@with_production("asyncable_funcdef", "[ASYNC] funcdef", version="<=3.6")
 def convert_asyncable_funcdef(config: ParserConfig, children: Sequence[Any]) -> Any:
     leading_lines, asyncnode, funcdef = _extract_async(config, children)
 
@@ -1274,7 +1275,12 @@ def convert_decorated(config: ParserConfig, children: Sequence[Any]) -> Any:
     )
 
 
-@with_production("asyncable_stmt", "['async'] (funcdef | with_stmt | for_stmt)")
+@with_production(
+    "asyncable_stmt", "['async'] (funcdef | with_stmt | for_stmt)", version=">=3.7"
+)
+@with_production(
+    "asyncable_stmt", "[ASYNC] (funcdef | with_stmt | for_stmt)", version="<=3.6"
+)
 def convert_asyncable_stmt(config: ParserConfig, children: Sequence[Any]) -> Any:
     leading_lines, asyncnode, stmtnode = _extract_async(config, children)
     if isinstance(stmtnode, FunctionDef):

--- a/libcst/_parser/_conversions/terminals.py
+++ b/libcst/_parser/_conversions/terminals.py
@@ -72,3 +72,11 @@ def convert_FSTRING_END(config: ParserConfig, token: Token) -> Any:
 
 def convert_FSTRING_STRING(config: ParserConfig, token: Token) -> Any:
     return token
+
+
+def convert_ASYNC(config: ParserConfig, token: Token) -> Any:
+    return token
+
+
+def convert_AWAIT(config: ParserConfig, token: Token) -> Any:
+    return token

--- a/libcst/_parser/_detect_config.py
+++ b/libcst/_parser/_detect_config.py
@@ -139,6 +139,7 @@ def detect_config(
             default_indent=default_indent,
             default_newline=default_newline,
             has_trailing_newline=has_trailing_newline,
+            version=python_version,
         ),
         tokens=tokens,
     )

--- a/libcst/_parser/_entrypoints.py
+++ b/libcst/_parser/_entrypoints.py
@@ -40,7 +40,7 @@ def _parse(
         detect_default_newline=detect_default_newline,
     )
     validate_grammar()
-    grammar = get_grammar()
+    grammar = get_grammar(config.parsed_python_version)
 
     parser = PythonCSTParser(
         tokens=detection_result.tokens,

--- a/libcst/_parser/_parso/_python/_token.py
+++ b/libcst/_parser/_parso/_python/_token.py
@@ -39,6 +39,8 @@ class PythonTokenTypes:
     INDENT: TokenType = TokenType("INDENT")
     DEDENT: TokenType = TokenType("DEDENT")
     ERROR_DEDENT: TokenType = TokenType("ERROR_DEDENT")
+    ASYNC: TokenType = TokenType("ASYNC")
+    AWAIT: TokenType = TokenType("AWAIT")
     FSTRING_STRING: TokenType = TokenType("FSTRING_STRING")
     FSTRING_START: TokenType = TokenType("FSTRING_START")
     FSTRING_END: TokenType = TokenType("FSTRING_END")

--- a/libcst/_parser/_production_decorator.py
+++ b/libcst/_parser/_production_decorator.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
-from typing import Callable, Iterable, TypeVar
+from typing import Callable, Iterable, Optional, TypeVar
 
 from libcst._parser._types.conversions import NonterminalConversion
 from libcst._parser._types.production import Production
@@ -18,7 +18,7 @@ _NonterminalConversionT = TypeVar(
 # We could version our grammar at a later point by adding a version metadata kwarg to
 # this decorator.
 def with_production(
-    production_name: str, children: str
+    production_name: str, children: str, *, version: Optional[str] = None
 ) -> Callable[[_NonterminalConversionT], _NonterminalConversionT]:
     """
     Attaches a bit of grammar to a conversion function. The parser extracts all of these
@@ -38,7 +38,7 @@ def with_production(
                 + f"'{fn_name}'."
             )
         # pyre-fixme[16]: Pyre doesn't know about this magic field we added
-        fn.productions.append(Production(production_name, children))
+        fn.productions.append(Production(production_name, children, version))
         return fn
 
     return inner

--- a/libcst/_parser/_python_parser.py
+++ b/libcst/_parser/_python_parser.py
@@ -38,7 +38,7 @@ class PythonCSTParser(BaseParser[Token, TokenType, Any]):
         )
         self.config = config
         self.terminal_conversions = get_terminal_conversions()
-        self.nonterminal_conversions = get_nonterminal_conversions()
+        self.nonterminal_conversions = get_nonterminal_conversions(config.version)
 
     def convert_nonterminal(self, nonterminal: str, children: Sequence[Any]) -> Any:
         return self.nonterminal_conversions[nonterminal](self.config, children)

--- a/libcst/_parser/_types/config.py
+++ b/libcst/_parser/_types/config.py
@@ -85,7 +85,7 @@ class PartialParserConfig:
     #: run LibCST. For example, you can parse code as 3.7 with a CPython 3.6
     #: interpreter.
     #:
-    #: Currently, only Python 3.6 and 3.7 syntax is supported.
+    #: Currently, only Python 3.5, 3.6 and 3.7 syntax is supported.
     python_version: Union[str, AutoConfig] = AutoConfig.token
 
     #: A named tuple with the ``major`` and ``minor`` Python version numbers. This is
@@ -120,13 +120,14 @@ class PartialParserConfig:
         # Once we add support for more versions of Python, we can change this to detect
         # the supported version range.
         if parsed_python_version not in (
+            PythonVersionInfo(3, 5),
             PythonVersionInfo(3, 6),
             PythonVersionInfo(3, 7),
         ):
             raise ValueError(
                 "LibCST can only parse code using one of the following versions of "
-                + "Python's grammar: 3.6, 3.7. More versions may be supported by future "
-                + "releases."
+                + "Python's grammar: 3.5, 3.6, 3.7. More versions may be supported "
+                + "by future releases."
             )
 
         object.__setattr__(self, "parsed_python_version", parsed_python_version)

--- a/libcst/_parser/_types/production.py
+++ b/libcst/_parser/_types/production.py
@@ -6,12 +6,14 @@
 # pyre-strict
 
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass(frozen=True)
 class Production:
     name: str
     children: str
+    version: Optional[str]
 
     def __str__(self) -> str:
         return f"{self.name}: {self.children}"

--- a/libcst/_parser/_types/tests/test_config.py
+++ b/libcst/_parser/_types/tests/test_config.py
@@ -33,8 +33,8 @@ class TestConfig(UnitTest):
                 "The given version is not in the right format",
             ),
             "python_version_unsupported": (
-                lambda: PartialParserConfig(python_version="3.6"),
-                "LibCST can only parse code using Python 3.7's grammar.",
+                lambda: PartialParserConfig(python_version="3.8"),
+                "LibCST can only parse code using one of the following versions of Python's grammar",
             ),
             "encoding": (
                 lambda: PartialParserConfig(encoding="utf-42"),

--- a/libcst/_parser/tests/test_detect_config.py
+++ b/libcst/_parser/tests/test_detect_config.py
@@ -7,6 +7,7 @@
 from typing import Union
 
 from libcst._parser._detect_config import detect_config
+from libcst._parser._parso._utils import PythonVersionInfo
 from libcst._parser._types.config import ParserConfig, PartialParserConfig
 from libcst.testing.utils import UnitTest, data_provider
 
@@ -16,7 +17,7 @@ class TestDetectConfig(UnitTest):
         {
             "empty_input": {
                 "source": b"",
-                "partial": PartialParserConfig(),
+                "partial": PartialParserConfig(python_version="3.7"),
                 "detect_trailing_newline": True,
                 "detect_default_newline": True,
                 "expected_config": ParserConfig(
@@ -25,11 +26,12 @@ class TestDetectConfig(UnitTest):
                     default_indent="    ",
                     default_newline="\n",
                     has_trailing_newline=False,
+                    version=PythonVersionInfo(3, 7),
                 ),
             },
             "detect_trailing_newline_disabled": {
                 "source": b"",
-                "partial": PartialParserConfig(),
+                "partial": PartialParserConfig(python_version="3.7"),
                 "detect_trailing_newline": False,
                 "detect_default_newline": True,
                 "expected_config": ParserConfig(
@@ -38,11 +40,12 @@ class TestDetectConfig(UnitTest):
                     default_indent="    ",
                     default_newline="\n",
                     has_trailing_newline=False,
+                    version=PythonVersionInfo(3, 7),
                 ),
             },
             "detect_default_newline_disabled": {
                 "source": b"pass\r",
-                "partial": PartialParserConfig(),
+                "partial": PartialParserConfig(python_version="3.7"),
                 "detect_trailing_newline": False,
                 "detect_default_newline": False,
                 "expected_config": ParserConfig(
@@ -51,11 +54,12 @@ class TestDetectConfig(UnitTest):
                     default_indent="    ",
                     default_newline="\n",
                     has_trailing_newline=False,
+                    version=PythonVersionInfo(3, 7),
                 ),
             },
             "newline_inferred": {
                 "source": b"first_line\r\n\nsomething\n",
-                "partial": PartialParserConfig(),
+                "partial": PartialParserConfig(python_version="3.7"),
                 "detect_trailing_newline": True,
                 "detect_default_newline": True,
                 "expected_config": ParserConfig(
@@ -64,11 +68,14 @@ class TestDetectConfig(UnitTest):
                     default_indent="    ",
                     default_newline="\r\n",
                     has_trailing_newline=True,
+                    version=PythonVersionInfo(3, 7),
                 ),
             },
             "newline_partial_given": {
                 "source": b"first_line\r\nsecond_line\r\n",
-                "partial": PartialParserConfig(default_newline="\n"),
+                "partial": PartialParserConfig(
+                    default_newline="\n", python_version="3.7"
+                ),
                 "detect_trailing_newline": True,
                 "detect_default_newline": True,
                 "expected_config": ParserConfig(
@@ -77,11 +84,12 @@ class TestDetectConfig(UnitTest):
                     default_indent="    ",
                     default_newline="\n",  # The given partial disables inference
                     has_trailing_newline=True,
+                    version=PythonVersionInfo(3, 7),
                 ),
             },
             "indent_inferred": {
                 "source": b"if test:\n\t  something\n",
-                "partial": PartialParserConfig(),
+                "partial": PartialParserConfig(python_version="3.7"),
                 "detect_trailing_newline": True,
                 "detect_default_newline": True,
                 "expected_config": ParserConfig(
@@ -90,11 +98,14 @@ class TestDetectConfig(UnitTest):
                     default_indent="\t  ",
                     default_newline="\n",
                     has_trailing_newline=True,
+                    version=PythonVersionInfo(3, 7),
                 ),
             },
             "indent_partial_given": {
                 "source": b"if test:\n\t  something\n",
-                "partial": PartialParserConfig(default_indent="      "),
+                "partial": PartialParserConfig(
+                    default_indent="      ", python_version="3.7"
+                ),
                 "detect_trailing_newline": True,
                 "detect_default_newline": True,
                 "expected_config": ParserConfig(
@@ -103,11 +114,12 @@ class TestDetectConfig(UnitTest):
                     default_indent="      ",
                     default_newline="\n",
                     has_trailing_newline=True,
+                    version=PythonVersionInfo(3, 7),
                 ),
             },
             "encoding_inferred": {
                 "source": b"#!/usr/bin/python3\n# -*- coding: latin-1 -*-\npass\n",
-                "partial": PartialParserConfig(),
+                "partial": PartialParserConfig(python_version="3.7"),
                 "detect_trailing_newline": True,
                 "detect_default_newline": True,
                 "expected_config": ParserConfig(
@@ -121,11 +133,14 @@ class TestDetectConfig(UnitTest):
                     default_indent="    ",
                     default_newline="\n",
                     has_trailing_newline=True,
+                    version=PythonVersionInfo(3, 7),
                 ),
             },
             "encoding_partial_given": {
                 "source": b"#!/usr/bin/python3\n# -*- coding: latin-1 -*-\npass\n",
-                "partial": PartialParserConfig(encoding="us-ascii"),
+                "partial": PartialParserConfig(
+                    encoding="us-ascii", python_version="3.7"
+                ),
                 "detect_trailing_newline": True,
                 "detect_default_newline": True,
                 "expected_config": ParserConfig(
@@ -139,11 +154,12 @@ class TestDetectConfig(UnitTest):
                     default_indent="    ",
                     default_newline="\n",
                     has_trailing_newline=True,
+                    version=PythonVersionInfo(3, 7),
                 ),
             },
             "encoding_str_not_bytes_disables_inference": {
                 "source": "#!/usr/bin/python3\n# -*- coding: latin-1 -*-\npass\n",
-                "partial": PartialParserConfig(),
+                "partial": PartialParserConfig(python_version="3.7"),
                 "detect_trailing_newline": True,
                 "detect_default_newline": True,
                 "expected_config": ParserConfig(
@@ -157,11 +173,12 @@ class TestDetectConfig(UnitTest):
                     default_indent="    ",
                     default_newline="\n",
                     has_trailing_newline=True,
+                    version=PythonVersionInfo(3, 7),
                 ),
             },
             "encoding_non_ascii_compatible_utf_16_with_bom": {
                 "source": b"\xff\xfet\x00e\x00s\x00t\x00",
-                "partial": PartialParserConfig(encoding="utf-16"),
+                "partial": PartialParserConfig(encoding="utf-16", python_version="3.7"),
                 "detect_trailing_newline": True,
                 "detect_default_newline": True,
                 "expected_config": ParserConfig(
@@ -170,6 +187,7 @@ class TestDetectConfig(UnitTest):
                     default_indent="    ",
                     default_newline="\n",
                     has_trailing_newline=False,
+                    version=PythonVersionInfo(3, 7),
                 ),
             },
         }

--- a/libcst/_parser/tests/test_version_compare.py
+++ b/libcst/_parser/tests/test_version_compare.py
@@ -1,0 +1,45 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from libcst._parser._grammar import _should_include
+from libcst._parser._parso._utils import PythonVersionInfo
+from libcst.testing.utils import UnitTest, data_provider
+
+
+class VersionCompareTest(UnitTest):
+    @data_provider(
+        (
+            # Simple equality
+            ("==3.6", PythonVersionInfo(3, 6), True),
+            ("!=3.6", PythonVersionInfo(3, 6), False),
+            # Equal or GT/LT
+            (">=3.6", PythonVersionInfo(3, 5), False),
+            (">=3.6", PythonVersionInfo(3, 6), True),
+            (">=3.6", PythonVersionInfo(3, 7), True),
+            ("<=3.6", PythonVersionInfo(3, 5), True),
+            ("<=3.6", PythonVersionInfo(3, 6), True),
+            ("<=3.6", PythonVersionInfo(3, 7), False),
+            # GT/LT
+            (">3.6", PythonVersionInfo(3, 5), False),
+            (">3.6", PythonVersionInfo(3, 6), False),
+            (">3.6", PythonVersionInfo(3, 7), True),
+            ("<3.6", PythonVersionInfo(3, 5), True),
+            ("<3.6", PythonVersionInfo(3, 6), False),
+            ("<3.6", PythonVersionInfo(3, 7), False),
+            # Multiple checks
+            (">3.6,<3.8", PythonVersionInfo(3, 6), False),
+            (">3.6,<3.8", PythonVersionInfo(3, 7), True),
+            (">3.6,<3.8", PythonVersionInfo(3, 8), False),
+        )
+    )
+    def test_tokenize(
+        self,
+        requested_version: str,
+        actual_version: PythonVersionInfo,
+        expected_result: bool,
+    ) -> None:
+        self.assertEqual(
+            _should_include(requested_version, actual_version), expected_result
+        )

--- a/libcst/_parser/tests/test_wrapped_tokenize.py
+++ b/libcst/_parser/tests/test_wrapped_tokenize.py
@@ -16,6 +16,7 @@ from libcst.testing.utils import UnitTest, data_provider
 _PY38 = parse_version_string("3.8.0")
 _PY37 = parse_version_string("3.7.0")
 _PY36 = parse_version_string("3.6.0")
+_PY35 = parse_version_string("3.5.0")
 
 
 class WrappedTokenizeTest(UnitTest):
@@ -23,6 +24,499 @@ class WrappedTokenizeTest(UnitTest):
 
     @data_provider(
         {
+            "simple_py35": (
+                "pass;\n",
+                _PY35,
+                (
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="pass",
+                        start_pos=(1, 0),
+                        end_pos=(1, 4),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=4, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.OP,
+                        string=";",
+                        start_pos=(1, 4),
+                        end_pos=(1, 5),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=4, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=5, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NEWLINE,
+                        string="\n",
+                        start_pos=(1, 5),
+                        end_pos=(2, 0),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=5, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.ENDMARKER,
+                        string="",
+                        start_pos=(2, 0),
+                        end_pos=(2, 0),
+                        whitespace_before=WhitespaceState(
+                            line=2, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                ),
+            ),
+            "with_indent_py35": (
+                "if foo:\n    bar\n",
+                _PY35,
+                (
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="if",
+                        start_pos=(1, 0),
+                        end_pos=(1, 2),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=2, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="foo",
+                        start_pos=(1, 3),
+                        end_pos=(1, 6),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=2, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=6, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.OP,
+                        string=":",
+                        start_pos=(1, 6),
+                        end_pos=(1, 7),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=6, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=7, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NEWLINE,
+                        string="\n",
+                        start_pos=(1, 7),
+                        end_pos=(2, 0),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=7, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.INDENT,
+                        string="",
+                        start_pos=(2, 4),
+                        end_pos=(2, 4),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent="    ",
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="bar",
+                        start_pos=(2, 4),
+                        end_pos=(2, 7),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=7,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NEWLINE,
+                        string="\n",
+                        start_pos=(2, 7),
+                        end_pos=(3, 0),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=7,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.DEDENT,
+                        string="",
+                        start_pos=(3, 0),
+                        end_pos=(3, 0),
+                        whitespace_before=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.ENDMARKER,
+                        string="",
+                        start_pos=(3, 0),
+                        end_pos=(3, 0),
+                        whitespace_before=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                ),
+            ),
+            "async_py35": (
+                "async def foo():\n    return await bar\n",
+                _PY35,
+                (
+                    Token(
+                        type=PythonTokenTypes.ASYNC,
+                        string="async",
+                        start_pos=(1, 0),
+                        end_pos=(1, 5),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=5, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="def",
+                        start_pos=(1, 6),
+                        end_pos=(1, 9),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=5, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=9, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="foo",
+                        start_pos=(1, 10),
+                        end_pos=(1, 13),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=9, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1,
+                            column=13,
+                            absolute_indent="",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.OP,
+                        string="(",
+                        start_pos=(1, 13),
+                        end_pos=(1, 14),
+                        whitespace_before=WhitespaceState(
+                            line=1,
+                            column=13,
+                            absolute_indent="",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=14, absolute_indent="", is_parenthesized=True
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.OP,
+                        string=")",
+                        start_pos=(1, 14),
+                        end_pos=(1, 15),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=14, absolute_indent="", is_parenthesized=True
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1,
+                            column=15,
+                            absolute_indent="",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.OP,
+                        string=":",
+                        start_pos=(1, 15),
+                        end_pos=(1, 16),
+                        whitespace_before=WhitespaceState(
+                            line=1,
+                            column=15,
+                            absolute_indent="",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1,
+                            column=16,
+                            absolute_indent="",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NEWLINE,
+                        string="\n",
+                        start_pos=(1, 16),
+                        end_pos=(2, 0),
+                        whitespace_before=WhitespaceState(
+                            line=1,
+                            column=16,
+                            absolute_indent="",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.INDENT,
+                        string="",
+                        start_pos=(2, 4),
+                        end_pos=(2, 4),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent="    ",
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="return",
+                        start_pos=(2, 4),
+                        end_pos=(2, 10),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=10,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.AWAIT,
+                        string="await",
+                        start_pos=(2, 11),
+                        end_pos=(2, 16),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=10,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=16,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="bar",
+                        start_pos=(2, 17),
+                        end_pos=(2, 20),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=16,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=20,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NEWLINE,
+                        string="\n",
+                        start_pos=(2, 20),
+                        end_pos=(3, 0),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=20,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.DEDENT,
+                        string="",
+                        start_pos=(3, 0),
+                        end_pos=(3, 0),
+                        whitespace_before=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.ENDMARKER,
+                        string="",
+                        start_pos=(3, 0),
+                        end_pos=(3, 0),
+                        whitespace_before=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                ),
+            ),
+            "async_no_token_35": (
+                "async;\n",
+                _PY35,
+                (
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="async",
+                        start_pos=(1, 0),
+                        end_pos=(1, 5),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=5, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.OP,
+                        string=";",
+                        start_pos=(1, 5),
+                        end_pos=(1, 6),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=5, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=6, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NEWLINE,
+                        string="\n",
+                        start_pos=(1, 6),
+                        end_pos=(2, 0),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=6, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.ENDMARKER,
+                        string="",
+                        start_pos=(2, 0),
+                        end_pos=(2, 0),
+                        whitespace_before=WhitespaceState(
+                            line=2, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                ),
+            ),
             "simple_py36": (
                 "pass;\n",
                 _PY36,

--- a/libcst/_parser/tests/test_wrapped_tokenize.py
+++ b/libcst/_parser/tests/test_wrapped_tokenize.py
@@ -7,13 +7,15 @@ from typing import Sequence
 
 from libcst._exceptions import ParserSyntaxError
 from libcst._parser._parso._python._token import PythonTokenTypes
-from libcst._parser._parso._utils import parse_version_string
+from libcst._parser._parso._utils import PythonVersionInfo, parse_version_string
 from libcst._parser._types.whitespace_state import WhitespaceState
 from libcst._parser._wrapped_tokenize import Token, tokenize
 from libcst.testing.utils import UnitTest, data_provider
 
 
 _PY38 = parse_version_string("3.8.0")
+_PY37 = parse_version_string("3.7.0")
+_PY36 = parse_version_string("3.6.0")
 
 
 class WrappedTokenizeTest(UnitTest):
@@ -21,8 +23,9 @@ class WrappedTokenizeTest(UnitTest):
 
     @data_provider(
         {
-            "simple": (
+            "simple_py36": (
                 "pass;\n",
+                _PY36,
                 (
                     Token(
                         type=PythonTokenTypes.NAME,
@@ -78,8 +81,9 @@ class WrappedTokenizeTest(UnitTest):
                     ),
                 ),
             ),
-            "with_indent": (
+            "with_indent_py36": (
                 "if foo:\n    bar\n",
+                _PY36,
                 (
                     Token(
                         type=PythonTokenTypes.NAME,
@@ -218,10 +222,1176 @@ class WrappedTokenizeTest(UnitTest):
                     ),
                 ),
             ),
+            "async_py36": (
+                "async def foo():\n    return await bar\n",
+                _PY36,
+                (
+                    Token(
+                        type=PythonTokenTypes.ASYNC,
+                        string="async",
+                        start_pos=(1, 0),
+                        end_pos=(1, 5),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=5, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="def",
+                        start_pos=(1, 6),
+                        end_pos=(1, 9),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=5, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=9, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="foo",
+                        start_pos=(1, 10),
+                        end_pos=(1, 13),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=9, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1,
+                            column=13,
+                            absolute_indent="",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.OP,
+                        string="(",
+                        start_pos=(1, 13),
+                        end_pos=(1, 14),
+                        whitespace_before=WhitespaceState(
+                            line=1,
+                            column=13,
+                            absolute_indent="",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=14, absolute_indent="", is_parenthesized=True
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.OP,
+                        string=")",
+                        start_pos=(1, 14),
+                        end_pos=(1, 15),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=14, absolute_indent="", is_parenthesized=True
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1,
+                            column=15,
+                            absolute_indent="",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.OP,
+                        string=":",
+                        start_pos=(1, 15),
+                        end_pos=(1, 16),
+                        whitespace_before=WhitespaceState(
+                            line=1,
+                            column=15,
+                            absolute_indent="",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1,
+                            column=16,
+                            absolute_indent="",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NEWLINE,
+                        string="\n",
+                        start_pos=(1, 16),
+                        end_pos=(2, 0),
+                        whitespace_before=WhitespaceState(
+                            line=1,
+                            column=16,
+                            absolute_indent="",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.INDENT,
+                        string="",
+                        start_pos=(2, 4),
+                        end_pos=(2, 4),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent="    ",
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="return",
+                        start_pos=(2, 4),
+                        end_pos=(2, 10),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=10,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.AWAIT,
+                        string="await",
+                        start_pos=(2, 11),
+                        end_pos=(2, 16),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=10,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=16,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="bar",
+                        start_pos=(2, 17),
+                        end_pos=(2, 20),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=16,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=20,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NEWLINE,
+                        string="\n",
+                        start_pos=(2, 20),
+                        end_pos=(3, 0),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=20,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.DEDENT,
+                        string="",
+                        start_pos=(3, 0),
+                        end_pos=(3, 0),
+                        whitespace_before=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.ENDMARKER,
+                        string="",
+                        start_pos=(3, 0),
+                        end_pos=(3, 0),
+                        whitespace_before=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                ),
+            ),
+            "async_no_token_36": (
+                "async;\n",
+                _PY36,
+                (
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="async",
+                        start_pos=(1, 0),
+                        end_pos=(1, 5),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=5, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.OP,
+                        string=";",
+                        start_pos=(1, 5),
+                        end_pos=(1, 6),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=5, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=6, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NEWLINE,
+                        string="\n",
+                        start_pos=(1, 6),
+                        end_pos=(2, 0),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=6, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.ENDMARKER,
+                        string="",
+                        start_pos=(2, 0),
+                        end_pos=(2, 0),
+                        whitespace_before=WhitespaceState(
+                            line=2, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                ),
+            ),
+            "simple_py37": (
+                "pass;\n",
+                _PY37,
+                (
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="pass",
+                        start_pos=(1, 0),
+                        end_pos=(1, 4),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=4, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.OP,
+                        string=";",
+                        start_pos=(1, 4),
+                        end_pos=(1, 5),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=4, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=5, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NEWLINE,
+                        string="\n",
+                        start_pos=(1, 5),
+                        end_pos=(2, 0),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=5, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.ENDMARKER,
+                        string="",
+                        start_pos=(2, 0),
+                        end_pos=(2, 0),
+                        whitespace_before=WhitespaceState(
+                            line=2, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                ),
+            ),
+            "with_indent_py37": (
+                "if foo:\n    bar\n",
+                _PY37,
+                (
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="if",
+                        start_pos=(1, 0),
+                        end_pos=(1, 2),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=2, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="foo",
+                        start_pos=(1, 3),
+                        end_pos=(1, 6),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=2, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=6, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.OP,
+                        string=":",
+                        start_pos=(1, 6),
+                        end_pos=(1, 7),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=6, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=7, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NEWLINE,
+                        string="\n",
+                        start_pos=(1, 7),
+                        end_pos=(2, 0),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=7, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.INDENT,
+                        string="",
+                        start_pos=(2, 4),
+                        end_pos=(2, 4),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent="    ",
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="bar",
+                        start_pos=(2, 4),
+                        end_pos=(2, 7),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=7,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NEWLINE,
+                        string="\n",
+                        start_pos=(2, 7),
+                        end_pos=(3, 0),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=7,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.DEDENT,
+                        string="",
+                        start_pos=(3, 0),
+                        end_pos=(3, 0),
+                        whitespace_before=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.ENDMARKER,
+                        string="",
+                        start_pos=(3, 0),
+                        end_pos=(3, 0),
+                        whitespace_before=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                ),
+            ),
+            "async_py37": (
+                "async def foo():\n    return await bar\n",
+                _PY37,
+                (
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="async",
+                        start_pos=(1, 0),
+                        end_pos=(1, 5),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=5, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="def",
+                        start_pos=(1, 6),
+                        end_pos=(1, 9),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=5, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=9, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="foo",
+                        start_pos=(1, 10),
+                        end_pos=(1, 13),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=9, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1,
+                            column=13,
+                            absolute_indent="",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.OP,
+                        string="(",
+                        start_pos=(1, 13),
+                        end_pos=(1, 14),
+                        whitespace_before=WhitespaceState(
+                            line=1,
+                            column=13,
+                            absolute_indent="",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=14, absolute_indent="", is_parenthesized=True
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.OP,
+                        string=")",
+                        start_pos=(1, 14),
+                        end_pos=(1, 15),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=14, absolute_indent="", is_parenthesized=True
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1,
+                            column=15,
+                            absolute_indent="",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.OP,
+                        string=":",
+                        start_pos=(1, 15),
+                        end_pos=(1, 16),
+                        whitespace_before=WhitespaceState(
+                            line=1,
+                            column=15,
+                            absolute_indent="",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1,
+                            column=16,
+                            absolute_indent="",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NEWLINE,
+                        string="\n",
+                        start_pos=(1, 16),
+                        end_pos=(2, 0),
+                        whitespace_before=WhitespaceState(
+                            line=1,
+                            column=16,
+                            absolute_indent="",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.INDENT,
+                        string="",
+                        start_pos=(2, 4),
+                        end_pos=(2, 4),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent="    ",
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="return",
+                        start_pos=(2, 4),
+                        end_pos=(2, 10),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=10,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="await",
+                        start_pos=(2, 11),
+                        end_pos=(2, 16),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=10,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=16,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="bar",
+                        start_pos=(2, 17),
+                        end_pos=(2, 20),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=16,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=20,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NEWLINE,
+                        string="\n",
+                        start_pos=(2, 20),
+                        end_pos=(3, 0),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=20,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.DEDENT,
+                        string="",
+                        start_pos=(3, 0),
+                        end_pos=(3, 0),
+                        whitespace_before=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.ENDMARKER,
+                        string="",
+                        start_pos=(3, 0),
+                        end_pos=(3, 0),
+                        whitespace_before=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                ),
+            ),
+            "simple_py38": (
+                "pass;\n",
+                _PY38,
+                (
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="pass",
+                        start_pos=(1, 0),
+                        end_pos=(1, 4),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=4, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.OP,
+                        string=";",
+                        start_pos=(1, 4),
+                        end_pos=(1, 5),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=4, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=5, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NEWLINE,
+                        string="\n",
+                        start_pos=(1, 5),
+                        end_pos=(2, 0),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=5, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.ENDMARKER,
+                        string="",
+                        start_pos=(2, 0),
+                        end_pos=(2, 0),
+                        whitespace_before=WhitespaceState(
+                            line=2, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                ),
+            ),
+            "with_indent_py38": (
+                "if foo:\n    bar\n",
+                _PY38,
+                (
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="if",
+                        start_pos=(1, 0),
+                        end_pos=(1, 2),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=2, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="foo",
+                        start_pos=(1, 3),
+                        end_pos=(1, 6),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=2, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=6, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.OP,
+                        string=":",
+                        start_pos=(1, 6),
+                        end_pos=(1, 7),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=6, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=7, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NEWLINE,
+                        string="\n",
+                        start_pos=(1, 7),
+                        end_pos=(2, 0),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=7, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.INDENT,
+                        string="",
+                        start_pos=(2, 4),
+                        end_pos=(2, 4),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent="    ",
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="bar",
+                        start_pos=(2, 4),
+                        end_pos=(2, 7),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=7,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NEWLINE,
+                        string="\n",
+                        start_pos=(2, 7),
+                        end_pos=(3, 0),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=7,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.DEDENT,
+                        string="",
+                        start_pos=(3, 0),
+                        end_pos=(3, 0),
+                        whitespace_before=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.ENDMARKER,
+                        string="",
+                        start_pos=(3, 0),
+                        end_pos=(3, 0),
+                        whitespace_before=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                ),
+            ),
+            "async_py38": (
+                "async def foo():\n    return await bar\n",
+                _PY38,
+                (
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="async",
+                        start_pos=(1, 0),
+                        end_pos=(1, 5),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=5, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="def",
+                        start_pos=(1, 6),
+                        end_pos=(1, 9),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=5, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=9, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="foo",
+                        start_pos=(1, 10),
+                        end_pos=(1, 13),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=9, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1,
+                            column=13,
+                            absolute_indent="",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.OP,
+                        string="(",
+                        start_pos=(1, 13),
+                        end_pos=(1, 14),
+                        whitespace_before=WhitespaceState(
+                            line=1,
+                            column=13,
+                            absolute_indent="",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1, column=14, absolute_indent="", is_parenthesized=True
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.OP,
+                        string=")",
+                        start_pos=(1, 14),
+                        end_pos=(1, 15),
+                        whitespace_before=WhitespaceState(
+                            line=1, column=14, absolute_indent="", is_parenthesized=True
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1,
+                            column=15,
+                            absolute_indent="",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.OP,
+                        string=":",
+                        start_pos=(1, 15),
+                        end_pos=(1, 16),
+                        whitespace_before=WhitespaceState(
+                            line=1,
+                            column=15,
+                            absolute_indent="",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=1,
+                            column=16,
+                            absolute_indent="",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NEWLINE,
+                        string="\n",
+                        start_pos=(1, 16),
+                        end_pos=(2, 0),
+                        whitespace_before=WhitespaceState(
+                            line=1,
+                            column=16,
+                            absolute_indent="",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.INDENT,
+                        string="",
+                        start_pos=(2, 4),
+                        end_pos=(2, 4),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent="    ",
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="return",
+                        start_pos=(2, 4),
+                        end_pos=(2, 10),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=0,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=10,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="await",
+                        start_pos=(2, 11),
+                        end_pos=(2, 16),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=10,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=16,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NAME,
+                        string="bar",
+                        start_pos=(2, 17),
+                        end_pos=(2, 20),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=16,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=2,
+                            column=20,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.NEWLINE,
+                        string="\n",
+                        start_pos=(2, 20),
+                        end_pos=(3, 0),
+                        whitespace_before=WhitespaceState(
+                            line=2,
+                            column=20,
+                            absolute_indent="    ",
+                            is_parenthesized=False,
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.DEDENT,
+                        string="",
+                        start_pos=(3, 0),
+                        end_pos=(3, 0),
+                        whitespace_before=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                    Token(
+                        type=PythonTokenTypes.ENDMARKER,
+                        string="",
+                        start_pos=(3, 0),
+                        end_pos=(3, 0),
+                        whitespace_before=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        whitespace_after=WhitespaceState(
+                            line=3, column=0, absolute_indent="", is_parenthesized=False
+                        ),
+                        relative_indent=None,
+                    ),
+                ),
+            ),
         }
     )
-    def test_tokenize(self, code: str, expected: Sequence[Token]) -> None:
-        tokens = tuple(tokenize(code, _PY38))
+    def test_tokenize(
+        self, code: str, ver: PythonVersionInfo, expected: Sequence[Token]
+    ) -> None:
+        tokens = tuple(tokenize(code, ver))
         self.assertSequenceEqual(tokens, expected)
         for a, b in zip(tokens, tokens[1:]):
             # These must be the same object, so if whitespace gets consumed (mutated) at
@@ -229,12 +1399,14 @@ class WrappedTokenizeTest(UnitTest):
             self.assertIs(a.whitespace_after, b.whitespace_before)
 
     def test_errortoken(self) -> None:
-        with self.assertRaisesRegex(ParserSyntaxError, "not a valid token"):
-            # use tuple() to read everything
-            # The copyright symbol isn't a valid token
-            tuple(tokenize("\u00a9", _PY38))
+        for version in [_PY36, _PY37, _PY38]:
+            with self.assertRaisesRegex(ParserSyntaxError, "not a valid token"):
+                # use tuple() to read everything
+                # The copyright symbol isn't a valid token
+                tuple(tokenize("\u00a9", version))
 
     def test_error_dedent(self) -> None:
-        with self.assertRaisesRegex(ParserSyntaxError, "Inconsistent indentation"):
-            # create some inconsistent indents to generate an ERROR_DEDENT token
-            tuple(tokenize("    a\n  b", _PY38))
+        for version in [_PY36, _PY37, _PY38]:
+            with self.assertRaisesRegex(ParserSyntaxError, "Inconsistent indentation"):
+                # create some inconsistent indents to generate an ERROR_DEDENT token
+                tuple(tokenize("    a\n  b", version))


### PR DESCRIPTION
## Summary

This PR adds support for parsing multiple versions of Python. Specifically, it adds support for 3.6, which exercises the need for versioning on grammar production decorators as well as a different tokenizer. All of the plumbing to make this happen based on the python version string in `PartialParserConfig` is included in this PR. It should be possible to add support for older grammars down to 2.7 and up through 3.9 after this PR lands.

## Test Plan

Added several tests for the 3.6 tokenizer, and made sure to add some tests for 3.7/3.8 to verify that the behavior did not leak. Updated several tests for the parser/generator code to work with 3.6-style async/await behavior, thus exercising our ability to parse 3.6 code.