### PR TITLE
Implement deep_replace helper on CSTNode.

### DIFF
--- a/libcst/_nodes/base.py
+++ b/libcst/_nodes/base.py
@@ -22,6 +22,7 @@ from typing import (
 from libcst._nodes.internal import CodegenState, CodePosition, CodeRange
 from libcst._removal_sentinel import RemovalSentinel
 from libcst._type_enforce import is_value_of_type
+from libcst._types import CSTNodeT
 from libcst._visitors import CSTTransformer, CSTVisitor, CSTVisitorT
 
 
@@ -51,6 +52,22 @@ class _ChildrenCollectionVisitor(CSTVisitor):
     def on_visit(self, node: "CSTNode") -> bool:
         self.children.append(node)
         return False  # Don't include transitive children
+
+
+class _ChildrenReplacementTransformer(CSTTransformer):
+    def __init__(self, old_node: "CSTNode", new_node: "CSTNode") -> None:
+        self.old_node = old_node
+        self.new_node = new_node
+
+    def on_visit(self, node: "CSTNode") -> bool:
+        # If the node is one we are about to replace, we shouldn't
+        # recurse down it, that would be a waste of time.
+        return node is not self.old_node
+
+    def on_leave(self, original_node: "CSTNode", updated_node: "CSTNode") -> "CSTNode":
+        if original_node is self.old_node:
+            return self.new_node
+        return updated_node
 
 
 class _NOOPVisitor(CSTTransformer):
@@ -345,6 +362,22 @@ class CSTNode(ABC):
         from libcst._nodes.deep_equals import deep_equals as deep_equals_impl
 
         return deep_equals_impl(self, other)
+
+    def deep_replace(
+        self: _CSTNodeSelfT, old_node: "CSTNode", new_node: CSTNodeT
+    ) -> Union[_CSTNodeSelfT, CSTNodeT]:
+        """
+        Recursively replaces any instance of ``old_node`` with ``new_node`` by identity.
+        Use this to avoid nested ``with_changes`` blocks when you are replacing one of
+        a node's deep children with a new node. Note that if you have previously
+        modified the tree in a way that ``old_node`` appears more than once as a deep
+        child, all instances will be replaced.
+        """
+        new_tree = self.visit(_ChildrenReplacementTransformer(old_node, new_node))
+        if isinstance(new_tree, RemovalSentinel):
+            # The above transform never returns RemovalSentinel, so this isn't possible
+            raise Exception("Logic error, cannot get a RemovalSentinel here!")
+        return new_tree
 
     def __eq__(self: _CSTNodeSelfT, other: _CSTNodeSelfT) -> bool:
         """

--- a/libcst/tests/test_deep_replace.py
+++ b/libcst/tests/test_deep_replace.py
@@ -1,0 +1,77 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from textwrap import dedent
+
+import libcst as cst
+from libcst.testing.utils import UnitTest
+
+
+class DeepReplaceTest(UnitTest):
+    def test_deep_replace_simple(self) -> None:
+        old_code = """
+            pass
+        """
+        new_code = """
+            break
+        """
+
+        module = cst.parse_module(dedent(old_code))
+        pass_stmt = cst.ensure_type(module.body[0], cst.SimpleStatementLine).body[0]
+        new_module = cst.ensure_type(
+            module.deep_replace(pass_stmt, cst.Break()), cst.Module
+        )
+        self.assertEqual(new_module.code, dedent(new_code))
+
+    def test_deep_replace_complex(self) -> None:
+        old_code = """
+            def a():
+                def b():
+                    def c():
+                        pass
+        """
+        new_code = """
+            def a():
+                def b():
+                    def d(): break
+        """
+
+        module = cst.parse_module(dedent(old_code))
+        outer_fun = cst.ensure_type(module.body[0], cst.FunctionDef)
+        middle_fun = cst.ensure_type(
+            cst.ensure_type(outer_fun.body, cst.IndentedBlock).body[0], cst.FunctionDef
+        )
+        inner_fun = cst.ensure_type(
+            cst.ensure_type(middle_fun.body, cst.IndentedBlock).body[0], cst.FunctionDef
+        )
+        new_module = cst.ensure_type(
+            module.deep_replace(
+                inner_fun,
+                cst.FunctionDef(
+                    name=cst.Name("d"),
+                    params=cst.Parameters(),
+                    body=cst.SimpleStatementSuite(body=(cst.Break(),)),
+                ),
+            ),
+            cst.Module,
+        )
+        self.assertEqual(new_module.code, dedent(new_code))
+
+    def test_deep_replace_identity(self) -> None:
+        old_code = """
+            pass
+        """
+        new_code = """
+            break
+        """
+
+        module = cst.parse_module(dedent(old_code))
+        new_module = module.deep_replace(
+            module,
+            cst.Module(
+                header=(cst.EmptyLine(),),
+                body=(cst.SimpleStatementLine(body=(cst.Break(),)),),
+            ),
+        )
+        self.assertEqual(new_module.code, dedent(new_code))


### PR DESCRIPTION
## Summary

Implement a `deep_replace()` helper method on CSTNode. This allows you to replace an instance of `old_node` by identity with `new_node`. This helper isn't extremely useful on its own, but coupled with a planned `find()` method in matchers this will allow for find and replace on arbitrary parts of the tree.

## Test Plan

Added a new test to verify functionality.