### PR TITLE
Organize document menu as three parts: introduction, tutorial and reference

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,13 +13,25 @@ LibCST
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Introduction:
 
    why_libcst
    motivation
-   tutorial
-   Metadata Tutorial <metadata_tutorial>
-   Matchers Tutorial <matchers_tutorial>
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Tutorial:
+
+   Parsing and Visitors <tutorial>
+   Metadata <metadata_tutorial>
+   Matchers <matchers_tutorial>
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Reference:
+
    parser
    nodes
    visitors


### PR DESCRIPTION
As we add more doc pages, we need to categorize pages better for readability.

## Summary

Organize document menu as three parts: introduction, tutorial and reference.

## Test Plan
Before
![image](https://user-images.githubusercontent.com/3840867/66063189-bc606600-e4f7-11e9-8056-ed995b9eccc1.png)

After
![image](https://user-images.githubusercontent.com/3840867/66063142-a5ba0f00-e4f7-11e9-9353-815e40b21050.png)

