### PR TITLE
Improve Scope analysis and add a tutorial doc

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,6 +25,7 @@ LibCST
 
    Parsing and Visitors <tutorial>
    Metadata <metadata_tutorial>
+   Scope Analysis <scope_tutorial>
    Matchers <matchers_tutorial>
 
 

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -124,6 +124,7 @@ There were four different type of scope in Python: :class:`~libcst.metadata.Glob
 
 .. autoclass:: libcst.metadata.Scope
    :no-undoc-members:
+   :special-members: __contains__, __getitem__, __iter__
 
 .. autoclass:: libcst.metadata.GlobalScope
    :no-undoc-members:

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -12,7 +12,7 @@ LibCST ships with a metadata interface that defines a standardized way to
 associate nodes in a CST with arbitrary metadata while maintaining the immutability
 of the tree. The metadata interface is designed to be declarative and type safe.
 Here's a quick example of using the metadata interface to get line and column
-numbers of nodes through the :class:`~libcst.SyntacticPositionProvider`:
+numbers of nodes through the :class:`~libcst.metadata.SyntacticPositionProvider`:
 
 .. _libcst-metadata-position-example:
 .. code-block:: python
@@ -24,7 +24,7 @@ numbers of nodes through the :class:`~libcst.SyntacticPositionProvider`:
             pos = self.get_metadata(cst.SyntacticPositionProvider, node).start
             print(f"{node.value} found at line {pos.line}, column {pos.column}")
 
-    wrapper = cst.MetadataWrapper(cst.parse_module("x = 1"))
+    wrapper = cst.metadata.MetadataWrapper(cst.parse_module("x = 1"))
     result = wrapper.visit(NamePrinter())  # should print "x found at line 1, column 0"
 
 More examples of using the metadata interface can be found on the
@@ -33,15 +33,15 @@ More examples of using the metadata interface can be found on the
 Accessing Metadata
 ------------------
 
-To work with metadata you need to wrap a module with a :class:`~libcst.MetadataWrapper`.
-The wrapper provides a :func:`~libcst.MetadataWrapper.resolve` function and a
-:func:`~libcst.MetadataWrapper.resolve_many` function to generate metadata.
+To work with metadata you need to wrap a module with a :class:`~libcst.metadata.MetadataWrapper`.
+The wrapper provides a :func:`~libcst.metadata.MetadataWrapper.resolve` function and a
+:func:`~libcst.metadata.MetadataWrapper.resolve_many` function to generate metadata.
 
-.. autoclass:: libcst.MetadataWrapper
+.. autoclass:: libcst.metadata.MetadataWrapper
 
 If you're working with visitors, which extend :class:`~libcst.MetadataDependent`, 
 metadata dependencies will be automatically computed when visited by a 
-:class:`~libcst.MetadataWrapper` and are accessible through
+:class:`~libcst.metadata.MetadataWrapper` and are accessible through
 :func:`~libcst.MetadataDependent.get_metadata`
 
 .. autoclass:: libcst.MetadataDependent
@@ -51,7 +51,7 @@ Providing Metadata
 
 Metadata is generated through provider classes that can be declared as a dependency
 by a subclass of :class:`~libcst.MetadataDependent`. These providers are then
-resolved automatically using methods provided by :class:`~libcst.MetadataWrapper`.
+resolved automatically using methods provided by :class:`~libcst.metadata.MetadataWrapper`.
 In most cases, you should extend :class:`~libcst.BatchableMetadataProvider` when
 writing a provider, unless you have a particular reason to not to use a
 batchable visitor. Only extend from :class:`~libcst.BaseMetadataProvider` if

--- a/docs/source/scope_tutorial.ipynb
+++ b/docs/source/scope_tutorial.ipynb
@@ -1,0 +1,191 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "==============\n",
+    "Scope Analysis\n",
+    "==============\n",
+    "Scope analysis keeps track of assignments and accesses which could be useful for code automatic refactoring. If you're not familiar with Scope analysis, see :doc:`Metadata <metadata>` for more detail about Scope metadata. This tutorial demonstrates some use cases of Scope analysis.\n",
+    "\n",
+    "Automatically Remove Unused Import\n",
+    "==================================\n",
+    "Unused import is a commmon code suggestion provided by lint tool like `flake8 F401 <https://lintlyci.github.io/Flake8Rules/rules/F401.html>`_ ``imported but unused``. To build an automatic refactoring tool to fix it, we use Scope metadata to identify all :class:`~libcst.Import`, :class:`~libcst.ImportFrom` assignments and their accesses.\n",
+    "An import statement may import multiple names, we want to remove those unused names from the import statement. If all the names in the import statement are not used, we remove the entire import.\n",
+    "Given the following example source code, the ``import`` and ``from ... import ...`` import multiple names.\n",
+    "With a parsed :class:`~libcst.Module`, we construct a :class:`~libcst.metadata.MetadataWrapper` object and it provides a :func:`~libcst.metadata.MetadataWrapper.resolve` function to resolve metadata given a metadata provider.\n",
+    ":class:`~libcst.metadata.ScopeProvider` is used here for analysing scope and there are three type of scopes (:class:`~libcst.metadata.GlobalScope`, :class:`~libcst.metadata.FunctionScope` and :class:`~libcst.metadata.ClassScope`) in this example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append(\"../../\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import libcst as cst\n",
+    "\n",
+    "source = \"\"\"\n",
+    "import a, b, c as d, e as f  # expect to keep: a, c as d\n",
+    "from g import h, i, j as k, l as m  # expect to keep: h, j as k\n",
+    "from m import n  # expect to be removed entirely\n",
+    "\n",
+    "a()\n",
+    "\n",
+    "def fun():\n",
+    "    d()\n",
+    "\n",
+    "class Cls:\n",
+    "    att = h.something\n",
+    "    \n",
+    "    def __init__(self) -> None:\n",
+    "        var = k.method()\n",
+    "\"\"\"\n",
+    "wrapper = cst.metadata.MetadataWrapper(cst.parse_module(source))\n",
+    "scopes = set(wrapper.resolve(cst.metadata.ScopeProvider).values())\n",
+    "for scope in scopes:\n",
+    "    print(scope)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "We're interested in those unused names and we traverse all import assignments in each scope to build a lookup table ``import_names_to_remove`` to record the mapping of import node and their unused names. There exist other types of assignment like :class:`~libcst.FunctionDef` or :class:`~libcst.ClassDef` but we don't care them here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from collections import defaultdict\n",
+    "from typing import Dict, Union, Set\n",
+    "\n",
+    "import_names_to_remove: Dict[Union[cst.Import, cst.ImportFrom], Set[str]] = defaultdict(set)\n",
+    "for scope in scopes:\n",
+    "    for assignment in scope:\n",
+    "        if isinstance(assignment, cst.metadata.Assignment) and isinstance(\n",
+    "            assignment.node, (cst.Import, cst.ImportFrom)\n",
+    "        ):\n",
+    "            if len(assignment.accesses) == 0:\n",
+    "                import_names_to_remove[assignment.node].add(assignment.name)\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "To remove the unused name, we implement ``RemoveUnusedImportTransformer`` by subclassing :class:`libcst.CSTTransformer`. We overwrite ``leave_Import`` and ``leave_ImportFrom`` to modify the import statements.\n",
+    "When we find the import node in lookup table, we iterate through all ``names`` and keep used names in ``names_to_keep``.\n",
+    "If ``names_to_keep`` is empty, all names are unused and we remove the entire import node.\n",
+    "Otherwise, we update the import node and just removing partial names."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class RemoveUnusedImportTransformer(cst.CSTTransformer):\n",
+    "    def __init__(\n",
+    "        self, import_names_to_remove: Dict[Union[cst.Import, cst.ImportFrom], Set[str]]\n",
+    "    ) -> None:\n",
+    "        self.import_names_to_remove = import_names_to_remove\n",
+    "\n",
+    "    def leave_import_alike(\n",
+    "        self,\n",
+    "        original_node: Union[cst.Import, cst.ImportFrom],\n",
+    "        updated_node: Union[cst.Import, cst.ImportFrom],\n",
+    "    ) -> Union[cst.Import, cst.ImportFrom, cst.RemovalSentinel]:\n",
+    "        if original_node not in self.import_names_to_remove:\n",
+    "            return updated_node\n",
+    "        names_to_keep = []\n",
+    "        for name in updated_node.names:\n",
+    "            asname = name.asname\n",
+    "            if asname is not None:\n",
+    "                name_value = asname.name.value\n",
+    "            else:\n",
+    "                name_value = name.name.value\n",
+    "            if name_value not in self.import_names_to_remove[original_node]:\n",
+    "                names_to_keep.append(name.with_changes(comma=cst.MaybeSentinel.DEFAULT))\n",
+    "        if len(names_to_keep) == 0:\n",
+    "            return cst.RemoveFromParent()\n",
+    "        else:\n",
+    "            return updated_node.with_changes(names=names_to_keep)\n",
+    "\n",
+    "    def leave_Import(\n",
+    "        self, original_node: cst.Import, updated_node: cst.Import\n",
+    "    ) -> cst.Import:\n",
+    "        return self.leave_import_alike(original_node, updated_node)\n",
+    "\n",
+    "    def leave_ImportFrom(\n",
+    "        self, original_node: cst.ImportFrom, updated_node: cst.ImportFrom\n",
+    "    ) -> cst.ImportFrom:\n",
+    "        return self.leave_import_alike(original_node, updated_node)\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "After the transform, we use ``.code`` to generate fixed code and all unused names are fixed as expected!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fixed_module = wrapper.module.visit(RemoveUnusedImportTransformer(import_names_to_remove))\n",
+    "print(fixed_module.code)"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Raw Cell Format",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -257,8 +257,7 @@ class Scope(abc.ABC):
         An imported name may be used for type annotation with :class:`~libcst.SimpleString` and
         currently resolving the qualified given :class:`~libcst.SimpleString` is not supported
         considering it could be a complex type annotation in the string which is hard to
