### PR TITLE
support mypy using py.typed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.rst LICENSE CODE_OF_CONDUCT.md CONTRIBUTING.md requirements.txt docs/source/*.rst
+include README.rst LICENSE CODE_OF_CONDUCT.md CONTRIBUTING.md requirements.txt docs/source/*.rst libcst/py.typed

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setuptools.setup(
     url="https://github.com/Instagram/LibCST",
     license="MIT",
     packages=setuptools.find_packages(),
+    package_data={"libcst": ["py.typed"]},
     test_suite="libcst",
     python_requires=">=3.6",
     install_requires=[
@@ -51,4 +52,5 @@ setuptools.setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
     ],
+    zip_safe=False,  # for mypy compatibility https://mypy.readthedocs.io/en/latest/installed_packages.html
 )


### PR DESCRIPTION
## Summary
LibCST is fully typed and mypy is the most popular type checker. 
More context in https://github.com/Instagram/LibCST/issues/57.
Based on https://python.org/dev/peps/pep-0561/ to add py.typed setting and update setup.py.

## Test Plan
After installed the build package, mypy didn't complaint the missing import error.
```
jimmylai-mbp:LibCST jimmylai$ python setup.py sdist
Writing libcst-0.1.2/setup.cfg
Creating tar archive
removing 'libcst-0.1.2' (and everything under it)
jimmylai-mbp:LibCST jimmylai$ ls dist/
libcst-0.1.2.tar.gz

(mypy-libcst-env) jimmylai-mbp:mypy-libcst jimmylai$ cat a.py
import libcst

(mypy-libcst-env) jimmylai-mbp:mypy-libcst jimmylai$ mypy a.py
a.py:1: error: Cannot find module named 'libcst'
a.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
(mypy-libcst-env) jimmylai-mbp:mypy-libcst jimmylai$ pip install LibCST/dist/libcst-0.1.2.tar.gz
Requirement 'LibCST/dist/libcst-0.1.2.tar.gz' looks like a filename, but the file does not exist
Processing ./LibCST/dist/libcst-0.1.2.tar.gz
Could not install packages due to an EnvironmentError: [Errno 2] No such file or directory: '/Users/jimmylai/github/mypy-libcst/LibCST/dist/libcst-0.1.2.tar.gz'

You are using pip version 19.0.3, however version 19.2.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
(mypy-libcst-env) jimmylai-mbp:mypy-libcst jimmylai$ pip install ../LibCST/dist/libcst-0.1.2.tar.gz
Processing /Users/jimmylai/github/LibCST/dist/libcst-0.1.2.tar.gz
Requirement already satisfied: typing_extensions>=3.7.2 in /Users/jimmylai/github/mypy-libcst-env/lib/python3.7/site-packages (from libcst==0.1.2) (3.7.4)
Requirement already satisfied: typing_inspect>=0.3.1 in /Users/jimmylai/github/mypy-libcst-env/lib/python3.7/site-packages (from libcst==0.1.2) (0.4.0)
Requirement already satisfied: mypy-extensions>=0.3.0 in /Users/jimmylai/github/mypy-libcst-env/lib/python3.7/site-packages (from typing_inspect>=0.3.1->libcst==0.1.2) (0.4.1)
Installing collected packages: libcst
  Running setup.py install for libcst ... done
Successfully installed libcst-0.1.2
You are using pip version 19.0.3, however version 19.2.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.

(mypy-libcst-env) jimmylai-mbp:mypy-libcst jimmylai$ mypy a.py
(mypy-libcst-env) jimmylai-mbp:mypy-libcst jimmylai$
```
