### PR TITLE
Matchers Documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,6 +19,7 @@ LibCST
    motivation
    tutorial
    Metadata Tutorial <metadata_tutorial>
+   Matchers Tutorial <matchers_tutorial>
    parser
    nodes
    visitors

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,6 +23,7 @@ LibCST
    nodes
    visitors
    metadata
+   matchers
 
 
 Indices and tables

--- a/docs/source/matchers.rst
+++ b/docs/source/matchers.rst
@@ -1,0 +1,159 @@
+.. _libcst-matchers:
+
+========
+Matchers
+========
+
+Matchers are provided as a way of asking whether a particular LibCST node and its
+children match the a particular shape. It is possible to write a visitor that
+tracks attributes using ``visit_<Node>`` methods. It is also possible to implement
+manual instance checking and traversal of a node's children. However, both are
+cumbersome to write and hard to understand. Matchers offer a more concise way of
+defining what attributes on a node matter when matching against predefined patterns.
+
+To accomplish this, a matcher has been created which corresponds to each LibCST
+node documented in :ref:`libcst-nodes`. Matchers default each of their attributes
+to the special sentinal matcher :func:`~libcst.matchers.DoNotCare`. When constructing
+a matcher, you can initialize the node with only the values of attributes that
+you are concerned with, leaving the rest of the attributes set to
+:func:`~libcst.matchers.DoNotCare` in order to skip comparing against them.
+
+------------
+Matcher APIs
+------------
+
+Functions
+^^^^^^^^^
+
+Matchers can be used either by calling :func:`~libcst.matchers.matches` directly,
+usually in an ``if`` statement, or by using various decorators to selectively control
+when LibCST calls visitor functions.
+
+.. autofunction:: libcst.matchers.matches
+
+Decorators
+^^^^^^^^^^
+
+The following decorators can be placed onto a method in a visitor or transformer
+in order to convert it into a visitor which is called when the provided matcher is
+true.
+
+.. autofunction:: libcst.matchers.visit
+.. autofunction:: libcst.matchers.leave
+
+The following decorators can be placed onto any existing ``visit_<Node>`` or
+``leave_<Node>`` visitor, as well as any visitor created using either
+:func:`~libcst.matchers.visit` or :func:`~libcst.matchers.leave`. They control
+whether the visitor itself gets called or skipped by LibCST when traversing a tree.
+Note that when a visitor function is skipped, its children will still be visited
+based on the rules set forth in :ref:`libcst-visitors`. Namely, if you have a separate
+``visit_<Node>`` visitor that returns ``False`` for a particular node, we will not
+traverse to its children.
+
+.. autofunction:: libcst.matchers.call_if_inside
+.. autofunction:: libcst.matchers.call_if_not_inside
+
+When using matcher decorators, your visitors must subclass from
+:class:`~libcst.matchers.MatcherDecoratableVisitor` instead of :class:`libcst.CSTVisitor`,
+and from :class:`~libcst.matchers.MatcherDecoratableTransformer` instead of
+:class:`libcst.CSTTransformer`. This is so that visitors and transformers not making
+use of matcher decorators do not pay the extra cost of their implementation. Note that
+if you do not subclass from :class:`~libcst.matchers.MatcherDecoratableVisitor` or
+:class:`~libcst.matchers.MatcherDecoratableTransformer`, you can still use the
+:func:`~libcst.matchers.matches` function.
+
+Both of these classes are strict subclasses of their corresponding LibCST base class,
+so they can be used anywhere that expects a LibCST base class. See :ref:`libcst-visitors`
+for more information.
+
+.. autoclass:: libcst.matchers.MatcherDecoratableVisitor
+.. autoclass:: libcst.matchers.MatcherDecoratableTransformer
+
+Traversal Order
+^^^^^^^^^^^^^^^
+
+Visit and leave functions created using :func:`~libcst.matchers.visit` or
+:func:`~libcst.matchers.leave` follow the traveral order rules laid out in
+LibCST's visitor :ref:`libcst-visitor-traversal` with one additional rule. Any
+visit function created using the :func:`~libcst.matchers.visit` decorator will be
+called **before** a ``visit_<Node>`` function if it is defined for your visitor.
+The order in which various visit functions which are created with
+:func:`~libcst.matchers.visit` are called is indeterminate, but all such functions
+will be called before calling the ``visit_<Node>`` method. Similarly, any leave
+function created using the :func:`~libcst.matchers.leave` decorator will be called
+**after** a ``leave_<Node>`` function if it is defined for your visitor. The order
+in which various leave functions which are created with
+:func:`~libcst.matchers.leave` are called is indeterminate, but all such functions
+will be called after calling the ``visit_<Node>`` function if it is defined for
+your visitor.
+
+This has a few implications. The first is that if you return ``False`` from a
+``visit_<Node>`` method, we are guaranteed to call your decorated visit functions
+as well. Second, when modifying a node in both ``leave_<Node>`` and a visitor
+created with :func:`~libcst.matchers.leave`, the ``original_node`` will be unchanged
+for both and the ``updated_node`` available to the decorated leave method will be
+the node that is returned by the ``leave_<Node>`` method. Chaining modifications
+across multiple leave functions is supported, but must be done with care.
+
+-------------
+Matcher Types
+-------------
+
+Concrete Matchers
+^^^^^^^^^^^^^^^^^
+
+For each node found in :ref:`libcst-nodes`, a corresponding concrete matcher
+has been generated. Each matcher has attributes identical to its LibCST node
+counterpart. For example, :class:`libcst.Expr` includes the ``value`` and ``semicolon``
+attributes, and therefore :class:`libcst.matchers.Expr` similarly includes the same
+attributes. Just as :class:`libcst.Expr`'s ``value`` is typed as taking a
+:class:`libcst.BaseExpression`, :class:`libcst.matchers.Expr`'s ``value`` is typed
+as taking a :class:`libcst.matchers.BaseExpression`. For every node that exists in
+LibCST, both concrete and abstract, a corresponding matcher has been defined.
+
+There are a few special cases to the rules laid out above. For starters, matchers
+don't support evaluating :class:`~libcst.MaybeSentinel`. There is no way to specify
+that you wish to match against a :class:`~libcst.MaybeSentinel` except with the
+:func:`~libcst.matchers.DoNotCare` matcher. This tends not to be an issue in
+practice because :class:`~libcst.MaybeSentinel` is only found on syntax nodes.
+
+While there are base classes such as :class:`libcst.matchers.BaseExpression`, you
+cannot match directly on them. They are provided for typing purposes only in order
+to exactly match the types on LibCST node attributes. If you need to match on
+all concrete subclasses of a base class, we recommend using the special matcher
+:class:`~libcst.matchers.OneOf`.
+
+.. autoclass:: libcst.matchers.BaseMatcherNode
+
+Special Matchers
+^^^^^^^^^^^^^^^^
+
+Special matchers are matchers that don't have a corresponding LibCST node. Concrete
+matchers only match against their corresponding LibCST node, limiting their use
+under certain circumstances. Special matchers fill in the gap by allowing
+higher-level logic constructs such as inversion. You can use any special matcher
+in place of a concrete matcher when specifying matcher attributes. Additionally,
+you can also use the :class:`~libcst.matchers.AllOf` and
+:class:`~libcst.matchers.OneOf` special matchers in place of a concrete matcher
+when calling :func:`~libcst.matchers.matches` or using decorators.
+
+.. autoclass:: libcst.matchers.OneOf
+.. autoclass:: libcst.matchers.AllOf
+.. autofunction:: libcst.matchers.DoesNotMatch
+.. autoclass:: libcst.matchers.MatchIfTrue
+.. autofunction:: libcst.matchers.MatchRegex
+.. autofunction:: libcst.matchers.DoNotCare
+
+Sequence Wildcard Matchers
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Sequence wildcard matchers are matchers that only get used when constructing a
+sequence to match against. Not all LibCST nodes have attributes which are sequences,
+but for those that do, sequence wildcard matchers offer a great degree of
+flexibility. Unlike all other matcher types, these allow you to match against
+more than one LibCST node, much like wildcards in regular expressions do.
+
+.. autoclass:: libcst.matchers.AtLeastN
+.. autofunction:: libcst.matchers.ZeroOrMore
+.. autoclass:: libcst.matchers.AtMostN
+.. autofunction:: libcst.matchers.ZeroOrOne