-        resolve, e.g.
-        ``List[Union[int, str]]``.
+        resolve, e.g. ``List[Union[int, str]]``.
         """
         results = set()
         full_name = _QualifiedNameUtil.get_full_name_for(node)
@@ -283,6 +282,14 @@ class Scope(abc.ABC):
                     )
                 )
         return results
+
+    def get_assignments_for(self, node: cst.CSTNode) -> Collection[BaseAssignment]:
+        """ Get all assignments in current scope given a :class:`~libcst.CSTNode`. """
+        full_name = _QualifiedNameUtil.get_full_name_for(node)
+        if full_name is None:
+            return set()
+        parts = full_name.split(".")
+        return self[parts[0]]
 
 
 class GlobalScope(Scope):

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -14,6 +14,7 @@ from enum import Enum, auto
 from typing import (
     Collection,
     Dict,
+    Generator,
     Iterator,
     List,
     MutableMapping,
@@ -220,11 +221,19 @@ class Scope(abc.ABC):
         self.record_assignment(name, node)
 
     def __contains__(self, name: str) -> bool:
+        """ Check if the name str exist in current scope by ``name in scope``. """
         return len(self[name]) > 0
 
     @abc.abstractmethod
     def __getitem__(self, name: str) -> Tuple[BaseAssignment, ...]:
+        """ Get assignments given a name str by ``scope[name]``. """
         ...
+
+    def __iter__(self) -> Generator[BaseAssignment, None, None]:
+        """ Get all assignments in current scope by iterating through scope object. """
+        for _, assignments in self._assignments.items():
+            for assignment in assignments:
+                yield assignment
 
     @abc.abstractmethod
     def record_global_overwrite(self, name: str) -> None:

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -800,3 +800,5 @@ class ScopeProviderTest(UnitTest):
             ],
             [call.func, call.func],
         )  # each assignment has single access of Call.func (a Name)
+
+        self.assertEqual(len(list(scope)), 2)


### PR DESCRIPTION
## Summary
Changes:
1. add `Scope.get_assignments_for()` to make accessing Assignments easier while traversing CST tree.
With existing API, user needs to parse the name string from CSTNode and then use `scope[name]`.
This new API is similar to `get_qualified_names_for()` but returns assignments instead when given a CSTNode.

2. implement Scope.__iter__ for accessing all assignments in current scope.

3. improve document of Scope: after vs before
![image](https://user-images.githubusercontent.com/3840867/66095556-ceb8bf00-e54c-11e9-8841-120469642075.png)


4. add scope tutorial to demonstrate some advanced use cases.
  - Automatically Remove Unused Import

https://2776-200896124-gh.circle-artifacts.com/0/doc/scope_tutorial.html

## Test Plan
unit tests.