### PR TITLE
Add type to init method in tutorial

### DIFF
--- a/docs/source/metadata_tutorial.ipynb
+++ b/docs/source/metadata_tutorial.ipynb
@@ -43,7 +43,7 @@
     "    \"\"\"\n",
     "    Marks Name nodes found as a parameter to a function.\n",
     "    \"\"\"\n",
-    "    def __init__(self):\n",
+    "    def __init__(self) -> None:\n",
     "        super().__init__()\n",
     "        self.is_param = False\n",
     "    \n",


### PR DESCRIPTION
## Summary
- Added the `None` type to the `__init__` method in the metadata tutorial
https://libcst.readthedocs.io/en/latest/metadata_tutorial.html#Providing-Metadata

## Test Plan

