### PR TITLE
Add deep_remove and RemoveFromParent() to LibCST.

### DIFF
--- a/docs/source/visitors.rst
+++ b/docs/source/visitors.rst
@@ -5,6 +5,7 @@ Visitors
 
 .. autoclass:: libcst.CSTVisitor
 .. autoclass:: libcst.CSTTransformer
+.. autofunction:: libcst.RemoveFromParent
 .. autoclass:: libcst.RemovalSentinel
 
 Visit and Leave Helper Functions

--- a/libcst/__init__.py
+++ b/libcst/__init__.py
@@ -185,7 +185,7 @@ from libcst._nodes.whitespace import (
 )
 from libcst._parser.entrypoints import parse_expression, parse_module, parse_statement
 from libcst._parser.types.config import PartialParserConfig
-from libcst._removal_sentinel import RemovalSentinel
+from libcst._removal_sentinel import RemovalSentinel, RemoveFromParent
 from libcst._visitors import CSTNodeT, CSTTransformer, CSTVisitor, CSTVisitorT
 from libcst.metadata.base_provider import (
     BaseMetadataProvider,
@@ -208,6 +208,7 @@ __all__ = [
     "MetadataException",
     "ParserSyntaxError",
     "PartialParserConfig",
+    "RemoveFromParent",
     "RemovalSentinel",
     "ensure_type",
     "visit_batched",

--- a/libcst/_nodes/tests/test_removal_behavior.py
+++ b/libcst/_nodes/tests/test_removal_behavior.py
@@ -7,9 +7,8 @@
 from typing import Type, Union
 
 import libcst as cst
-from libcst import parse_module
+from libcst import RemovalSentinel, parse_module
 from libcst._nodes.tests.base import CSTNodeTest
-from libcst._removal_sentinel import RemovalSentinel
 from libcst._types import CSTNodeT
 from libcst._visitors import CSTTransformer
 from libcst.testing.utils import data_provider
@@ -20,7 +19,7 @@ class IfStatementRemovalVisitor(CSTTransformer):
         self, original_node: CSTNodeT, updated_node: CSTNodeT
     ) -> Union[CSTNodeT, RemovalSentinel]:
         if isinstance(updated_node, cst.If):
-            return updated_node.remove()
+            return cst.RemoveFromParent()
         else:
             return updated_node
 
@@ -30,7 +29,7 @@ class ContinueStatementRemovalVisitor(CSTTransformer):
         self, original_node: CSTNodeT, updated_node: CSTNodeT
     ) -> Union[CSTNodeT, RemovalSentinel]:
         if isinstance(updated_node, cst.Continue):
-            return updated_node.remove()
+            return cst.RemoveFromParent()
         else:
             return updated_node
 
@@ -43,11 +42,11 @@ class SpecificImportRemovalVisitor(CSTTransformer):
             for alias in updated_node.names:
                 name = alias.name
                 if isinstance(name, cst.Name) and name.value == "b":
-                    return updated_node.remove()
+                    return cst.RemoveFromParent()
         elif isinstance(updated_node, cst.ImportFrom):
             module = updated_node.module
             if isinstance(module, cst.Name) and module.value == "e":
-                return updated_node.remove()
+                return cst.RemoveFromParent()
         return updated_node
 
 

--- a/libcst/_removal_sentinel.py
+++ b/libcst/_removal_sentinel.py
@@ -16,8 +16,8 @@ class RemovalSentinel(Enum):
     """
     A :attr:`RemovalSentinel.REMOVE` value should be returned by a
     :meth:`CSTTransformer.on_leave` method when we want to remove that child from its
-    parent. As a convenience, this can be constructed given a CSTNode by calling
-    ``node.remove()``.
+    parent. As a convenience, this can be constructed by calling
+    :func:`libcst.RemoveFromParent`.
 
     The parent node should make a best-effort to remove the child, but may raise an
     exception when removing the child doesn't make sense, or could change the semantics
@@ -35,3 +35,17 @@ class RemovalSentinel(Enum):
     """
 
     REMOVE = auto()
