### PR TITLE
Bump version to 0.1.3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.1.3 - 2019-09-18
+
+## Added
+
+ - Added preliminary support for parsing Python 3.5 and Python 3.6 source.
+ - Added scope analysis metadata provider.
+ - Added mypy type support for built package.
+
+## Fixed
+
+ - Several typos in documentation are fixed.
+
 # 0.1.2 - 2019-08-29
 
 ## Added

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,10 @@ with open(path.join(this_directory, "README.rst"), encoding="utf-8") as f:
 
 setuptools.setup(
     name="libcst",
-    description="A concrete syntax tree with AST-like properties for Python 3.7 programs.",
+    description="A concrete syntax tree with AST-like properties for Python 3.5, 3.6 and 3.7 programs.",
     long_description=long_description,
     long_description_content_type="text/x-rst",
-    version="0.1.2",
+    version="0.1.3",
     url="https://github.com/Instagram/LibCST",
     license="MIT",
     packages=setuptools.find_packages(),


### PR DESCRIPTION
## Summary

As it says on the tin! Bump the version so I can make a new release.

## Test Plan

Compared to ast bump at https://github.com/Instagram/LibCST/commit/38d220d2247c389ef2de30f35b5e4bb56061216b