--- a/docs/source/matchers.rst
+++ b/docs/source/matchers.rst
@@ -31,6 +31,8 @@ when LibCST calls visitor functions.
 
 .. autofunction:: libcst.matchers.matches
 
+.. _libcst-matcher-decorators:
+
 Decorators
 ^^^^^^^^^^
 

--- a/docs/source/matchers_tutorial.ipynb
+++ b/docs/source/matchers_tutorial.ipynb
@@ -1,0 +1,428 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "=====================\n",
+    "Working with Matchers\n",
+    "=====================\n",
+    "Matchers provide a flexible way of comparing LibCST nodes in order to build ",
+    "more complex transforms. See :doc:`Matchers <matchers>` for the complete ",
+    "documentation.\n",
+    "\n",
+    "Basic Matcher Usage\n",
+    "===================\n",
+    "Let's say you are visiting a LibCST :class:`~libcst.Call` node and you want ",
+    "to know if all arguments provided are the literal ``True`` or ``False``. ",
+    "You look at the documentation and see that ``Call.args`` is a sequence of ",
+    ":class:`~libcst.Arg`, and each ``Arg.value`` is a :class:`~libcst.BaseExpression`. ",
+    "In order to verify that each argument is either ``True`` or ``False`` you ",
+    "would have to first loop over ``node.args``, and then check ",
+    "``isinstance(arg.value, cst.Name)`` for each ``arg`` in the loop before ",
+    "finally checking ``arg.value.value in (\"True\", \"False\")``. \n",
+    "\n",
+    "Here's a short example of that in action:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append(\"../../\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import libcst as cst\n",
+    "\n",
+    "def is_call_with_booleans(node: cst.Call) -> bool:\n",
+    "    for arg in node.args:\n",
+    "        if not isinstance(arg.value, cst.Name):\n",
+    "            # This can't be the literal True/False, so bail early.\n",
+    "            return False\n",
+    "        if cst.ensure_type(arg.value, cst.Name).value not in (\"True\", \"False\"):\n",
+    "            # This is a Name node, but not the literal True/False, so bail.\n",
+    "            return False\n",
+    "    # We got here, so all arguments are literal boolean values.\n",
+    "    return True\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "We can see from a few examples that this does work as intended. ",
+    "However, it is an awful lot of boilerplate that was fairly cumbersome to write.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "call_1 = cst.Call(\n",
+    "    func=cst.Name(\"foo\"),\n",
+    "    args=(\n",
+    "        cst.Arg(cst.Name(\"True\")),\n",
+    "    ),\n",
+    ")\n",
+    "is_call_with_booleans(call_1)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "call_2 = cst.Call(\n",
+    "    func=cst.Name(\"foo\"),\n",
+    "    args=(\n",
+    "        cst.Arg(cst.Name(\"None\")),\n",
+    "    ),\n",
+    ")\n",
+    "is_call_with_booleans(call_2)\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "Let's try to do a bit better with matchers. We can make a better function ",
+    "that takes advantage of matchers to get rid of both the instance check and ",
+    "the ``ensure_type`` call, like so:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import libcst.matchers as m\n",
+    "\n",
+    "def better_is_call_with_booleans(node: cst.Call) -> bool:\n",
+    "    for arg in node.args:\n",
+    "        if not m.matches(arg.value, m.Name(\"True\") | m.Name(\"False\")):\n",
+    "            # Oops, this isn't a True/False literal!\n",
+    "            return False\n",
+    "    # We got here, so all arguments are literal boolean values.\n",
+    "    return True\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "This is a lot shorter and is easier to read as well! We made use of the ",
+    "fact that matchers handles instance checking for us in a safe way. We also ",
+    "made use of the fact that matchers allows us to concisely express multiple ",
+    "match options with the use of Python's or operator. We can also see that ",
+    "it still works on our previous examples:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "better_is_call_with_booleans(call_1)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "better_is_call_with_booleans(call_2)\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "We still have one more trick up our sleeve though. Matchers don't just ",
+    "allow us to specify which attributes we want to match on exactly. It ",
+    "also allows us to specify rules for matching sequences of nodes, like ",
+    "the list of :class:`~libcst.Arg` nodes that appears in :class:`~libcst.Call`. ",
+    "Let's make use of that, turning our original ``is_call_with_booleans`` ",
+    "function into a call to :func:`~libcst.matchers.matches`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def best_is_call_with_booleans(node: cst.Call) -> bool:\n",
+    "    return m.matches(\n",
+    "        node,\n",
+    "        m.Call(\n",
+    "            args=(\n",
+    "                m.ZeroOrMore(m.Arg(m.Name(\"True\") | m.Name(\"False\"))),\n",
+    "            ),\n",
+    "        ),\n",
+    "    )\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "We've turned our original function into a single call to ",
+    ":func:`~libcst.matchers.matches`. As an added benefit, the match node can ",
+    "be read from left to right in a way that makes sense in english: \"match ",
+    "any call with zero or more arguments that are the literal ``True`` or ",
+    "``False``\". As we can see, it works as intended: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "best_is_call_with_booleans(call_1)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "best_is_call_with_booleans(call_2)\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "Matcher Decorators\n",
+    "==================\n",
+    "You can already do a lot with just :func:`~libcst.matchers.matches`. It ",
+    "lets you define the shape of nodes you want to match and LibCST takes ",
+    "care of the rest. However, you still need to include a lot of boilerplate ",
+    "into your :ref:`libcst-visitors` in order to identify which nodes you care ",
+    "about. Matcher :ref:`libcst-matcher-decorators` help reduce that boilerplate.\n",
+    "\n",
+    "Say you wanted to invert the the boolean literals in functions which ",
+    "match the above ``best_is_call_with_booleans``. You could build something ",
+    "that looks like the following:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class BoolInverter(cst.CSTTransformer):\n",
+    "    def __init__(self) -> None:\n",
+    "        self.in_call: int = 0\n",
+    "\n",
+    "    def visit_Call(self, node: cst.Call) -> None:\n",
+    "        if m.matches(node, m.Call(args=(\n",
+    "            m.ZeroOrMore(m.Arg(m.Name(\"True\") | m.Name(\"False\"))),\n",
+    "        ))):\n",
+    "            self.in_call += 1\n",
+    "\n",
+    "    def leave_Call(self, original_node: cst.Call, updated_node: cst.Call) -> cst.Call:\n",
+    "        if m.matches(original_node, m.Call(args=(\n",
+    "            m.ZeroOrMore(m.Arg(m.Name(\"True\") | m.Name(\"False\"))),\n",
+    "        ))):\n",
+    "            self.in_call -= 1\n",
+    "        return updated_node\n",
+    "\n",
+    "    def leave_Name(self, original_node: cst.Name, updated_node: cst.Name) -> cst.Name:\n",
+    "        if self.in_call > 0:\n",
+    "            if updated_node.value == \"True\":\n",
+    "                return updated_node.with_changes(value=\"False\")\n",
+    "            if updated_node.value == \"False\":\n",
+    "                return updated_node.with_changes(value=\"True\")\n",
+    "        return updated_node\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "We can try it out on a source file to see that it works:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source = \"def some_func(*params: object) -> None:\\n    pass\\n\\nsome_func(True, False)\\nsome_func(1, 2, 3)\\nsome_func()\\n\"\n",
+    "module = cst.parse_module(source)\n",
+    "print(source)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_module = module.visit(BoolInverter())\n",
+    "print(new_module.code)\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "While this works its not super elegant. We have to track where we are in ",
+    "the tree so we know when its safe to invert boolean literals which means ",
+    "we have to create a constructor and we have to duplicate matching logic. ",
+    "We could refactor that into a helper like the ``best_is_call_with_booleans`` ",
+    "above, but it only makes things so much better.\n",
+    "\n",
+    "So, let's try rewriting it with matcher decorators instead. Note that this ",
+    "includes changing the class we inherit from to ",
+    ":class:`~libcst.matchers.MatcherDecoratableTransformer` in order to enable ",
+    "the matcher decorator feature:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class BetterBoolInverter(m.MatcherDecoratableTransformer):\n",
+    "    @m.call_if_inside(m.Call(args=(\n",
+    "        m.ZeroOrMore(m.Arg(m.Name(\"True\") | m.Name(\"False\"))),\n",
+    "    )))\n",
+    "    def leave_Name(self, original_node: cst.Name, updated_node: cst.Name) -> cst.Name:\n",
+    "        if updated_node.value == \"True\":\n",
+    "            return updated_node.with_changes(value=\"False\")\n",
+    "        if updated_node.value == \"False\":\n",
+    "            return updated_node.with_changes(value=\"True\")\n",
+    "        return updated_node\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_module = module.visit(BetterBoolInverter())\n",
+    "print(new_module.code)\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "Using matcher decorators we successfully removed all of the boilerplate ",
+    "around state tracking! The only thing that ``leave_Name`` needs to concern ",
+    "itself with is the actual business logic of the transform. However, it ",
+    "still needs to check to see if the value of the node should be inverted. ",
+    "This is because the ``Call.func`` is a :class:`~libcst.Name` in this case. ",
+    "Let's use another matcher decorator to make that problem go away:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class BestBoolInverter(m.MatcherDecoratableTransformer):\n",
+    "    @m.call_if_inside(m.Call(args=(\n",
+    "        m.ZeroOrMore(m.Arg(m.Name(\"True\") | m.Name(\"False\"))),\n",
+    "    )))\n",
+    "    @m.leave(m.Name(\"True\") | m.Name(\"False\"))\n",
+    "    def invert_bool_literal(self, original_node: cst.Name, updated_node: cst.Name) -> cst.Name:\n",
+    "        return updated_node.with_changes(value=\"False\" if updated_node.value == \"True\" else \"True\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_module = module.visit(BestBoolInverter())\n",
+    "print(new_module.code)\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "That's it! Instead of using a ``leave_Name`` which modifies all ",
+    ":class:`~libcst.Name` nodes we instead created a matcher visitor that ",
+    "only modifies :class:`~libcst.Name` nodes with the value of ``True`` or ",
+    "``False``. We decorate *that* with :func:`~libcst.matchers.call_if_inside` ",
+    "to ensure we run this on :class:`~libcst.Name` nodes found inside of ",
+    "function calls that only take boolean literals. Using two matcher ",
+    "decorators we got rid of all of the state management as well as all of the ",
+    "cases where we needed to handle nodes we weren't interested in."
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Edit Metadata",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/source/nodes.rst
+++ b/docs/source/nodes.rst
@@ -1,3 +1,5 @@
+.. _libcst-nodes:
+
 Nodes
 =====
 

--- a/docs/source/visitors.rst
+++ b/docs/source/visitors.rst
@@ -1,3 +1,5 @@
+.. _libcst-visitors:
+
 Visitors
 ========
 
@@ -47,6 +49,8 @@ An example Python REPL using the above visitor is as follows::
     >>> _ = demo.visit(FooingAround())
     'abc'
     '123'
+
+.. _libcst-visitor-traversal:
 
 Traversal Order
 ---------------

--- a/libcst/_nodes/base.py
+++ b/libcst/_nodes/base.py
@@ -275,12 +275,12 @@ class CSTNode(ABC):
 
         For example, to update the test of an if conditional, you could do::
 
-            def leave_If(self, old_node: cst.If) -> cst.If:
-                new_node = old_node.with_changes(test=new_conditional)
+            def leave_If(self, original_node: cst.If, updated_node: cst.If) -> cst.If:
+                new_node = updated_node.with_changes(test=new_conditional)
                 return new_node
 
         ``new_node`` will have the same ``body``, ``orelse``, and whitespace fields as
-        ``old_node``, but with the updated ``test`` field.
+        ``updated_node``, but with the updated ``test`` field.
 
         The accepted arguments match the arguments given to ``__init__``, however there
         are no required or positional arguments.
@@ -290,6 +290,18 @@ class CSTNode(ABC):
         similar API in the future.
         """
         return replace(self, **changes)
+
+    def remove(self) -> RemovalSentinel:
+        """
+        A convenience method for requesting that this node be removed by its parent.
+        Use this in place of returning :class:`RemovalSentinel` directly.
+
+        For example, to remove all arguments unconditionally::
+
+            def leave_Arg(self, original_node: cst.Arg, updated_node: cst.Arg) -> Union[cst.Arg, cst.RemovalSentinel]:
+                return updated_node.remove()
+        """
+        return RemovalSentinel.REMOVE
 
     def deep_clone(self: _CSTNodeSelfT) -> _CSTNodeSelfT:
         """

--- a/libcst/_nodes/tests/test_removal_behavior.py
+++ b/libcst/_nodes/tests/test_removal_behavior.py
@@ -20,7 +20,7 @@ class IfStatementRemovalVisitor(CSTTransformer):
         self, original_node: CSTNodeT, updated_node: CSTNodeT
     ) -> Union[CSTNodeT, RemovalSentinel]:
         if isinstance(updated_node, cst.If):
-            return RemovalSentinel.REMOVE
+            return updated_node.remove()
         else:
             return updated_node
 
@@ -30,7 +30,7 @@ class ContinueStatementRemovalVisitor(CSTTransformer):
         self, original_node: CSTNodeT, updated_node: CSTNodeT
     ) -> Union[CSTNodeT, RemovalSentinel]:
         if isinstance(updated_node, cst.Continue):
