### PR TITLE
Clarify license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,27 @@
+All contributions towards LibCST are MIT licensed.
+
+Some Python files have been taken from the standard library and are therefore
+PSF licensed. Modifications on these files are dual licensed (both MIT and
+PSF). These files are:
+
+- libcst/_parser/base_parser.py
+- libcst/_parser/parso/utils.py
+- libcst/_parser/parso/pgen2/generator.py
+- libcst/_parser/parso/pgen2/grammar_parser.py
+- libcst/_parser/parso/python/token.py
+- libcst/_parser/parso/python/tokenize.py
+- libcst/_parser/parso/tests/test_fstring.py
+- libcst/_parser/parso/tests/test_tokenize.py
+- libcst/_parser/parso/tests/test_utils.py
+
+Some Python files have been taken from dataclasses and are therefore Apache
+licensed. Modifications on these files are licensed under Apache 2.0 license.
+These files are:
+
+- libcst/_add_slots.py
+
+-------------------------------------------------------------------------------
+
 MIT License
 
 Copyright (c) Facebook, Inc. and its affiliates.
@@ -19,3 +43,58 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+-------------------------------------------------------------------------------
+
+PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+
+1. This LICENSE AGREEMENT is between the Python Software Foundation
+("PSF"), and the Individual or Organization ("Licensee") accessing and
+otherwise using this software ("Python") in source or binary form and
+its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, PSF hereby
+grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+analyze, test, perform and/or display publicly, prepare derivative works,
+distribute, and otherwise use Python alone or in any derivative version,
+provided, however, that PSF's License Agreement and PSF's notice of copyright,
+i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+2011, 2012, 2013, 2014, 2015 Python Software Foundation; All Rights Reserved"
+are retained in Python alone or in any derivative version prepared by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python.
+
+4. PSF is making Python available to Licensee on an "AS IS"
+basis.  PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any
+relationship of agency, partnership, or joint venture between PSF and
+Licensee.  This License Agreement does not grant permission to use PSF
+trademarks or trade name in a trademark sense to endorse or promote
+products or services of Licensee, or any third party.
+
+8. By copying, installing or otherwise using Python, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.
+
+-------------------------------------------------------------------------------
+
+APACHE LICENSE, VERSION 2.0
+
+http://www.apache.org/licenses/LICENSE-2.0

--- a/README.rst
+++ b/README.rst
@@ -179,6 +179,13 @@ To generate documents, do the following in the root:
 
     tox -e docs
 
+Future
+======
+
+- Extension to Matchers API which incorporates metadata on nodes.
+- Addition to Matchers API which allows for operations such as extract/find/replaceall, similar to the RE module.
+- Additional layer providing command-line frontend for executing refactors.
+
 License
 =======
 

--- a/README.rst
+++ b/README.rst
@@ -183,3 +183,10 @@ License
 =======
 
 LibCST is MIT licensed, as found in the LICENSE file.
+
+Acknowledgements
+================
+
+- Guido van Rossum for creating the parser generator pgen2 (originally used in lib2to3 and forked into parso).
+- David Halter for parso which provides the parser and tokenizer that LibCST sits on top of.
+- Zac Hatfield-Dodds for hypothesis integration which continues to help us find bugs.

--- a/README.rst
+++ b/README.rst
@@ -185,6 +185,7 @@ Future
 - Extension to Matchers API which incorporates metadata on nodes.
 - Addition to Matchers API which allows for operations such as extract/find/replaceall, similar to the RE module.
 - Additional layer providing command-line frontend for executing refactors.
+- More metadata providers from deep static analysis including variable fully qualified name, variable type annotation, etc.
 
 License
 =======


### PR DESCRIPTION
## Summary

Reproduce copyright headers in files that were forked from repositories other than LibCST in the LICENSE file. Add a copy of the PSF license to license file. Add a link to Apache 2.0 license in the license file. Add an acknowledgements section. Add a future section.

## Test Plan

Pushed branch, looked at the rendered readme and license files.