### PR TITLE
Bump pyre version to 0.0.30.

### DIFF
--- a/libcst/_batched_visitor.py
+++ b/libcst/_batched_visitor.py
@@ -124,8 +124,9 @@ class _BatchedCSTVisitor(CSTVisitor):
         """
         Call appropriate visit methods on node before visiting children.
         """
-        if self.before_visit is not None:
-            self.before_visit(node)
+        before_visit = self.before_visit
+        if before_visit is not None:
+            before_visit(node)
         type_name = type(node).__name__
         for v in self.visitor_methods.get(f"visit_{type_name}", []):
             v(node)
@@ -138,5 +139,6 @@ class _BatchedCSTVisitor(CSTVisitor):
         type_name = type(original_node).__name__
         for v in self.visitor_methods.get(f"leave_{type_name}", []):
             v(original_node)
-        if self.after_leave is not None:
-            self.after_leave(original_node)
+        after_leave = self.after_leave
+        if after_leave is not None:
+            after_leave(original_node)

--- a/libcst/_metadata_dependent.py
+++ b/libcst/_metadata_dependent.py
@@ -72,8 +72,8 @@ class MetadataDependent:
             for c in inspect.getmro(cls):
                 if issubclass(c, MetadataDependent):
                     dependencies.update(c.METADATA_DEPENDENCIES)
-            cls._INHERITED_METADATA_DEPENDENCIES_CACHE = frozenset(dependencies)
             # pyre-fixme[16]: use a hidden attribute to cache the property
+            cls._INHERITED_METADATA_DEPENDENCIES_CACHE = frozenset(dependencies)
             return cls._INHERITED_METADATA_DEPENDENCIES_CACHE
 
     @contextmanager

--- a/libcst/_nodes/op.py
+++ b/libcst/_nodes/op.py
@@ -20,13 +20,12 @@ class _BaseOneTokenOp(CSTNode, ABC):
     Any node that has a static value and needs to own whitespace on both sides.
     """
 
-    # pyre-fixme[13]: Uninitialized attribute
     whitespace_before: BaseParenthesizableWhitespace
 
-    # pyre-fixme[13]: Uninitialized attribute
     whitespace_after: BaseParenthesizableWhitespace
 
     def _visit_and_replace_children(self, visitor: CSTVisitorT) -> "_BaseOneTokenOp":
+        # pyre-ignore Pyre thinks that self.__class__ is CSTNode, not _BaseOneTokenOp
         return self.__class__(
             whitespace_before=visit_required(
                 self, "whitespace_before", self.whitespace_before, visitor
@@ -53,13 +52,10 @@ class _BaseTwoTokenOp(CSTNode, ABC):
     in beteween them.
     """
 
-    # pyre-fixme[13]: Uninitialized attribute
     whitespace_before: BaseParenthesizableWhitespace
 
-    # pyre-fixme[13]: Uninitialized attribute
     whitespace_between: BaseParenthesizableWhitespace
 
-    # pyre-fixme[13]: Uninitialized attribute
     whitespace_after: BaseParenthesizableWhitespace
 
     def _validate(self) -> None:
@@ -67,6 +63,7 @@ class _BaseTwoTokenOp(CSTNode, ABC):
             raise CSTValidationError("Must have at least one space between not and in.")
 
     def _visit_and_replace_children(self, visitor: CSTVisitorT) -> "_BaseTwoTokenOp":