-            return RemovalSentinel.REMOVE
+            return updated_node.remove()
         else:
             return updated_node
 
@@ -43,11 +43,11 @@ class SpecificImportRemovalVisitor(CSTTransformer):
             for alias in updated_node.names:
                 name = alias.name
                 if isinstance(name, cst.Name) and name.value == "b":
-                    return RemovalSentinel.REMOVE
+                    return updated_node.remove()
         elif isinstance(updated_node, cst.ImportFrom):
             module = updated_node.module
             if isinstance(module, cst.Name) and module.value == "e":
-                return RemovalSentinel.REMOVE
+                return updated_node.remove()
         return updated_node
 
 

--- a/libcst/_removal_sentinel.py
+++ b/libcst/_removal_sentinel.py
@@ -16,7 +16,8 @@ class RemovalSentinel(Enum):
     """
     A :attr:`RemovalSentinel.REMOVE` value should be returned by a
     :meth:`CSTTransformer.on_leave` method when we want to remove that child from its
-    parent.
+    parent. As a convenience, this can be constructed given a CSTNode by calling
+    ``node.remove()``.
 
     The parent node should make a best-effort to remove the child, but may raise an
     exception when removing the child doesn't make sense, or could change the semantics

--- a/libcst/_visitors.py
+++ b/libcst/_visitors.py
@@ -64,7 +64,8 @@ class CSTTransformer(CSTTypedTransformerFunctions, MetadataDependent):
 
         Returning :attr:`RemovalSentinel.REMOVE` indicates that the node should be
         removed from its parent. This is not always possible, and may raise an
-        exception if this node is required.
+        exception if this node is required. As a convenience, you can use
+        ``updated_node.remove()`` as an alias to :attr:`RemovalSentinel.REMOVE`.
         """
         leave_func = getattr(self, f"leave_{type(original_node).__name__}", None)
         if leave_func is not None:

--- a/libcst/codegen/gen_matcher_classes.py
+++ b/libcst/codegen/gen_matcher_classes.py
@@ -96,7 +96,7 @@ class CleanseFullTypeNames(cst.CSTTransformer):
             if isinstance(val, cst.Name):
                 if "Sentinel" in val.value:
                     # We don't support maybes in matchers.
-                    return cst.RemovalSentinel.REMOVE
+                    return updated_node.remove()
         # Simple trick to kill trailing commas
         return updated_node.with_changes(comma=cst.MaybeSentinel.DEFAULT)
 
@@ -121,7 +121,7 @@ class RemoveDoNotCareFromGeneric(cst.CSTTransformer):
             if isinstance(val, cst.Name):
                 if val.value == "DoNotCareSentinel":
                     # We don't support maybes in matchers.
-                    return cst.RemovalSentinel.REMOVE
+                    return updated_node.remove()
         return updated_node
 
     def leave_Subscript(

--- a/libcst/matchers/_decorators.py
+++ b/libcst/matchers/_decorators.py
@@ -22,12 +22,12 @@ def call_if_inside(
     matcher: BaseMatcherNode
 ) -> Callable[[_CSTVisitFuncT], _CSTVisitFuncT]:
     """
-    A decorator for visit and leave methods inside a :class:`CMFTransformVisitor`
-    or a :class:`CMFCollectVisitor`. A method that is decorated with this decorator
+    A decorator for visit and leave methods inside a :class:`MatcherDecoratableTransformer`
+    or a :class:`MatcherDecoratableVisitor`. A method that is decorated with this decorator
     will only be called if it or one of its parents matches the supplied matcher.
     Use this to selectively gate visit and leave methods to be called only when
     inside of another relevant node. Note that this works for both node and attribute
-    methods.
+    methods, so you can decorate a ``visit_<Node>`` or a ``visit_<Node>_<Attr>`` method.
     """
 
     def inner(original: _CSTVisitFuncT) -> _CSTVisitFuncT:
@@ -47,12 +47,13 @@ def call_if_not_inside(
     matcher: BaseMatcherNode
 ) -> Callable[[_CSTVisitFuncT], _CSTVisitFuncT]:
     """
-    A decorator for visit and leave methods inside a :class:`CMFTransformVisitor`
-    or a :class:`CMFCollectVisitor`. A method that is decorated with this decorator
+    A decorator for visit and leave methods inside a :class:`MatcherDecoratableTransformer`
+    or a :class:`MatcherDecoratableVisitor`. A method that is decorated with this decorator
     will only be called if it or one of its parents does not match the supplied
     matcher. Use this to selectively gate visit and leave methods to be called only
     when outside of another relevant node. Note that this works for both node and
-    attribute methods.
+    attribute methods, so you can decorate a ``visit_<Node>`` or a ``visit_<Node>_<Attr>``
+    method.
     """
 
     def inner(original: _CSTVisitFuncT) -> _CSTVisitFuncT:
@@ -74,14 +75,15 @@ def visit(matcher: BaseMatcherNode) -> Callable[[_CSTVisitFuncT], _CSTVisitFuncT
     or a :class:`MatcherDecoratableVisitor` visitor to be called when visiting a node
     that matches the provided matcher. Note that you can use this in combination with
     :func:`call_if_inside` and :func:`call_if_not_inside` decorators. Unlike explicit
-    visit_* and leave_* methods, functions decorated with this decorator cannot stop
-    child traversal by returning ``False``.
+    ``visit_<Node>`` and ``leave_<Node>`` methods, functions decorated with this
+    decorator cannot stop child traversal by returning ``False``. Decorated visit
+    functions should always have a return annotation of ``None``.
 
     There is no restriction on the number of visit decorators allowed on a method.
     There is also no restriction on the number of methods that may be decorated
     with the same matcher. When multiple visit decorators are found on the same
     method, they act as a simple or, and the method will be called when any one
-    of the contained matches is True.
+    of the contained matches is ``True``.
     """
 
     def inner(original: _CSTVisitFuncT) -> _CSTVisitFuncT:
@@ -108,7 +110,7 @@ def leave(matcher: BaseMatcherNode) -> Callable[[_CSTVisitFuncT], _CSTVisitFuncT
     There is also no restriction on the number of methods that may be decorated
     with the same matcher. When multiple leave decorators are found on the same
     method, they act as a simple or, and the method will be called when any one
-    of the contained matches is True.
+    of the contained matches is ``True``.
     """
 
     def inner(original: _CSTVisitFuncT) -> _CSTVisitFuncT:

--- a/libcst/matchers/_visitors.py
+++ b/libcst/matchers/_visitors.py
@@ -244,9 +244,6 @@ def _gather_matchers(obj: object) -> Set[BaseMatcherNode]:
     visit_matchers: Set[BaseMatcherNode] = set()
 
     for func in dir(obj):
-        if not func.startswith("visit_") and not func.startswith("leave_"):
-            continue
-
         try:
             for matcher in getattr(getattr(obj, func), VISIT_POSITIVE_MATCHER_ATTR, []):
                 visit_matchers.add(cast(BaseMatcherNode, matcher))

--- a/libcst/matchers/_visitors.py
+++ b/libcst/matchers/_visitors.py
@@ -288,7 +288,7 @@ def _gather_constructed_visit_funcs(
 
 # pyre-ignore: There is no reasonable way to type this, so ignore the Any type. This
 # is because the leave_* methods have a different signature depending on whether they
-# are in a CMFTransformVisitor or a CMFCollectVisitor.
+# are in a MatcherDecoratableTransformer or a MatcherDecoratableVisitor.
 def _gather_constructed_leave_funcs(
     obj: object
 ) -> Dict[BaseMatcherNode, Sequence[Callable[..., Any]]]:
@@ -388,10 +388,10 @@ def _visit_constructed_funcs(
 
 class MatcherDecoratableTransformer(CSTTransformer):
     """
-    This class provides all of the features of a :class:`CSTTransformer`, and additionally
-    supports various decorators to control when methods get called when traversing a
-    tree. Use this instead of a :class:`CSTTransformer` if you wish to do more powerful
-    decorator-based visiting.
+    This class provides all of the features of a :class:`libcst.CSTTransformer`, and
+    additionally supports various decorators to control when methods get called when
+    traversing a tree. Use this instead of a :class:`libcst.CSTTransformer` if you
+    wish to do more powerful decorator-based visiting.
     """
 
     def __init__(self) -> None:
@@ -509,10 +509,10 @@ class MatcherDecoratableTransformer(CSTTransformer):
 
 class MatcherDecoratableVisitor(CSTVisitor):
     """
-    This class provides all of the features of a :class:`CSTVisitor`, and additionally
-    supports various decorators to control when methods get called when traversing a
-    tree. Use this instead of a :class:`CSTVisitor` if you wish to do more powerful
-    decorator-based visiting.
+    This class provides all of the features of a :class:`libcst.CSTVisitor`, and
+    additionally supports various decorators to control when methods get called
+    when traversing a tree. Use this instead of a :class:`libcst.CSTVisitor` if
+    you wish to do more powerful decorator-based visiting.
     """
 
     def __init__(self) -> None:

--- a/libcst/matchers/tests/test_decorators.py
+++ b/libcst/matchers/tests/test_decorators.py
@@ -25,7 +25,7 @@ def fixture(code: str) -> cst.Module:
     return cst.parse_module(dedent(code))
 
 
-class CMFGatingDecoratorsTest(UnitTest):
+class MatchersGatingDecoratorsTest(UnitTest):
 
     ONCALL_SHORTNAME = "instagram_server_framework"
 
@@ -378,7 +378,7 @@ class CMFGatingDecoratorsTest(UnitTest):
         self.assertEqual(visitor.str_visits, ['"foo"', '"bar"', '"foobar"'])
 
 
-class CMFVisitLeaveDecoratorsTest(UnitTest):
+class MatchersVisitLeaveDecoratorsTest(UnitTest):
 
     ONCALL_SHORTNAME = "instagram_server_framework"
 

--- a/libcst/matchers/tests/test_matchers.py
+++ b/libcst/matchers/tests/test_matchers.py
@@ -10,7 +10,7 @@ from libcst.matchers import matches
 from libcst.testing.utils import UnitTest
 
 
-class CMFMatcherTest(UnitTest):
+class MatchersMatcherTest(UnitTest):
 
     ONCALL_SHORTNAME = "instagram_server_framework"
 

--- a/libcst/matchers/tests/test_visitors.py
+++ b/libcst/matchers/tests/test_visitors.py
@@ -18,7 +18,7 @@ from libcst.matchers import (
 from libcst.testing.utils import UnitTest
 
 
-class CMFVisitLeaveDecoratorTypingTest(UnitTest):
+class MatchersVisitLeaveDecoratorTypingTest(UnitTest):
 
     ONCALL_SHORTNAME = "instagram_server_framework"
 

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -689,7 +689,7 @@ class ScopeVisitor(cst.CSTVisitor):
 
 class ScopeProvider(BatchableMetadataProvider[Optional[Scope]]):
     """
-     ScopeProvider traverses the entire module and creates the scope inheritance
+    :class:`ScopeProvider` traverses the entire module and creates the scope inheritance
     structure. It provides the scope of name assignment and accesses. It is useful for
     more advanced static analysis. E.g. given a :class:`~libcst.FunctionDef`
     node, we can check the type of its Scope to figure out whether it is a class method


### PR DESCRIPTION
## Summary

As promised, this is the documentation for matchers. Included in this is documentation on how to use matchers, as well as a tutorial to help get started and show off various concepts. Also, I was naughty and snuck in two things: 1) A fix to a warning when generating docs. 2) Fixed matchers being incapable of combining @call and @visit/@leave even though it was designed to do so. Those are at least kept in separate commits.

## Test Plan

tox, also look at the generated docs by CI (the pages are far too big to screenshot here).