### PR TITLE
Verify Tree Construction Uniqueness

### DIFF
--- a/libcst/_nodes/base.py
+++ b/libcst/_nodes/base.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, fields, replace
+from dataclasses import dataclass, field, fields, replace
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -346,6 +346,17 @@ class CSTNode(ABC):
                 lines.append(_indent(f"{key}={_pretty_repr(value)},"))
         lines.append(")")
         return "\n".join(lines)
+
+    @classmethod
+    def field(cls, *args: object, **kwargs: object) -> Any:
+        """
+        A helper that allows us to easily use CSTNodes in dataclass constructor
+        defaults without accidentally aliasing nodes by identity across multiple
+        instances.
+        """
+        # pyre-ignore Pyre is complaining about CSTNode not being instantiable,
+        # but we're only going to call this from concrete subclasses.
+        return field(default_factory=lambda: cls(*args, **kwargs))
 
 
 class BaseLeaf(CSTNode, ABC):

--- a/libcst/_nodes/expression.py
+++ b/libcst/_nodes/expression.py
@@ -8,7 +8,7 @@
 import re
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum, auto
 from tokenize import (
     Floatnumber as FLOATNUMBER_RE,
@@ -57,7 +57,7 @@ class LeftSquareBracket(CSTNode):
     """
 
     #: Any space that appears directly after this left square bracket.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     def _visit_and_replace_children(self, visitor: CSTVisitorT) -> "LeftSquareBracket":
         return LeftSquareBracket(
@@ -80,7 +80,7 @@ class RightSquareBracket(CSTNode):
     """
 
     #: Any space that appears directly before this right square bracket.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     def _visit_and_replace_children(self, visitor: CSTVisitorT) -> "RightSquareBracket":
         return RightSquareBracket(
@@ -103,7 +103,7 @@ class LeftCurlyBrace(CSTNode):
     """
 
     #: Any space that appears directly after this left curly brace.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     def _visit_and_replace_children(self, visitor: CSTVisitorT) -> "LeftCurlyBrace":
         return LeftCurlyBrace(
@@ -126,7 +126,7 @@ class RightCurlyBrace(CSTNode):
     """
 
     #: Any space that appears directly before this right curly brace.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     def _visit_and_replace_children(self, visitor: CSTVisitorT) -> "RightCurlyBrace":
         return RightCurlyBrace(
@@ -149,7 +149,7 @@ class LeftParen(CSTNode):
     """
 
     #: Any space that appears directly after this left parenthesis.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     def _visit_and_replace_children(self, visitor: CSTVisitorT) -> "LeftParen":
         return LeftParen(
@@ -172,7 +172,7 @@ class RightParen(CSTNode):
     """
 
     #: Any space that appears directly after this left parenthesis.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     def _visit_and_replace_children(self, visitor: CSTVisitorT) -> "RightParen":
         return RightParen(
@@ -195,7 +195,7 @@ class Asynchronous(CSTNode):
     """
 
     #: Any space that appears directly after this async keyword.
-    whitespace_after: SimpleWhitespace = SimpleWhitespace(" ")
+    whitespace_after: SimpleWhitespace = SimpleWhitespace.field(" ")
 
     def _validate(self) -> None:
         if len(self.whitespace_after.value) < 1:
@@ -673,11 +673,15 @@ class FormattedStringExpression(BaseFormattedStringContent):
     format_spec: Optional[Sequence[BaseFormattedStringContent]] = None
 
     #: Whitespace after the opening curly brace (``{``), but before the ``expression``.
-    whitespace_before_expression: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_before_expression: BaseParenthesizableWhitespace = SimpleWhitespace.field(
+        ""
+    )
 
     #: Whitespace after the ``expression``, ``conversion``, and ``format_spec``, but
     #: before the closing curly brace (``}``).
-    whitespace_after_expression: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_after_expression: BaseParenthesizableWhitespace = SimpleWhitespace.field(
+        ""
+    )
 
     def _validate(self) -> None:
         if self.conversion is not None and self.conversion not in ("s", "r", "a"):
@@ -855,7 +859,7 @@ class ConcatenatedString(BaseString):
     rpar: Sequence[RightParen] = ()
 
     #: Whitespace between the ``left`` and ``right`` substrings.
-    whitespace_between: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_between: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     def _safe_to_use_with_word_operator(self, position: ExpressionPosition) -> bool:
         if super(ConcatenatedString, self)._safe_to_use_with_word_operator(position):
@@ -1316,7 +1320,7 @@ class Slice(CSTNode):
     step: Optional[BaseExpression] = None
 
     #: The first slice operator
-    first_colon: Colon = Colon()
+    first_colon: Colon = Colon.field()
 
     #: The second slice operator, usually omitted
     second_colon: Union[Colon, MaybeSentinel] = MaybeSentinel.DEFAULT
@@ -1400,16 +1404,16 @@ class Subscript(BaseAssignTargetExpression, BaseDelTargetExpression):
     #: ``value``.
     slice: Union[Index, Slice, Sequence[ExtSlice]]
 
-    lbracket: LeftSquareBracket = LeftSquareBracket()
+    lbracket: LeftSquareBracket = LeftSquareBracket.field()
     #: Brackets after the ``value`` surrounding the ``slice``.
-    rbracket: RightSquareBracket = RightSquareBracket()
+    rbracket: RightSquareBracket = RightSquareBracket.field()
 
     lpar: Sequence[LeftParen] = ()
     #: Sequence of parenthesis for precedence dictation.
     rpar: Sequence[RightParen] = ()
 
     #: Whitespace after the ``value``, but before the ``lbracket``.
-    whitespace_after_value: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_after_value: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     def _validate(self) -> None:
         super(Subscript, self)._validate()
@@ -1488,7 +1492,9 @@ class Annotation(CSTNode):
     whitespace_before_indicator: Union[
         BaseParenthesizableWhitespace, MaybeSentinel
     ] = MaybeSentinel.DEFAULT
-    whitespace_after_indicator: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after_indicator: BaseParenthesizableWhitespace = SimpleWhitespace.field(
+        " "
+    )
 
     def _visit_and_replace_children(self, visitor: CSTVisitorT) -> "Annotation":
         return Annotation(
@@ -1547,7 +1553,7 @@ class ParamStar(CSTNode):
     """
 
     # Comma that comes after the star.
-    comma: Comma = Comma(whitespace_after=SimpleWhitespace(" "))
+    comma: Comma = Comma.field(whitespace_after=SimpleWhitespace(" "))
 
     def _visit_and_replace_children(self, visitor: CSTVisitorT) -> "ParamStar":
         return ParamStar(comma=visit_required(self, "comma", self.comma, visitor))
@@ -1588,10 +1594,10 @@ class Param(CSTNode):
 
     #: The whitespace before ``name``. It will appear after ``star`` when a star
     #: exists.
-    whitespace_after_star: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_after_star: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     #: The whitespace after this entire node.
-    whitespace_after_param: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_after_param: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     def _validate(self) -> None:
         if self.default is None and isinstance(self.equal, AssignEqual):
@@ -1846,7 +1852,7 @@ class Lambda(BaseExpression):
     body: BaseExpression
 
     #: The colon separating the parameters from the body.
-    colon: Colon = Colon(whitespace_after=SimpleWhitespace(" "))
+    colon: Colon = Colon.field(whitespace_after=SimpleWhitespace(" "))
 
     lpar: Sequence[LeftParen] = ()
     #: Sequence of parenthesis for precedence dictation.
@@ -1951,10 +1957,10 @@ class Arg(CSTNode):
 
     #: Whitespace after the ``star`` (if it exists), but before the ``keyword`` or
     #: ``value`` (if no keyword is provided).
-    whitespace_after_star: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_after_star: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
     #: Whitespace after this entire node. The :class:`Comma` node (if it exists) may
     #: also store some trailing whitespace.
-    whitespace_after_arg: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_after_arg: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     def _validate(self) -> None:
         if self.keyword is None and isinstance(self.equal, AssignEqual):
@@ -2128,11 +2134,11 @@ class Call(_BaseExpressionWithArgs):
     rpar: Sequence[RightParen] = ()
 
     #: Whitespace after the ``func`` name, but before the opening parenthesis.
-    whitespace_after_func: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_after_func: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
     #: Whitespace after the opening parenthesis but before the first argument (if there
     #: are any). Whitespace after the last argument but before the closing parenthesis
     #: is owned by the last :class:`Arg` if it exists.
-    whitespace_before_args: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_before_args: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     def _safe_to_use_with_word_operator(self, position: ExpressionPosition) -> bool:
         """
@@ -2192,7 +2198,7 @@ class Await(BaseExpression):
 
     #: Whitespace that appears after the ``async`` keyword, but before the inner
     #: ``expression``.
-    whitespace_after_await: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after_await: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _validate(self) -> None:
         # Validate any super-class stuff, whatever it may be.
@@ -2241,16 +2247,16 @@ class IfExp(BaseExpression):
     rpar: Sequence[RightParen] = ()
 
     #: Whitespace after the ``body`` expression, but before the ``if`` keyword.
-    whitespace_before_if: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before_if: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Whitespace after the ``if`` keyword, but before the ``test`` clause.
-    whitespace_after_if: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after_if: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Whitespace after the ``test`` expression, but before the ``else`` keyword.
-    whitespace_before_else: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before_else: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Whitespace after the ``else`` keyword, but before the ``orelse`` expression.
-    whitespace_after_else: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after_else: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _validate(self) -> None:
         # Paren validation and such
@@ -2335,7 +2341,7 @@ class From(CSTNode):
     ] = MaybeSentinel.DEFAULT
 
     #: The whitespace after the ``from`` keyword, but before the ``item``.
-    whitespace_after_from: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after_from: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _validate(self) -> None:
         if (
@@ -2544,9 +2550,9 @@ class DictElement(BaseDictElement):
     comma: Union[Comma, MaybeSentinel] = MaybeSentinel.DEFAULT
 
     #: Whitespace after the key, but before the colon in ``key : value``.
-    whitespace_before_colon: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_before_colon: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
     #: Whitespace after the colon, but before the value in ``key : value``.
-    whitespace_after_colon: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after_colon: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _visit_and_replace_children(self, visitor: CSTVisitorT) -> "DictElement":
         return DictElement(
@@ -2611,7 +2617,7 @@ class StarredElement(BaseElement, _BaseParenthesizedNode):
     rpar: Sequence[RightParen] = ()
 
     #: Whitespace between the leading asterisk and the value expression.
-    whitespace_before_value: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_before_value: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     def _visit_and_replace_children(self, visitor: CSTVisitorT) -> "StarredElement":
         return StarredElement(
@@ -2658,7 +2664,7 @@ class StarredDictElement(BaseDictElement):
     comma: Union[Comma, MaybeSentinel] = MaybeSentinel.DEFAULT
 
     #: Whitespace between the leading asterisks and the value expression.
-    whitespace_before_value: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_before_value: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     def _visit_and_replace_children(self, visitor: CSTVisitorT) -> "StarredDictElement":
         return StarredDictElement(
@@ -2705,9 +2711,9 @@ class Tuple(BaseAssignTargetExpression, BaseDelTargetExpression):
     #: in the tuple.
     elements: Sequence[BaseElement]
 
-    lpar: Sequence[LeftParen] = (LeftParen(),)
+    lpar: Sequence[LeftParen] = field(default_factory=lambda: (LeftParen(),))
     #: Sequence of parenthesis for precedence dictation.
-    rpar: Sequence[RightParen] = (RightParen(),)
+    rpar: Sequence[RightParen] = field(default_factory=lambda: (RightParen(),))
 
     def _safe_to_use_with_word_operator(self, position: ExpressionPosition) -> bool:
         if super(Tuple, self)._safe_to_use_with_word_operator(position):
@@ -2774,9 +2780,9 @@ class BaseList(BaseExpression, ABC):
     object when evaluated.
     """
 
-    lbracket: LeftSquareBracket = LeftSquareBracket()
+    lbracket: LeftSquareBracket = LeftSquareBracket.field()
     #: Brackets surrounding the list.
-    rbracket: RightSquareBracket = RightSquareBracket()
+    rbracket: RightSquareBracket = RightSquareBracket.field()
 
     lpar: Sequence[LeftParen] = ()
     #: Sequence of parenthesis for precedence dictation.
@@ -2817,9 +2823,9 @@ class List(BaseList, BaseAssignTargetExpression, BaseDelTargetExpression):
     #: in the list.
     elements: Sequence[BaseElement]
 
-    lbracket: LeftSquareBracket = LeftSquareBracket()
+    lbracket: LeftSquareBracket = LeftSquareBracket.field()
     #: Brackets surrounding the list.
-    rbracket: RightSquareBracket = RightSquareBracket()
+    rbracket: RightSquareBracket = RightSquareBracket.field()
 
     lpar: Sequence[LeftParen] = ()
     #: Sequence of parenthesis for precedence dictation.
@@ -2854,9 +2860,9 @@ class _BaseSetOrDict(BaseExpression, ABC):
     shouldn't be exported.
     """
 
-    lbrace: LeftCurlyBrace = LeftCurlyBrace()
+    lbrace: LeftCurlyBrace = LeftCurlyBrace.field()
     #: Braces surrounding the set or dict.
-    rbrace: RightCurlyBrace = RightCurlyBrace()
+    rbrace: RightCurlyBrace = RightCurlyBrace.field()
 
     lpar: Sequence[LeftParen] = ()
     #: Sequence of parenthesis for precedence dictation.
@@ -2905,9 +2911,9 @@ class Set(BaseSet):
     #: in the set.
     elements: Sequence[BaseElement]
 
-    lbrace: LeftCurlyBrace = LeftCurlyBrace()
+    lbrace: LeftCurlyBrace = LeftCurlyBrace.field()
     #: Braces surrounding the set.
-    rbrace: RightCurlyBrace = RightCurlyBrace()
+    rbrace: RightCurlyBrace = RightCurlyBrace.field()
 
     lpar: Sequence[LeftParen] = ()
     #: Sequence of parenthesis for precedence dictation.
@@ -2973,8 +2979,8 @@ class Dict(BaseDict):
     """
 
     elements: Sequence[BaseDictElement]
-    lbrace: LeftCurlyBrace = LeftCurlyBrace()
-    rbrace: RightCurlyBrace = RightCurlyBrace()
+    lbrace: LeftCurlyBrace = LeftCurlyBrace.field()
+    rbrace: RightCurlyBrace = RightCurlyBrace.field()
     lpar: Sequence[LeftParen] = ()
     rpar: Sequence[RightParen] = ()
 
@@ -3069,16 +3075,16 @@ class CompFor(CSTNode):
 
     #: Whitespace that appears at the beginning of this node, before the ``for`` and
     #: ``async`` keywords.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Whitespace appearing after the ``for`` keyword, but before the ``target``.
-    whitespace_after_for: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after_for: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Whitespace appearing after the ``target``, but before the ``in`` keyword.
-    whitespace_before_in: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before_in: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Whitespace appearing after the ``in`` keyword, but before the ``iter``.
-    whitespace_after_in: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after_in: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _validate(self) -> None:
         if (
@@ -3188,10 +3194,10 @@ class CompIf(CSTNode):
     test: BaseExpression
 
     #: Whitespace before the ``if`` keyword.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Whitespace after the ``if`` keyword, but before the ``test`` expression.
-    whitespace_before_test: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before_test: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _validate(self) -> None:
         if (
@@ -3276,12 +3282,12 @@ class GeneratorExp(BaseSimpleComp):
     #: nested structure for nested comprehensions. See :class:`CompFor` for details.
     for_in: CompFor
 
-    lpar: Sequence[LeftParen] = (LeftParen(),)
+    lpar: Sequence[LeftParen] = field(default_factory=lambda: (LeftParen(),))
     #: Sequence of parentheses for precedence dictation. Generator expressions must
     #: always be parenthesized. However, if a generator expression is the only argument
     #: inside a function call, the enclosing :class:`Call` node may own the parentheses
     #: instead.
-    rpar: Sequence[RightParen] = (RightParen(),)
+    rpar: Sequence[RightParen] = field(default_factory=lambda: (RightParen(),))
 
     def _safe_to_use_with_word_operator(self, position: ExpressionPosition) -> bool:
         # Generators are always parenthesized
@@ -3327,9 +3333,9 @@ class ListComp(BaseList, BaseSimpleComp):
     #: nested structure for nested comprehensions. See :class:`CompFor` for details.
     for_in: CompFor
 
-    lbracket: LeftSquareBracket = LeftSquareBracket()
+    lbracket: LeftSquareBracket = LeftSquareBracket.field()
     #: Brackets surrounding the list comprehension.
-    rbracket: RightSquareBracket = RightSquareBracket()
+    rbracket: RightSquareBracket = RightSquareBracket.field()
 
     lpar: Sequence[LeftParen] = ()
     #: Sequence of parenthesis for precedence dictation.
@@ -3369,9 +3375,9 @@ class SetComp(BaseSet, BaseSimpleComp):
     #: nested structure for nested comprehensions. See :class:`CompFor` for details.
     for_in: CompFor
 
-    lbrace: LeftCurlyBrace = LeftCurlyBrace()
+    lbrace: LeftCurlyBrace = LeftCurlyBrace.field()
     #: Braces surrounding the set comprehension.
-    rbrace: RightCurlyBrace = RightCurlyBrace()
+    rbrace: RightCurlyBrace = RightCurlyBrace.field()
 
     lpar: Sequence[LeftParen] = ()
     #: Sequence of parenthesis for precedence dictation.
@@ -3415,18 +3421,18 @@ class DictComp(BaseDict, BaseComp):
     #: :class:`CompFor` for details.
     for_in: CompFor
 
-    lbrace: LeftCurlyBrace = LeftCurlyBrace()
+    lbrace: LeftCurlyBrace = LeftCurlyBrace.field()
     #: Braces surrounding the dict comprehension.
-    rbrace: RightCurlyBrace = RightCurlyBrace()
+    rbrace: RightCurlyBrace = RightCurlyBrace.field()
 
     lpar: Sequence[LeftParen] = ()
     #: Sequence of parenthesis for precedence dictation.
     rpar: Sequence[RightParen] = ()
 
     #: Whitespace after the key, but before the colon in ``key : value``.
-    whitespace_before_colon: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_before_colon: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
     #: Whitespace after the colon, but before the value in ``key : value``.
-    whitespace_after_colon: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after_colon: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _validate(self) -> None:
         super(DictComp, self)._validate()

--- a/libcst/_nodes/op.py
+++ b/libcst/_nodes/op.py
@@ -152,10 +152,10 @@ class Semicolon(_BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this semicolon.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     #: Any space that appears directly after this semicolon.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     def _get_token(self) -> str:
         return ";"
@@ -170,10 +170,10 @@ class Colon(_BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this colon.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     #: Any space that appears directly after this colon.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     def _get_token(self) -> str:
         return ":"
@@ -194,10 +194,10 @@ class Comma(_BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this comma.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     #: Any space that appears directly after this comma.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     def _get_token(self) -> str:
         return ","
@@ -211,10 +211,10 @@ class Dot(_BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this dot.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     #: Any space that appears directly after this dot.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     def _get_token(self) -> str:
         return "."
@@ -242,10 +242,10 @@ class AssignEqual(_BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this equal sign.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this equal sign.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "="
@@ -260,7 +260,7 @@ class Plus(BaseUnaryOp):
     """
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     def _get_token(self) -> str:
         return "+"
@@ -275,7 +275,7 @@ class Minus(BaseUnaryOp):
     """
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     def _get_token(self) -> str:
         return "-"
@@ -290,7 +290,7 @@ class BitInvert(BaseUnaryOp):
     """
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace("")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     def _get_token(self) -> str:
         return "~"
@@ -305,7 +305,7 @@ class Not(BaseUnaryOp):
     """
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "not"
@@ -320,10 +320,10 @@ class And(BaseBooleanOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "and"
@@ -338,10 +338,10 @@ class Or(BaseBooleanOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "or"
@@ -356,10 +356,10 @@ class Add(BaseBinaryOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "+"
@@ -374,10 +374,10 @@ class Subtract(BaseBinaryOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "-"
@@ -392,10 +392,10 @@ class Multiply(BaseBinaryOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "*"
@@ -410,10 +410,10 @@ class Divide(BaseBinaryOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "/"
@@ -428,10 +428,10 @@ class FloorDivide(BaseBinaryOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "//"
@@ -446,10 +446,10 @@ class Modulo(BaseBinaryOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "%"
@@ -464,10 +464,10 @@ class Power(BaseBinaryOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "**"
@@ -482,10 +482,10 @@ class LeftShift(BaseBinaryOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "<<"
@@ -500,10 +500,10 @@ class RightShift(BaseBinaryOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return ">>"
@@ -518,10 +518,10 @@ class BitOr(BaseBinaryOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "|"
@@ -536,10 +536,10 @@ class BitAnd(BaseBinaryOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "&"
@@ -554,10 +554,10 @@ class BitXor(BaseBinaryOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "^"
@@ -572,10 +572,10 @@ class MatrixMultiply(BaseBinaryOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "@"
@@ -589,10 +589,10 @@ class LessThan(BaseCompOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "<"
@@ -606,10 +606,10 @@ class GreaterThan(BaseCompOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return ">"
@@ -623,10 +623,10 @@ class Equal(BaseCompOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "=="
@@ -640,10 +640,10 @@ class LessThanEqual(BaseCompOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "<="
@@ -657,10 +657,10 @@ class GreaterThanEqual(BaseCompOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return ">="
@@ -681,10 +681,10 @@ class NotEqual(BaseCompOp):
     value: str = "!="
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _validate(self) -> None:
         if self.value not in ["!=", "<>"]:
@@ -715,10 +715,10 @@ class In(BaseCompOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "in"
@@ -735,13 +735,13 @@ class NotIn(BaseCompOp, _BaseTwoTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears between the ``not`` and ``in`` tokens.
-    whitespace_between: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_between: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_tokens(self) -> Tuple[str, str]:
         return ("not", "in")
@@ -755,10 +755,10 @@ class Is(BaseCompOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "is"
@@ -775,13 +775,13 @@ class IsNot(BaseCompOp, _BaseTwoTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears between the ``is`` and ``not`` tokens.
-    whitespace_between: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_between: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_tokens(self) -> Tuple[str, str]:
         return ("is", "not")
@@ -796,10 +796,10 @@ class AddAssign(BaseAugOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "+="
@@ -814,10 +814,10 @@ class SubtractAssign(BaseAugOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "-="
@@ -832,10 +832,10 @@ class MultiplyAssign(BaseAugOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "*="
@@ -850,10 +850,10 @@ class MatrixMultiplyAssign(BaseAugOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "@="
@@ -868,10 +868,10 @@ class DivideAssign(BaseAugOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "/="
@@ -886,10 +886,10 @@ class ModuloAssign(BaseAugOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "%="
@@ -904,10 +904,10 @@ class BitAndAssign(BaseAugOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "&="
@@ -922,10 +922,10 @@ class BitOrAssign(BaseAugOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "|="
@@ -940,10 +940,10 @@ class BitXorAssign(BaseAugOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "^="
@@ -958,10 +958,10 @@ class LeftShiftAssign(BaseAugOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "<<="
@@ -976,10 +976,10 @@ class RightShiftAssign(BaseAugOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return ">>="
@@ -994,10 +994,10 @@ class PowerAssign(BaseAugOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "**="
@@ -1012,10 +1012,10 @@ class FloorDivideAssign(BaseAugOp, _BaseOneTokenOp):
     """
 
     #: Any space that appears directly before this operator.
-    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Any space that appears directly after this operator.
-    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _get_token(self) -> str:
         return "//="

--- a/libcst/_nodes/statement.py
+++ b/libcst/_nodes/statement.py
@@ -109,7 +109,7 @@ class Del(BaseSmallStatement):
     target: BaseDelTargetExpression
 
     #: The whitespace after the ``del`` keyword.
-    whitespace_after_del: SimpleWhitespace = SimpleWhitespace(" ")
+    whitespace_after_del: SimpleWhitespace = SimpleWhitespace.field(" ")
 
     #: Optional semicolon when this is used in a statement line. This semicolon
     #: owns the whitespace on both sides of it when it is used.
@@ -409,7 +409,7 @@ class SimpleStatementLine(_BaseSimpleStatement, BaseStatement):
     leading_lines: Sequence[EmptyLine] = ()
 
     #: Any optional trailing comment and the final ``NEWLINE`` at the end of the line.
-    trailing_whitespace: TrailingWhitespace = TrailingWhitespace()
+    trailing_whitespace: TrailingWhitespace = TrailingWhitespace.field()
 
     def _visit_and_replace_children(
         self, visitor: CSTVisitorT
@@ -458,10 +458,10 @@ class SimpleStatementSuite(_BaseSimpleStatement, BaseSuite):
     body: Sequence[BaseSmallStatement]
 
     #: The whitespace between the colon in the parent statement and the body.
-    leading_whitespace: SimpleWhitespace = SimpleWhitespace(" ")
+    leading_whitespace: SimpleWhitespace = SimpleWhitespace.field(" ")
 
     #: Any optional trailing comment and the final ``NEWLINE`` at the end of the line.
-    trailing_whitespace: TrailingWhitespace = TrailingWhitespace()
+    trailing_whitespace: TrailingWhitespace = TrailingWhitespace.field()
 
     def _visit_and_replace_children(
         self, visitor: CSTVisitorT
@@ -500,7 +500,7 @@ class Else(CSTNode):
     leading_lines: Sequence[EmptyLine] = ()
 
     #: The whitespace appearing after the ``else`` keyword but before the colon.
-    whitespace_before_colon: SimpleWhitespace = SimpleWhitespace("")
+    whitespace_before_colon: SimpleWhitespace = SimpleWhitespace.field("")
 
     def _visit_and_replace_children(self, visitor: CSTVisitorT) -> "Else":
         return Else(
@@ -570,10 +570,10 @@ class If(BaseCompoundStatement):
     leading_lines: Sequence[EmptyLine] = ()
 
     #: The whitespace appearing after the ``if`` keyword but before the test expression.
-    whitespace_before_test: SimpleWhitespace = SimpleWhitespace(" ")
+    whitespace_before_test: SimpleWhitespace = SimpleWhitespace.field(" ")
 
     #: The whitespace appearing after the test expression but before the colon.
-    whitespace_after_test: SimpleWhitespace = SimpleWhitespace("")
+    whitespace_after_test: SimpleWhitespace = SimpleWhitespace.field("")
 
     # TODO: _validate
 
@@ -640,7 +640,7 @@ class IndentedBlock(BaseSuite):
     body: Sequence[BaseStatement]
 
     #: Any optional trailing comment and the final ``NEWLINE`` at the end of the line.
-    header: TrailingWhitespace = TrailingWhitespace()
+    header: TrailingWhitespace = TrailingWhitespace.field()
 
     #: A string represents a specific indentation. A ``None`` value uses the modules's
     #: default indentation. This is included because indentation is allowed to be
@@ -716,10 +716,10 @@ class AsName(CSTNode):
     name: Union[Name, Tuple, List]
 
     #: Whitespace between the parent node and the ``as`` keyword.
-    whitespace_before_as: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_before_as: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     #: Whitespace between the ``as`` keyword and the name.
-    whitespace_after_as: BaseParenthesizableWhitespace = SimpleWhitespace(" ")
+    whitespace_after_as: BaseParenthesizableWhitespace = SimpleWhitespace.field(" ")
 
     def _validate(self) -> None:
         if self.whitespace_after_as.empty:
@@ -768,11 +768,11 @@ class ExceptHandler(CSTNode):
     leading_lines: Sequence[EmptyLine] = ()
 
     #: The whitespace between the ``except`` keyword and the type attribute.
-    whitespace_after_except: SimpleWhitespace = SimpleWhitespace(" ")
+    whitespace_after_except: SimpleWhitespace = SimpleWhitespace.field(" ")
 
     #: The whitespace after any type or name node (whichever comes last) and
     #: the colon.
-    whitespace_before_colon: SimpleWhitespace = SimpleWhitespace("")
+    whitespace_before_colon: SimpleWhitespace = SimpleWhitespace.field("")
 
     def _validate(self) -> None:
         name = self.name
@@ -837,7 +837,7 @@ class Finally(CSTNode):
 
     #: The whitespace that appears after the ``finally`` keyword but before
     #: the colon.
-    whitespace_before_colon: SimpleWhitespace = SimpleWhitespace("")
+    whitespace_before_colon: SimpleWhitespace = SimpleWhitespace.field("")
 
     def _visit_and_replace_children(self, visitor: CSTVisitorT) -> "Finally":
         return Finally(
@@ -886,7 +886,7 @@ class Try(BaseCompoundStatement):
 
     #: The whitespace that appears after the ``try`` keyword but before
     #: the colon.
-    whitespace_before_colon: SimpleWhitespace = SimpleWhitespace("")
+    whitespace_before_colon: SimpleWhitespace = SimpleWhitespace.field("")
 
     def _validate(self) -> None:
         if len(self.handlers) == 0 and self.finalbody is None:
@@ -1002,7 +1002,7 @@ class Import(BaseSmallStatement):
 
     #: The whitespace that appears after the ``import`` keyword but before
     #: the first import alias.
-    whitespace_after_import: SimpleWhitespace = SimpleWhitespace(" ")
+    whitespace_after_import: SimpleWhitespace = SimpleWhitespace.field(" ")
 
     def _validate(self) -> None:
         if len(self.names) == 0:
@@ -1073,15 +1073,15 @@ class ImportFrom(BaseSmallStatement):
 
     #: The whitespace that appears after the ``from`` keyword but before
     #: the module and any relative import dots.
-    whitespace_after_from: SimpleWhitespace = SimpleWhitespace(" ")
+    whitespace_after_from: SimpleWhitespace = SimpleWhitespace.field(" ")
 
     #: The whitespace that appears after the module but before the
     #: ``import`` keyword.
-    whitespace_before_import: SimpleWhitespace = SimpleWhitespace(" ")
+    whitespace_before_import: SimpleWhitespace = SimpleWhitespace.field(" ")
 
     #: The whitespace that appears after the ``import`` keyword but
     #: before the first import name or optional left paren.
-    whitespace_after_import: SimpleWhitespace = SimpleWhitespace(" ")
+    whitespace_after_import: SimpleWhitespace = SimpleWhitespace.field(" ")
 
     def _validate_module(self) -> None:
         if self.module is None and len(self.relative) == 0:
@@ -1201,10 +1201,10 @@ class AssignTarget(CSTNode):
     target: BaseAssignTargetExpression
 
     #: The whitespace appearing before the equals sign.
-    whitespace_before_equal: SimpleWhitespace = SimpleWhitespace(" ")
+    whitespace_before_equal: SimpleWhitespace = SimpleWhitespace.field(" ")
 
     #: The whitespace appearing after the equals sign.
-    whitespace_after_equal: SimpleWhitespace = SimpleWhitespace(" ")
+    whitespace_after_equal: SimpleWhitespace = SimpleWhitespace.field(" ")
 
     def _visit_and_replace_children(self, visitor: CSTVisitorT) -> "AssignTarget":
         return AssignTarget(
@@ -1400,10 +1400,10 @@ class Decorator(CSTNode):
     leading_lines: Sequence[EmptyLine] = ()
 
     #: Whitespace after the ``@`` and before the decorator expression itself.
-    whitespace_after_at: SimpleWhitespace = SimpleWhitespace("")
+    whitespace_after_at: SimpleWhitespace = SimpleWhitespace.field("")
 
     #: Optional trailing comment and newline following the decorator before the next line.
-    trailing_whitespace: TrailingWhitespace = TrailingWhitespace()
+    trailing_whitespace: TrailingWhitespace = TrailingWhitespace.field()
 
     def _validate(self) -> None:
         decorator = self.decorator
@@ -1484,19 +1484,19 @@ class FunctionDef(BaseCompoundStatement):
     lines_after_decorators: Sequence[EmptyLine] = ()
 
     #: Whitespace after the ``def`` keyword and before the function name.
-    whitespace_after_def: SimpleWhitespace = SimpleWhitespace(" ")
+    whitespace_after_def: SimpleWhitespace = SimpleWhitespace.field(" ")
 
     #: Whitespace after the function name and before the opening parenthesis for
     #: the parameters.
-    whitespace_after_name: SimpleWhitespace = SimpleWhitespace("")
+    whitespace_after_name: SimpleWhitespace = SimpleWhitespace.field("")
 
     #: Whitespace after the opening parenthesis for the parameters but before
     #: the first param itself.
-    whitespace_before_params: SimpleWhitespace = SimpleWhitespace("")
+    whitespace_before_params: SimpleWhitespace = SimpleWhitespace.field("")
 
     #: Whitespace after the closing parenthesis or return annotation and before
     #: the colon.
-    whitespace_before_colon: SimpleWhitespace = SimpleWhitespace("")
+    whitespace_before_colon: SimpleWhitespace = SimpleWhitespace.field("")
 
     def _validate(self) -> None:
         if len(self.name.lpar) > 0 or len(self.name.rpar) > 0:
@@ -1605,15 +1605,15 @@ class ClassDef(BaseCompoundStatement):
     lines_after_decorators: Sequence[EmptyLine] = ()
 
     #: Whitespace after the ``class`` keyword and before the class name.
-    whitespace_after_class: SimpleWhitespace = SimpleWhitespace(" ")
+    whitespace_after_class: SimpleWhitespace = SimpleWhitespace.field(" ")
 
     #: Whitespace after the class name and before the opening parenthesis for
     #: the bases and keywords.
-    whitespace_after_name: SimpleWhitespace = SimpleWhitespace("")
+    whitespace_after_name: SimpleWhitespace = SimpleWhitespace.field("")
 
     #: Whitespace after the closing parenthesis or class name and before
     #: the colon.
-    whitespace_before_colon: SimpleWhitespace = SimpleWhitespace("")
+    whitespace_before_colon: SimpleWhitespace = SimpleWhitespace.field("")
 
     def _validate_whitespace(self) -> None:
         if self.whitespace_after_class.empty:
@@ -1766,10 +1766,10 @@ class With(BaseCompoundStatement):
     leading_lines: Sequence[EmptyLine] = ()
 
     #: Whitespace after the ``with`` keyword and before the first item.
-    whitespace_after_with: SimpleWhitespace = SimpleWhitespace(" ")
+    whitespace_after_with: SimpleWhitespace = SimpleWhitespace.field(" ")
 
     #: Whitespace after the last item and before the colon.
-    whitespace_before_colon: SimpleWhitespace = SimpleWhitespace("")
+    whitespace_before_colon: SimpleWhitespace = SimpleWhitespace.field("")
 
     def _validate(self) -> None:
         if len(self.items) == 0:
@@ -1849,16 +1849,16 @@ class For(BaseCompoundStatement):
     leading_lines: Sequence[EmptyLine] = ()
 
     #: Whitespace after the ``for`` keyword and before the target.
-    whitespace_after_for: SimpleWhitespace = SimpleWhitespace(" ")
+    whitespace_after_for: SimpleWhitespace = SimpleWhitespace.field(" ")
 
     #: Whitespace after the target and before the ``in`` keyword.
-    whitespace_before_in: SimpleWhitespace = SimpleWhitespace(" ")
+    whitespace_before_in: SimpleWhitespace = SimpleWhitespace.field(" ")
 
     #: Whitespace after the ``in`` keyword and before the iter.
-    whitespace_after_in: SimpleWhitespace = SimpleWhitespace(" ")
+    whitespace_after_in: SimpleWhitespace = SimpleWhitespace.field(" ")
 
     #: Whitespace after the iter and before the colon.
-    whitespace_before_colon: SimpleWhitespace = SimpleWhitespace("")
+    whitespace_before_colon: SimpleWhitespace = SimpleWhitespace.field("")
 
     def _validate(self) -> None:
         if (
@@ -1957,10 +1957,10 @@ class While(BaseCompoundStatement):
     leading_lines: Sequence[EmptyLine] = ()
 
     #: Whitespace after the ``while`` keyword and before the test.
-    whitespace_after_while: SimpleWhitespace = SimpleWhitespace(" ")
+    whitespace_after_while: SimpleWhitespace = SimpleWhitespace.field(" ")
 
     #: Whitespace after the test and before the colon.
-    whitespace_before_colon: SimpleWhitespace = SimpleWhitespace("")
+    whitespace_before_colon: SimpleWhitespace = SimpleWhitespace.field("")
 
     def _validate(self) -> None:
         if (
@@ -2115,7 +2115,7 @@ class Assert(BaseSmallStatement):
     comma: Union[Comma, MaybeSentinel] = MaybeSentinel.DEFAULT
 
     #: Whitespace appearing after the ``assert`` keyword and before the test.
-    whitespace_after_assert: SimpleWhitespace = SimpleWhitespace(" ")
+    whitespace_after_assert: SimpleWhitespace = SimpleWhitespace.field(" ")
 
     #: Optional semicolon when this is used in a statement line. This semicolon
     #: owns the whitespace on both sides of it when it is used.
@@ -2221,7 +2221,7 @@ class Global(BaseSmallStatement):
     names: Sequence[NameItem]
 
     #: Whitespace appearing after the ``global`` keyword and before the first name.
-    whitespace_after_global: SimpleWhitespace = SimpleWhitespace(" ")
+    whitespace_after_global: SimpleWhitespace = SimpleWhitespace.field(" ")
 
     #: Optional semicolon when this is used in a statement line. This semicolon
     #: owns the whitespace on both sides of it when it is used.
@@ -2279,7 +2279,7 @@ class Nonlocal(BaseSmallStatement):
     names: Sequence[NameItem]
 
     #: Whitespace appearing after the ``global`` keyword and before the first name.
-    whitespace_after_nonlocal: SimpleWhitespace = SimpleWhitespace(" ")
+    whitespace_after_nonlocal: SimpleWhitespace = SimpleWhitespace.field(" ")
 
     #: Optional semicolon when this is used in a statement line. This semicolon
     #: owns the whitespace on both sides of it when it is used.

--- a/libcst/_nodes/whitespace.py
+++ b/libcst/_nodes/whitespace.py
@@ -174,13 +174,13 @@ class TrailingWhitespace(CSTNode):
     """
 
     #: Any simple whitespace before any comment or newline.
-    whitespace: SimpleWhitespace = SimpleWhitespace("")
+    whitespace: SimpleWhitespace = SimpleWhitespace.field("")
 
     #: An optional comment appearing after any simple whitespace.
     comment: Optional[Comment] = None
 
     #: The newline character that terminates this trailing whitespace.
-    newline: Newline = Newline()
+    newline: Newline = Newline.field()
 
     def _visit_and_replace_children(self, visitor: CSTVisitorT) -> "TrailingWhitespace":
         return TrailingWhitespace(
@@ -212,13 +212,13 @@ class EmptyLine(CSTNode):
     indent: bool = True
 
     #: Extra whitespace after the indent, but before the comment.
-    whitespace: SimpleWhitespace = SimpleWhitespace("")
+    whitespace: SimpleWhitespace = SimpleWhitespace.field("")
 
     #: An optional comment appearing after the indent and extra whitespace.
     comment: Optional[Comment] = None
 
     #: The newline character that terminates this empty line.
-    newline: Newline = Newline()
+    newline: Newline = Newline.field()
 
     def _visit_and_replace_children(self, visitor: CSTVisitorT) -> "EmptyLine":
         return EmptyLine(
@@ -255,7 +255,7 @@ class ParenthesizedWhitespace(BaseParenthesizableWhitespace):
 
     #: The whitespace that comes after the previous node, up to and including
     #: the end-of-line comment and newline.
-    first_line: TrailingWhitespace = TrailingWhitespace()
+    first_line: TrailingWhitespace = TrailingWhitespace.field()
 
     #: Any lines after the first that contain only indentation and/or comments.
     empty_lines: Sequence[EmptyLine] = ()
@@ -264,7 +264,7 @@ class ParenthesizedWhitespace(BaseParenthesizableWhitespace):
     indent: bool = False
 
     #: Extra whitespace after the indent, but before the next node.
-    last_line: SimpleWhitespace = SimpleWhitespace("")
+    last_line: SimpleWhitespace = SimpleWhitespace.field("")
 
     def _visit_and_replace_children(
         self, visitor: CSTVisitorT

--- a/libcst/_parser/tests/test_node_identity.py
+++ b/libcst/_parser/tests/test_node_identity.py
@@ -1,0 +1,46 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from collections import Counter
+from textwrap import dedent
+
+import libcst as cst
+from libcst.testing.utils import UnitTest, data_provider
+
+
+class DuplicateLeafNodeTest(UnitTest):
+    @data_provider(
+        (
+            # Simple program
+            (
+                """
+                foo = 'toplevel'
+                fn1(foo)
+                fn2(foo)
+                def fn_def():
+                    foo = 'shadow'
+                    fn3(foo)
+            """,
+            ),
+        )
+    )
+    def test_tokenize(self, code: str) -> None:
+        test_case = self
+
+        class CountVisitor(cst.CSTVisitor):
+            def __init__(self) -> None:
+                self.count = Counter()
+                self.nodes = {}
+
+            def on_visit(self, node: cst.CSTNode) -> bool:
+                self.count[id(node)] += 1
+                test_case.assertTrue(
+                    self.count[id(node)] == 1,
+                    f"Node duplication detected between {node} and {self.nodes.get(id(node))}",
+                )
+                self.nodes[id(node)] = node
+                return True
+
+        module = cst.parse_module(dedent(code))
+        module.visit(CountVisitor())

--- a/libcst/tests/test_deep_clone.py
+++ b/libcst/tests/test_deep_clone.py
@@ -1,0 +1,54 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from textwrap import dedent
+from typing import Set
+
+import libcst as cst
+from libcst.testing.utils import UnitTest, data_provider
+
+
+class DeepCloneTest(UnitTest):
+    @data_provider(
+        (
+            # Simple program
+            (
+                """
+                foo = 'toplevel'
+                fn1(foo)
+                fn2(foo)
+                def fn_def():
+                    foo = 'shadow'
+                    fn3(foo)
+            """,
+            ),
+        )
+    )
+    def test_deep_clone(self, code: str) -> None:
+        test_case = self
+
+        class NodeGatherVisitor(cst.CSTVisitor):
+            def __init__(self) -> None:
+                self.nodes: Set[int] = set()
+
+            def on_visit(self, node: cst.CSTNode) -> bool:
+                self.nodes.add(id(node))
+                return True
+
+        class NodeVerifyVisitor(cst.CSTVisitor):
+            def __init__(self, nodes: Set[int]) -> None:
+                self.nodes = nodes
+
+            def on_visit(self, node: cst.CSTNode) -> bool:
+                test_case.assertFalse(
+                    id(node) in self.nodes, f"Node {node} was not cloned properly!"
+                )
+                return True
+
+        module = cst.parse_module(dedent(code))
+        gatherer = NodeGatherVisitor()
+        module.visit(gatherer)
+        new_module = module.deep_clone()
+        self.assertTrue(module.deep_equals(new_module))
+        new_module.visit(NodeVerifyVisitor(gatherer.nodes))

--- a/libcst/tool.py
+++ b/libcst/tool.py
@@ -59,8 +59,16 @@ def _node_repr_recursive(  # noqa: C901
             fields = [f for f in fields if not _is_whitespace(f)]
         # Filter values which aren't changed from their defaults
         if not show_defaults:
+
+            def _get_default(fld: "dataclasses.Field[object]") -> object:
+                if fld.default_factory is not dataclasses.MISSING:
+                    return fld.default_factory()
+                return fld.default
+
             fields = [
-                f for f in fields if not deep_equals(getattr(node, f.name), f.default)
+                f
+                for f in fields
+                if not deep_equals(getattr(node, f.name), _get_default(f))
             ]
         # Filter out values which aren't interesting if needed
         if not show_syntax:


### PR DESCRIPTION
## Summary

Add test case for uniqueness of resulting tree when parsing. This should be guaranteed by LibCST, and again guaranteed if using metadata by doing a deep copy. The reason for this second copy is that it is completely valid to ask for metadata on a tree that was constructed via a previous traversal, and we don't want to rely on visitors to guarantee uniqueness itself.

Also add a test case for deep_clone, since this was discovered broken. Fix deep_clone in a subsequent commit, as verified by the newly added test.

This fixes https://github.com/Instagram/LibCST/issues/72

## Test Plan

tox