+        # pyre-ignore Pyre thinks that self.__class__ is CSTNode, not _BaseTwoTokenOp
         return self.__class__(
             whitespace_before=visit_required(
                 self, "whitespace_before", self.whitespace_before, visitor
@@ -98,10 +95,10 @@ class BaseUnaryOp(CSTNode, ABC):
     """
 
     #: Any space that appears directly after this operator.
-    # pyre-fixme[13]: Uninitialized attribute
     whitespace_after: BaseParenthesizableWhitespace
 
     def _visit_and_replace_children(self, visitor: CSTVisitorT) -> "BaseUnaryOp":
+        # pyre-ignore Pyre thinks that self.__class__ is CSTNode, not BaseUnaryOp
         return self.__class__(
             whitespace_after=visit_required(
                 self, "whitespace_after", self.whitespace_after, visitor

--- a/libcst/_nodes/tests/base.py
+++ b/libcst/_nodes/tests/base.py
@@ -160,11 +160,6 @@ class CSTNodeTest(UnitTest):
         with ExitStack() as patch_stack:
             for t in patch_targets:
                 patch_stack.enter_context(
-                    # pyre-ignore Incompatible parameter type [6]: Expected
-                    # pyre-ignore `typing.ContextManager[Variable[contextlib._T]]`
-                    # pyre-ignore for 1st anonymous parameter to call
-                    # pyre-ignore `contextlib.ExitStack.enter_context` but got
-                    # pyre-ignore `unittest.mock._patch`.
                     patch(f"libcst.{t.name}._codegen", _get_codegen_override(t))
                 )
             # Execute `node._codegen()`

--- a/libcst/_nodes/tests/test_assert.py
+++ b/libcst/_nodes/tests/test_assert.py
@@ -18,7 +18,6 @@ class AssertConstructionTest(CSTNodeTest):
     @data_provider(
         (
             # Simple assert
-            # pyre-fixme[6]: Incompatible parameter type
             {
                 "node": cst.Assert(cst.Name("True")),
                 "code": "assert True",

--- a/libcst/_nodes/tests/test_assign.py
+++ b/libcst/_nodes/tests/test_assign.py
@@ -16,7 +16,6 @@ class AssignTest(CSTNodeTest):
     @data_provider(
         (
             # Simple assignment creation case.
-            # pyre-fixme[6]: Incompatible parameter type
             {
                 "node": cst.Assign(
                     (cst.AssignTarget(cst.Name("foo")),), cst.Integer("5")
@@ -125,7 +124,6 @@ class AnnAssignTest(CSTNodeTest):
     @data_provider(
         (
             # Simple assignment creation case.
-            # pyre-fixme[6]: Incompatible parameter type
             {
                 "node": cst.AnnAssign(
                     cst.Name("foo"), cst.Annotation(cst.Name("str")), cst.Integer("5")
@@ -285,7 +283,6 @@ class AugAssignTest(CSTNodeTest):
     @data_provider(
         (
             # Simple assignment constructor case.
-            # pyre-fixme[6]: Incompatible parameter type
             {
                 "node": cst.AugAssign(
                     cst.Name("foo"), cst.AddAssign(), cst.Integer("5")

--- a/libcst/_nodes/tests/test_atom.py
+++ b/libcst/_nodes/tests/test_atom.py
@@ -17,7 +17,6 @@ class AtomTest(CSTNodeTest):
     @data_provider(
         (
             # Simple identifier
-            # pyre-fixme[6]: Incompatible parameter type
             {
                 "node": cst.Name("test"),
                 "code": "test",
@@ -630,7 +629,6 @@ class AtomTest(CSTNodeTest):
     @data_provider(
         (
             # Expression wrapping parenthesis rules
-            # pyre-fixme[6]: Incompatible parameter type
             {
                 "get_node": (lambda: cst.Name("foo", lpar=(cst.LeftParen(),))),
                 "expected_re": "left paren without right paren",

--- a/libcst/_nodes/tests/test_binary_op.py
+++ b/libcst/_nodes/tests/test_binary_op.py
@@ -16,7 +16,6 @@ class BinaryOperationTest(CSTNodeTest):
     @data_provider(
         (
             # Simple binary operations
-            # pyre-fixme[6]: Incompatible parameter type
             {
                 "node": cst.BinaryOperation(
                     cst.Name("foo"), cst.Add(), cst.Float("5.5")

--- a/libcst/_nodes/tests/test_boolean_op.py
+++ b/libcst/_nodes/tests/test_boolean_op.py
@@ -16,7 +16,6 @@ class BooleanOperationTest(CSTNodeTest):
     @data_provider(
         (
             # Simple boolean operations
-            # pyre-fixme[6]: Incompatible parameter type
             {
                 "node": cst.BooleanOperation(
                     cst.Name("foo"), cst.And(), cst.Name("bar")

--- a/libcst/_nodes/tests/test_call.py
+++ b/libcst/_nodes/tests/test_call.py
@@ -16,7 +16,6 @@ class CallTest(CSTNodeTest):
     @data_provider(
         (
             # Simple call
-            # pyre-fixme[6]: Incompatible parameter type
             {
                 "node": cst.Call(cst.Name("foo")),
                 "code": "foo()",

--- a/libcst/_nodes/tests/test_classdef.py
+++ b/libcst/_nodes/tests/test_classdef.py
@@ -16,7 +16,6 @@ class ClassDefCreationTest(CSTNodeTest):
     @data_provider(
         (
             # Simple classdef
-            # pyre-fixme[6]: Incompatible parameter type
             {
                 "node": cst.ClassDef(
                     cst.Name("Foo"), cst.SimpleStatementSuite((cst.Pass(),))
@@ -153,7 +152,6 @@ class ClassDefParserTest(CSTNodeTest):
     @data_provider(
         (
             # Simple classdef
-            # pyre-fixme[6]: Incompatible parameter type
             {
                 "node": cst.ClassDef(
                     cst.Name("Foo"), cst.SimpleStatementSuite((cst.Pass(),))

--- a/libcst/_nodes/tests/test_funcdef.py
+++ b/libcst/_nodes/tests/test_funcdef.py
@@ -16,7 +16,6 @@ class FunctionDefCreationTest(CSTNodeTest):
     @data_provider(
         (
             # Simple function definition without any arguments or return
-            # pyre-fixme[6]: Incompatible parameter type
             {
                 "node": cst.FunctionDef(
                     cst.Name("foo"),

--- a/libcst/_nodes/tests/test_global.py
+++ b/libcst/_nodes/tests/test_global.py
@@ -17,7 +17,6 @@ class GlobalConstructionTest(CSTNodeTest):
     @data_provider(
         (
             # Single global statement
-            # pyre-fixme[6]: Incompatible parameter type
             {"node": cst.Global((cst.NameItem(cst.Name("a")),)), "code": "global a"},
             # Multiple entries in global statement
             {

--- a/libcst/_nodes/tests/test_if.py
+++ b/libcst/_nodes/tests/test_if.py
@@ -16,7 +16,6 @@ class IfTest(CSTNodeTest):
     @data_provider(
         (
             # Simple if without elif or else
-            # pyre-fixme[6]: Incompatible parameter type
             {
                 "node": cst.If(
                     cst.Name("conditional"), cst.SimpleStatementSuite((cst.Pass(),))

--- a/libcst/_nodes/tests/test_import.py
+++ b/libcst/_nodes/tests/test_import.py
@@ -17,7 +17,6 @@ class ImportCreateTest(CSTNodeTest):
     @data_provider(
         (
             # Simple import statement
-            # pyre-fixme[6]: Incompatible parameter type
             {
                 "node": cst.Import(names=(cst.ImportAlias(cst.Name("foo")),)),
                 "code": "import foo",
@@ -349,7 +348,6 @@ class ImportFromCreateTest(CSTNodeTest):
     @data_provider(
         (
             # Simple from import statement
-            # pyre-fixme[6]: Incompatible parameter type
             {
                 "node": cst.ImportFrom(
                     module=cst.Name("foo"), names=(cst.ImportAlias(cst.Name("bar")),)

--- a/libcst/_nodes/tests/test_nonlocal.py
+++ b/libcst/_nodes/tests/test_nonlocal.py
@@ -17,7 +17,6 @@ class NonlocalConstructionTest(CSTNodeTest):
     @data_provider(
         (
             # Single nonlocal statement
-            # pyre-fixme[6]: Incompatible parameter type
             {
                 "node": cst.Nonlocal((cst.NameItem(cst.Name("a")),)),
                 "code": "nonlocal a",

--- a/libcst/_nodes/tests/test_raise.py
+++ b/libcst/_nodes/tests/test_raise.py
@@ -17,7 +17,6 @@ class RaiseConstructionTest(CSTNodeTest):
     @data_provider(
         (
             # Simple raise
-            # pyre-fixme[6]: Incompatible parameter type
             {"node": cst.Raise(), "code": "raise"},
             # Raise exception
             {

--- a/libcst/_nodes/tests/test_removal_behavior.py
+++ b/libcst/_nodes/tests/test_removal_behavior.py
@@ -41,13 +41,12 @@ class SpecificImportRemovalVisitor(CSTTransformer):
     ) -> Union[cst.Import, cst.ImportFrom, CSTNodeT, RemovalSentinel]:
         if isinstance(updated_node, cst.Import):
             for alias in updated_node.names:
-                if isinstance(alias.name, cst.Name) and alias.name.value == "b":
+                name = alias.name
+                if isinstance(name, cst.Name) and name.value == "b":
                     return RemovalSentinel.REMOVE
         elif isinstance(updated_node, cst.ImportFrom):
-            if (
-                isinstance(updated_node.module, cst.Name)
-                and updated_node.module.value == "e"
-            ):
+            module = updated_node.module
+            if isinstance(module, cst.Name) and module.value == "e":
                 return RemovalSentinel.REMOVE
         return updated_node
 

--- a/libcst/_nodes/tests/test_simple_statement.py
+++ b/libcst/_nodes/tests/test_simple_statement.py
@@ -16,7 +16,6 @@ class SimpleStatementTest(CSTNodeTest):
     @data_provider(
         (
             # a single-element SimpleStatementLine
-            # pyre-fixme[6]: Incompatible parameter type
             {
                 "node": cst.SimpleStatementLine((cst.Pass(),)),
                 "code": "pass\n",

--- a/libcst/_nodes/tests/test_small_statement.py
+++ b/libcst/_nodes/tests/test_small_statement.py
@@ -15,7 +15,6 @@ from libcst.testing.utils import data_provider
 class SmallStatementTest(CSTNodeTest):
     @data_provider(
         (
-            # pyre-fixme[6]: Incompatible parameter type
             {"node": cst.Pass(), "code": "pass"},
             {"node": cst.Pass(semicolon=cst.Semicolon()), "code": "pass;"},
             {

--- a/libcst/_nodes/tests/test_try.py
+++ b/libcst/_nodes/tests/test_try.py
@@ -16,7 +16,6 @@ class TryTest(CSTNodeTest):
     @data_provider(
         (
             # Simple try/except block
-            # pyre-fixme[6]: Incompatible parameter type
             {
                 "node": cst.Try(
                     cst.SimpleStatementSuite((cst.Pass(),)),
@@ -288,7 +287,6 @@ class TryTest(CSTNodeTest):
 
     @data_provider(
         (
-            # pyre-fixme[6]: Incompatible parameter type
             {
                 "get_node": lambda: cst.AsName(cst.Name("")),
                 "expected_re": "empty name identifier",

--- a/libcst/_nodes/tests/test_while.py
+++ b/libcst/_nodes/tests/test_while.py
@@ -16,7 +16,6 @@ class WhileTest(CSTNodeTest):
     @data_provider(
         (
             # Simple while block
-            # pyre-fixme[6]: Incompatible parameter type
             {
                 "node": cst.While(
                     cst.Call(cst.Name("iter")), cst.SimpleStatementSuite((cst.Pass(),))

--- a/libcst/_nodes/whitespace.py
+++ b/libcst/_nodes/whitespace.py
@@ -127,13 +127,15 @@ class Newline(BaseLeaf):
     value: Optional[str] = None
 
     def _validate(self) -> None:
-        if self.value and NEWLINE_RE.fullmatch(self.value) is None:
+        value = self.value
+        if value and NEWLINE_RE.fullmatch(value) is None:
             raise CSTValidationError(
-                f"Got an invalid value for newline node: {repr(self.value)}"
+                f"Got an invalid value for newline node: {repr(value)}"
             )
 
     def _codegen_impl(self, state: CodegenState) -> None:
-        state.add_token(state.default_newline if self.value is None else self.value)
+        value = self.value
+        state.add_token(state.default_newline if value is None else value)
 
 
 @add_slots
@@ -189,8 +191,9 @@ class TrailingWhitespace(CSTNode):
 
     def _codegen_impl(self, state: CodegenState) -> None:
         self.whitespace._codegen(state)
-        if self.comment is not None:
-            self.comment._codegen(state)
+        comment = self.comment
+        if comment is not None:
+            comment._codegen(state)
         self.newline._codegen(state)
 
 
@@ -229,8 +232,9 @@ class EmptyLine(CSTNode):
         if self.indent:
             state.add_indent_tokens()
         self.whitespace._codegen(state)
-        if self.comment is not None:
-            self.comment._codegen(state)
+        comment = self.comment
+        if comment is not None:
+            comment._codegen(state)
         self.newline._codegen(state)
 
 

--- a/libcst/_parser/conversions/expression.py
+++ b/libcst/_parser/conversions/expression.py
@@ -314,6 +314,7 @@ def convert_boolop(
             raise Exception(f"Unexpected token '{op.string}'!")
         leftexpr = BooleanOperation(
             left=leftexpr,
+            # pyre-ignore Pyre thinks that the type of the LUT is CSTNode.
             operator=BOOLOP_TOKEN_LUT[op.string](
                 whitespace_before=parse_parenthesizable_whitespace(
                     config, op.whitespace_before
@@ -381,6 +382,7 @@ def convert_comp_op(
         (op,) = children
         if op.string in COMPOP_TOKEN_LUT:
             # A regular comparison containing one token
+            # pyre-ignore Pyre thinks that the type of the LUT is CSTNode.
             return COMPOP_TOKEN_LUT[op.string](
                 whitespace_before=parse_parenthesizable_whitespace(
                     config, op.whitespace_before
@@ -477,6 +479,7 @@ def convert_binop(
             raise Exception(f"Unexpected token '{op.string}'!")
         leftexpr = BinaryOperation(
             left=leftexpr,
+            # pyre-ignore Pyre thinks that the type of the LUT is CSTNode.
             operator=BINOP_TOKEN_LUT[op.string](
                 whitespace_before=parse_parenthesizable_whitespace(
                     config, op.whitespace_before

--- a/libcst/_parser/conversions/params.py
+++ b/libcst/_parser/conversions/params.py
@@ -78,6 +78,7 @@ def convert_argslist(config: ParserConfig, children: Sequence[Any]) -> Any:
                     "Cannot have multiple star ('*') markers in a single argument "
                     + "list."
                 )
+        # pyre-ignore Pyre seems to think param.star.__eq__ is not callable
         elif isinstance(param.star, str) and param.star == "" and param.default is None:
             # Can only add this if we're in the params or kwonly_params section
             if current_param is params:
@@ -93,6 +94,7 @@ def convert_argslist(config: ParserConfig, children: Sequence[Any]) -> Any:
                 )
         elif (
             isinstance(param.star, str)
+            # pyre-ignore Pyre seems to think param.star.__eq__ is not callable
             and param.star == ""
             and param.default is not None
         ):
@@ -109,7 +111,10 @@ def convert_argslist(config: ParserConfig, children: Sequence[Any]) -> Any:
                 # This should be unreachable, the grammar already disallows it.
                 raise Exception("Cannot have any arguments after a kwargs expansion.")
         elif (
-            isinstance(param.star, str) and param.star == "*" and param.default is None
+            isinstance(param.star, str)
+            # pyre-ignore Pyre seems to think param.star.__eq__ is not callable
+            and param.star == "*"
+            and param.default is None
         ):
             # Can only add this if we're in params/default_params, since
             # we only allow one of "*" or "*param".
@@ -125,7 +130,10 @@ def convert_argslist(config: ParserConfig, children: Sequence[Any]) -> Any:
                     + "argument expansion."
                 )
         elif (
-            isinstance(param.star, str) and param.star == "**" and param.default is None
+            isinstance(param.star, str)
+            # pyre-ignore Pyre seems to think param.star.__eq__ is not callable
+            and param.star == "**"
+            and param.default is None
         ):
             # Can add this in all cases where we don't have a star_kwarg
             # yet.

--- a/libcst/_parser/conversions/statement.py
+++ b/libcst/_parser/conversions/statement.py
@@ -309,6 +309,7 @@ def convert_augassign(config: ParserConfig, children: Sequence[Any]) -> Any:
     if op.string not in AUGOP_TOKEN_LUT:
         raise Exception(f"Unexpected token '{op.string}'!")
     return AugAssignPartial(
+        # pyre-ignore Pyre seems to think that the value of this LUT is CSTNode
         operator=AUGOP_TOKEN_LUT[op.string](
             whitespace_before=parse_simple_whitespace(config, op.whitespace_before),
             whitespace_after=parse_simple_whitespace(config, op.whitespace_after),

--- a/libcst/_parser/parso/pgen2/grammar_parser.py
+++ b/libcst/_parser/parso/pgen2/grammar_parser.py
@@ -59,6 +59,8 @@ class GrammarParser:
                 self._gettoken()
 
             # rule: NAME ':' rhs NEWLINE
+            # pyre-ignore Pyre is unhappy with the fact that we haven't put
+            # _current_rule_name in the constructor.
             self._current_rule_name = self._expect(PythonTokenTypes.NAME)
             self._expect(PythonTokenTypes.OP, ":")
 

--- a/libcst/_parser/production_decorator.py
+++ b/libcst/_parser/production_decorator.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
-from typing import Callable, Iterable, Optional, TypeVar
+from typing import Callable, Optional, Sequence, TypeVar
 
 from libcst._parser.types.conversions import NonterminalConversion
 from libcst._parser.types.production import Production
@@ -44,5 +44,5 @@ def with_production(
     return inner
 
 
-def get_productions(fn: NonterminalConversion) -> Iterable[Production]:
+def get_productions(fn: NonterminalConversion) -> Sequence[Production]:
     return fn.productions

--- a/libcst/_parser/types/config.py
+++ b/libcst/_parser/types/config.py
@@ -26,9 +26,7 @@ class BaseWhitespaceParserConfig(abc.ABC):
     makes calling the whitespace parser in tests with a mocked configuration easier.
     """
 
-    # pyre-fixme[13]: Uninitialized attribute
     lines: Sequence[str]
-    # pyre-fixme[13]: Uninitialized attribute
     default_newline: str
 
 

--- a/libcst/_parser/whitespace_parser.py
+++ b/libcst/_parser/whitespace_parser.py
@@ -48,7 +48,6 @@ def parse_simple_whitespace(
         # continuation character
         state.line += 1
         state.column = 0
-        # pyre-fixme[16]: Optional type has no attribute `group`.
         ws_line = SIMPLE_WHITESPACE_RE.match(lines[state.line - 1], state.column).group(
             0
         )

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -73,6 +73,8 @@ class Assignment(BaseAssignment):
         super().__init__(name, scope)
 
 
+# pyre-ignore Pyre doesn't think that the attributes in the base class are initialized
+# even though we don't override the constructor.
 class BuiltinAssignment(BaseAssignment):
     """
     A BuiltinAssignment represents an value provide by Python as a builtin, including
@@ -187,6 +189,8 @@ class LocalScope(Scope, abc.ABC):
             return self.parent._getitem_from_self_or_parent(name)
 
 
+# pyre-ignore Pyre doesn't think that the attributes in the base class are initialized
+# even though we don't override the constructor.
 class FunctionScope(LocalScope):
     """
     When a function is defined, it creates a FunctionScope.
@@ -195,6 +199,8 @@ class FunctionScope(LocalScope):
     pass
 
 
+# pyre-ignore Pyre doesn't think that the attributes in the base class are initialized
+# even though we don't override the constructor.
 class ClassScope(LocalScope):
     """
     When a class is defined, it creates a ClassScope.
@@ -225,6 +231,8 @@ class ClassScope(LocalScope):
         return self.parent._getitem_from_self_or_parent(name)
 
 
+# pyre-ignore Pyre doesn't think that the attributes in the base class are initialized
+# even though we don't override the constructor.
 class ComprehensionScope(LocalScope):
     """
     Comprehensions and generator expressions create their own scope. For example, in
@@ -269,8 +277,9 @@ class ScopeVisitor(cst.CSTVisitor):
         if not isinstance(names, cst.ImportStar):
             # make sure node.names is Sequence[ImportAlias]
             for name in names:
-                if name.asname is not None:
-                    name_value = cst.ensure_type(name.asname.name, cst.Name).value
+                asname = name.asname
+                if asname is not None:
+                    name_value = cst.ensure_type(asname.name, cst.Name).value
                 else:
                     name_node = name.name
                     while isinstance(name_node, cst.Attribute):
@@ -333,8 +342,9 @@ class ScopeVisitor(cst.CSTVisitor):
 
         for decorator in node.decorators:
             decorator.visit(self)
-        if node.returns:
-            node.returns.visit(self)
+        returns = node.returns
+        if returns:
+            returns.visit(self)
 
         return False
 
@@ -375,8 +385,9 @@ class ScopeVisitor(cst.CSTVisitor):
         return False
 
     def visit_Arg_keyword(self, node: cst.Arg) -> None:
-        if node.keyword is not None:
-            self.scope.record_assignment(node.keyword.value, node)
+        keyword = node.keyword
+        if keyword is not None:
+            self.scope.record_assignment(keyword.value, node)
 
     def visit_ClassDef(self, node: cst.ClassDef) -> Optional[bool]:
         self.scope.record_assignment(node.name.value, node)
@@ -481,8 +492,9 @@ class ScopeVisitor(cst.CSTVisitor):
             for_in.target.visit(self)
             for condition in for_in.ifs:
                 condition.visit(self)
-            if for_in.inner_for_in:
-                for_in.inner_for_in.visit(self)
+            inner_for_in = for_in.inner_for_in
+            if inner_for_in:
+                inner_for_in.visit(self)
             if isinstance(node, cst.DictComp):
                 node.key.visit(self)
                 node.value.visit(self)

--- a/libcst/testing/utils.py
+++ b/libcst/testing/utils.py
@@ -167,6 +167,7 @@ class BaseTestMeta(type):
     def __new__(mcs, name: str, bases: Tuple[type, ...], dct: Dict[str, Any]) -> object:
         validate_provider_tests(dct)
         populate_data_provider_tests(dct)
+        # pyre-ignore Pyre doesn't seem to know about __new__
         return super().__new__(mcs, name, bases, dict(dct))
 
 

--- a/libcst/tests/test_type_enforce.py
+++ b/libcst/tests/test_type_enforce.py
@@ -81,7 +81,7 @@ class TypeEnforcementTest(UnitTest):
             (123, Union[Optional[str], Optional[int]]),
             # Iterables are supported and must match the type covariantly
             ([123], List[int]),
-            ([123], Iterable[int]),
+            ([123], Iterable[int]),  # pyre-ignore This is a type specification
             ([123], Iterable),
             ((123,), Iterable[int]),
             ([123], Sequence[int]),
@@ -182,6 +182,7 @@ class TypeEnforcementTest(UnitTest):
             #   List[ -> means its invariant
             #     MyExampleClass -> has a subclass
             # does not allow List[List[MyExampleChildClass]]
+            # pyre-ignore This is a type specification
             ([[MyExampleChildClass()]], Iterable[List[MyExampleClass]]),
             # Iterables allow subclassing, but sets are not lists and vice versa.
             ([123], Set[int]),
@@ -194,4 +195,5 @@ class TypeEnforcementTest(UnitTest):
 
     def test_not_implemented(self) -> None:
         with self.assertRaises(NotImplementedError):
+            # pyre-ignore Pyre doesn't like the params to AsyncGenerator
             is_value_of_type("something", AsyncGenerator[None, None])

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,6 @@ git+https://github.com/jimmylai/sphinx.git@slots_type_annotation
 isort==4.3.20
 jupyter==1.0.0
 nbsphinx==0.4.2
-pyre-check==0.0.27
+pyre-check==0.0.30
 sphinx-rtd-theme==0.4.3
 prompt-toolkit==1.0.16

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,4 +10,4 @@ jupyter==1.0.0
 nbsphinx==0.4.2
 pyre-check==0.0.30
 sphinx-rtd-theme==0.4.3
-prompt-toolkit==1.0.16
+prompt-toolkit==2.0.9


### PR DESCRIPTION
## Summary

This introduces a few new gotchas (namely attribute access and a bug with
Union[Callable]), but it also removes a whole host of pyre-fixmes and gets us
updated to a release of pyre that came out after May.

## Test Plan

Wait for circle CI. Ran Pyre locally.