### PR TITLE
consolidate metadata imports

### DIFF
--- a/libcst/metadata/__init__.py
+++ b/libcst/metadata/__init__.py
@@ -5,6 +5,10 @@
 
 # pyre-strict
 
+from libcst.metadata.base_provider import (
+    BatchableMetadataProvider,
+    VisitorMetadataProvider,
+)
 from libcst.metadata.expression_context_provider import (
     ExpressionContext,
     ExpressionContextProvider,
@@ -28,6 +32,7 @@ from libcst.metadata.scope_provider import (
     Scope,
     ScopeProvider,
 )
+from libcst.metadata.wrapper import MetadataWrapper
 
 
 __all__ = [
@@ -48,4 +53,7 @@ __all__ = [
     "ParentNodeProvider",
     "QualifiedName",
     "QualifiedNameSource",
+    "MetadataWrapper",
+    "BatchableMetadataProvider",
+    "VisitorMetadataProvider",
 ]

--- a/libcst/metadata/tests/test_base_provider.py
+++ b/libcst/metadata/tests/test_base_provider.py
@@ -8,12 +8,12 @@ from typing import cast
 
 import libcst as cst
 from libcst import parse_module
-from libcst.metadata.base_provider import (
+from libcst.metadata import (
     BatchableMetadataProvider,
+    MetadataWrapper,
     VisitorMetadataProvider,
-    _gen_batchable,
 )
-from libcst.metadata.wrapper import MetadataWrapper
+from libcst.metadata.base_provider import _gen_batchable
 from libcst.testing.utils import UnitTest
 
 

--- a/libcst/metadata/tests/test_expression_context_provider.py
+++ b/libcst/metadata/tests/test_expression_context_provider.py
@@ -10,11 +10,11 @@ from typing import Dict, Tuple, cast
 import libcst as cst
 from libcst import parse_module
 from libcst._visitors import CSTVisitor
-from libcst.metadata.expression_context_provider import (
+from libcst.metadata import (
     ExpressionContext,
     ExpressionContextProvider,
+    MetadataWrapper,
 )
-from libcst.metadata.wrapper import MetadataWrapper
 from libcst.testing.utils import UnitTest
 
 

--- a/libcst/metadata/tests/test_metadata_provider.py
+++ b/libcst/metadata/tests/test_metadata_provider.py
@@ -10,11 +10,11 @@ import libcst as cst
 from libcst import parse_module
 from libcst._exceptions import MetadataException
 from libcst._visitors import CSTTransformer
-from libcst.metadata.base_provider import (
+from libcst.metadata import (
     BatchableMetadataProvider,
+    MetadataWrapper,
     VisitorMetadataProvider,
 )
-from libcst.metadata.wrapper import MetadataWrapper
 from libcst.testing.utils import UnitTest
 
 

--- a/libcst/metadata/tests/test_parent_node_provider.py
+++ b/libcst/metadata/tests/test_parent_node_provider.py
@@ -8,8 +8,7 @@
 from textwrap import dedent
 
 import libcst as cst
-from libcst.metadata.parent_node_provider import ParentNodeProvider
-from libcst.metadata.wrapper import MetadataWrapper
+from libcst.metadata import MetadataWrapper, ParentNodeProvider
 from libcst.testing.utils import UnitTest, data_provider
 
 

--- a/libcst/metadata/tests/test_position_provider.py
+++ b/libcst/metadata/tests/test_position_provider.py
@@ -8,8 +8,7 @@ import libcst as cst
 from libcst import CodeRange, parse_module
 from libcst._batched_visitor import BatchableCSTVisitor
 from libcst._visitors import CSTTransformer
-from libcst.metadata.position_provider import SyntacticPositionProvider
-from libcst.metadata.wrapper import MetadataWrapper
+from libcst.metadata import MetadataWrapper, SyntacticPositionProvider
 from libcst.testing.utils import UnitTest
 
 

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -10,6 +10,7 @@ from typing import Mapping, Tuple, cast
 
 import libcst as cst
 from libcst import ensure_type
+from libcst.metadata import MetadataWrapper
 from libcst.metadata.scope_provider import (
     Assignment,
     ClassScope,
@@ -21,7 +22,6 @@ from libcst.metadata.scope_provider import (
     Scope,
     ScopeProvider,
 )
-from libcst.metadata.wrapper import MetadataWrapper
 from libcst.testing.utils import UnitTest, data_provider
 
 


### PR DESCRIPTION
## Summary
Consolidate metadata imports. Metadata users should just import needed metadata objects from `libcst.metadata` without remember submodule in libcst.metadata..

## Test Plan