+
+
+def RemoveFromParent() -> RemovalSentinel:
+    """
+    A convenience method for requesting that this node be removed by its parent.
+    Use this in place of returning :class:`RemovalSentinel` directly.
+    For example, to remove all arguments unconditionally::
+
+        def leave_Arg(
+            self, original_node: cst.Arg, updated_node: cst.Arg
+        ) -> Union[cst.Arg, cst.RemovalSentinel]:
+            return RemoveFromParent()
+    """
+    return RemovalSentinel.REMOVE

--- a/libcst/_visitors.py
+++ b/libcst/_visitors.py
@@ -65,7 +65,7 @@ class CSTTransformer(CSTTypedTransformerFunctions, MetadataDependent):
         Returning :attr:`RemovalSentinel.REMOVE` indicates that the node should be
         removed from its parent. This is not always possible, and may raise an
         exception if this node is required. As a convenience, you can use
-        ``updated_node.remove()`` as an alias to :attr:`RemovalSentinel.REMOVE`.
+        :func:`RemoveFromParent` as an alias to :attr:`RemovalSentinel.REMOVE`.
         """
         leave_func = getattr(self, f"leave_{type(original_node).__name__}", None)
         if leave_func is not None:

--- a/libcst/codegen/gen_matcher_classes.py
+++ b/libcst/codegen/gen_matcher_classes.py
@@ -96,7 +96,7 @@ class CleanseFullTypeNames(cst.CSTTransformer):
             if isinstance(val, cst.Name):
                 if "Sentinel" in val.value:
                     # We don't support maybes in matchers.
-                    return updated_node.remove()
+                    return cst.RemoveFromParent()
         # Simple trick to kill trailing commas
         return updated_node.with_changes(comma=cst.MaybeSentinel.DEFAULT)
 
@@ -121,7 +121,7 @@ class RemoveDoNotCareFromGeneric(cst.CSTTransformer):
             if isinstance(val, cst.Name):
                 if val.value == "DoNotCareSentinel":
                     # We don't support maybes in matchers.
-                    return updated_node.remove()
+                    return cst.RemoveFromParent()
         return updated_node
 
     def leave_Subscript(

--- a/libcst/tests/test_deep_replace.py
+++ b/libcst/tests/test_deep_replace.py
@@ -75,3 +75,27 @@ class DeepReplaceTest(UnitTest):
             ),
         )
         self.assertEqual(new_module.code, dedent(new_code))
+
+    def test_deep_remove_complex(self) -> None:
+        old_code = """
+            def a():
+                def b():
+                    def c():
+                        print("Hello, world!")
+        """
+        new_code = """
+            def a():
+                def b():
+                    pass
+        """
+
+        module = cst.parse_module(dedent(old_code))
+        outer_fun = cst.ensure_type(module.body[0], cst.FunctionDef)
+        middle_fun = cst.ensure_type(
+            cst.ensure_type(outer_fun.body, cst.IndentedBlock).body[0], cst.FunctionDef
+        )
+        inner_fun = cst.ensure_type(
+            cst.ensure_type(middle_fun.body, cst.IndentedBlock).body[0], cst.FunctionDef
+        )
+        new_module = cst.ensure_type(module.deep_remove(inner_fun), cst.Module)
+        self.assertEqual(new_module.code, dedent(new_code))


### PR DESCRIPTION
## Summary

We've gotten a few comments that RemovalSentinel is a bit difficult to use. Its not that intuitive to return RemovalSentinel.REMOVE. We already have helper methods on `CSTNode` which return new values (`deep_clone`, `with_changes`) so we have precedent here for adding another. Add a `deep_remove` onto CSTNode that can be called similar to the other modifying calls, and identically to `deep_replace` which was newly added. Add a `RemoveFromParent()` helper method that constructs a `RemovalSentinel.REMOVE` and refer to that as the default in documentation. Hopefully this helps the ergonomics of removing nodes a bit.

## Test Plan

tox, look at generated docs.