### PR TITLE
Add Assignments and Accesses to Scope Analysis

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,6 +25,7 @@ LibCST
 
    Parsing and Visitors <tutorial>
    Metadata <metadata_tutorial>
+   Scope Analysis <scope_tutorial>
    Matchers <matchers_tutorial>
 
 

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -94,6 +94,8 @@ Expression Context Metadata
 
 .. autoclass:: libcst.metadata.ExpressionContext
 
+.. _libcst-scope-metadata:
+
 Scope Metadata
 --------------
 Scope is the block of naming binding. The bind name is not available

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -12,7 +12,7 @@ LibCST ships with a metadata interface that defines a standardized way to
 associate nodes in a CST with arbitrary metadata while maintaining the immutability
 of the tree. The metadata interface is designed to be declarative and type safe.
 Here's a quick example of using the metadata interface to get line and column
-numbers of nodes through the :class:`~libcst.metadta.SyntacticPositionProvider`:
+numbers of nodes through the :class:`~libcst.metadata.SyntacticPositionProvider`:
 
 .. _libcst-metadata-position-example:
 .. code-block:: python
@@ -24,7 +24,7 @@ numbers of nodes through the :class:`~libcst.metadta.SyntacticPositionProvider`:
             pos = self.get_metadata(cst.SyntacticPositionProvider, node).start
             print(f"{node.value} found at line {pos.line}, column {pos.column}")
 
-    wrapper = cst.metadta.MetadataWrapper(cst.parse_module("x = 1"))
+    wrapper = cst.metadata.MetadataWrapper(cst.parse_module("x = 1"))
     result = wrapper.visit(NamePrinter())  # should print "x found at line 1, column 0"
 
 More examples of using the metadata interface can be found on the
@@ -33,15 +33,15 @@ More examples of using the metadata interface can be found on the
 Accessing Metadata
 ------------------
 
-To work with metadata you need to wrap a module with a :class:`~libcst.metadta.MetadataWrapper`.
-The wrapper provides a :func:`~libcst.metadta.MetadataWrapper.resolve` function and a
-:func:`~libcst.metadta.MetadataWrapper.resolve_many` function to generate metadata.
+To work with metadata you need to wrap a module with a :class:`~libcst.metadata.MetadataWrapper`.
+The wrapper provides a :func:`~libcst.metadata.MetadataWrapper.resolve` function and a
+:func:`~libcst.metadata.MetadataWrapper.resolve_many` function to generate metadata.
 
-.. autoclass:: libcst.MetadataWrapper
+.. autoclass:: libcst.metadata.MetadataWrapper
 
 If you're working with visitors, which extend :class:`~libcst.MetadataDependent`, 
 metadata dependencies will be automatically computed when visited by a 
-:class:`~libcst.metadta.MetadataWrapper` and are accessible through
+:class:`~libcst.metadata.MetadataWrapper` and are accessible through
 :func:`~libcst.MetadataDependent.get_metadata`
 
 .. autoclass:: libcst.MetadataDependent
@@ -51,15 +51,15 @@ Providing Metadata
 
 Metadata is generated through provider classes that can be declared as a dependency
 by a subclass of :class:`~libcst.MetadataDependent`. These providers are then
-resolved automatically using methods provided by :class:`~libcst.metadta.MetadataWrapper`.
+resolved automatically using methods provided by :class:`~libcst.metadata.MetadataWrapper`.
 In most cases, you should extend :class:`~libcst.BatchableMetadataProvider` when
 writing a provider, unless you have a particular reason to not to use a
 batchable visitor. Only extend from :class:`~libcst.BaseMetadataProvider` if
 your provider does not use the visitor pattern for computing metadata for a tree.
 
 .. autoclass:: libcst.BaseMetadataProvider
-.. autoclass:: libcst.BatchableMetadataProvider
-.. autoclass:: libcst.VisitorMetadataProvider
+.. autoclass:: libcst.metadata.BatchableMetadataProvider
+.. autoclass:: libcst.metadata.VisitorMetadataProvider
 
 .. _libcst-metadata-position:
 

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -121,7 +121,6 @@ There were four different type of scope in Python: :class:`~libcst.metadata.Glob
 .. autoclass:: libcst.metadata.Assignment
 .. autoclass:: libcst.metadata.BuiltinAssignment
 
-
 .. autoclass:: libcst.metadata.Scope
    :no-undoc-members:
 
@@ -131,6 +130,12 @@ There were four different type of scope in Python: :class:`~libcst.metadata.Glob
 .. autoclass:: libcst.metadata.FunctionScope
 .. autoclass:: libcst.metadata.ClassScope
 .. autoclass:: libcst.metadata.ComprehensionScope
+
+.. autoclass:: libcst.metadata.Assignments
+   :special-members: __contains__, __getitem__, __iter__
+
+.. autoclass:: libcst.metadata.Accesses
+   :special-members: __contains__, __getitem__, __iter__
 
 Qualified Name Metadata
 -----------------------

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -12,7 +12,7 @@ LibCST ships with a metadata interface that defines a standardized way to
 associate nodes in a CST with arbitrary metadata while maintaining the immutability
 of the tree. The metadata interface is designed to be declarative and type safe.
 Here's a quick example of using the metadata interface to get line and column
-numbers of nodes through the :class:`~libcst.SyntacticPositionProvider`:
+numbers of nodes through the :class:`~libcst.metadta.SyntacticPositionProvider`:
 
 .. _libcst-metadata-position-example:
 .. code-block:: python
@@ -24,7 +24,7 @@ numbers of nodes through the :class:`~libcst.SyntacticPositionProvider`:
             pos = self.get_metadata(cst.SyntacticPositionProvider, node).start
             print(f"{node.value} found at line {pos.line}, column {pos.column}")
 
-    wrapper = cst.MetadataWrapper(cst.parse_module("x = 1"))
+    wrapper = cst.metadta.MetadataWrapper(cst.parse_module("x = 1"))
     result = wrapper.visit(NamePrinter())  # should print "x found at line 1, column 0"
 
 More examples of using the metadata interface can be found on the
@@ -33,15 +33,15 @@ More examples of using the metadata interface can be found on the
 Accessing Metadata
 ------------------
 
-To work with metadata you need to wrap a module with a :class:`~libcst.MetadataWrapper`.
-The wrapper provides a :func:`~libcst.MetadataWrapper.resolve` function and a
-:func:`~libcst.MetadataWrapper.resolve_many` function to generate metadata.
+To work with metadata you need to wrap a module with a :class:`~libcst.metadta.MetadataWrapper`.
+The wrapper provides a :func:`~libcst.metadta.MetadataWrapper.resolve` function and a
+:func:`~libcst.metadta.MetadataWrapper.resolve_many` function to generate metadata.
 
 .. autoclass:: libcst.MetadataWrapper
 
 If you're working with visitors, which extend :class:`~libcst.MetadataDependent`, 
 metadata dependencies will be automatically computed when visited by a 
-:class:`~libcst.MetadataWrapper` and are accessible through
+:class:`~libcst.metadta.MetadataWrapper` and are accessible through
 :func:`~libcst.MetadataDependent.get_metadata`
 
 .. autoclass:: libcst.MetadataDependent
@@ -51,7 +51,7 @@ Providing Metadata
 
 Metadata is generated through provider classes that can be declared as a dependency
 by a subclass of :class:`~libcst.MetadataDependent`. These providers are then
-resolved automatically using methods provided by :class:`~libcst.MetadataWrapper`.
+resolved automatically using methods provided by :class:`~libcst.metadta.MetadataWrapper`.
 In most cases, you should extend :class:`~libcst.BatchableMetadataProvider` when
 writing a provider, unless you have a particular reason to not to use a
 batchable visitor. Only extend from :class:`~libcst.BaseMetadataProvider` if
@@ -123,6 +123,7 @@ There were four different type of scope in Python: :class:`~libcst.metadata.Glob
 
 .. autoclass:: libcst.metadata.Scope
    :no-undoc-members:
+   :special-members: __contains__, __getitem__, __iter__
 
 .. autoclass:: libcst.metadata.GlobalScope
    :no-undoc-members:

--- a/docs/source/scope_tutorial.ipynb
+++ b/docs/source/scope_tutorial.ipynb
@@ -9,15 +9,13 @@
     "==============\n",
     "Scope Analysis\n",
     "==============\n",
-    "Scope analysis keeps track of assignments and accesses which could be useful for code automatic refactoring. If you're not familiar with Scope analysis, see :doc:`Metadata <metadata>` for more detail about Scope metadata. This tutorial demonstrates some use cases of Scope analysis. \n",
-    "Given source codes, Scope analysis parses all variable :class:`~libcst.metadata.Assignment` (or a :class:`~libcst.metadata.BuiltinAssignment` if it's a builtin) and :class:`~libcst.metadata.Access` to store in :class:`~libcst.metadata.Scope` containers.\n",
-    "\n",
-    "Given the following example source code contains a couple of unused imports (``f``, ``i``, ``m`` and ``n``) and undefined variable references (``func_undefined`` and ``var_undefined``). Scope analysis helps us identifying those unused imports and undefined variables to automatically provide warnings to developers to prevent bugs while they're developing.\n",
-    "With a parsed :class:`~libcst.Module`, we construct a :class:`~libcst.metadata.MetadataWrapper` object and it provides a :func:`~libcst.metadata.MetadataWrapper.resolve` function to resolve metadata given a metadata provider.\n",
-    ":class:`~libcst.metadata.ScopeProvider` is used here for analysing scope and there are three types of scopes (:class:`~libcst.metadata.GlobalScope`, :class:`~libcst.metadata.FunctionScope` and :class:`~libcst.metadata.ClassScope`) in this example.\n",
+    "Scope analysis keeps track of assignments and accesses which could be useful for code automatic refactoring. If you're not familiar with scope analysis, see :ref:`Scope Metadata <libcst-scope-metadata>` for more detail about scope metadata. This tutorial demonstrates some use cases of scope analysis. If you're new to metadata, see :doc:`Metadata Tutorial <metadata_tutorial>` to get started.\n",
+    "Given source codes, scope analysis parses all variable :class:`~libcst.metadata.Assignment` (or a :class:`~libcst.metadata.BuiltinAssignment` if it's a builtin) and :class:`~libcst.metadata.Access` to store in :class:`~libcst.metadata.Scope` containers.\n",
     "\n",
     ".. note::\n",
-    "   The scope analysis only handles local variable name access and cannot handle simple string type annotation forward references. See :class:`~libcst.metadata.Access`\n"
+    "   The scope analysis only handles local variable name access and cannot handle simple string type annotation forward references. See :class:`~libcst.metadata.Access`\n",
+    "\n",
+    "Given the following example source code contains a couple of unused imports (``f``, ``i``, ``m`` and ``n``) and undefined variable references (``func_undefined`` and ``var_undefined``). Scope analysis helps us identifying those unused imports and undefined variables to automatically provide warnings to developers to prevent bugs while they're developing.\n"
    ]
   },
   {
@@ -38,8 +36,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import libcst as cst\n",
-    "\n",
     "source = \"\"\"\\\n",
     "import a, b, c as d, e as f  # expect to keep: a, c as d\n",
     "from g import h, i, j as k, l as m  # expect to keep: h, j as k\n",
@@ -56,7 +52,28 @@
     "    def __new__(self) -> \"Cls\":\n",
     "        var = k.method()\n",
     "        func_undefined(var_undefined)\n",
-    "\"\"\"\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "With a parsed :class:`~libcst.Module`, we construct a :class:`~libcst.metadata.MetadataWrapper` object and it provides a :func:`~libcst.metadata.MetadataWrapper.resolve` function to resolve metadata given a metadata provider.\n",
+    ":class:`~libcst.metadata.ScopeProvider` is used here for analysing scope and there are three types of scopes (:class:`~libcst.metadata.GlobalScope`, :class:`~libcst.metadata.FunctionScope` and :class:`~libcst.metadata.ClassScope`) in this example.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import libcst as cst\n",
+    "\n",
+    "\n",
     "wrapper = cst.metadata.MetadataWrapper(cst.parse_module(source))\n",
     "scopes = set(wrapper.resolve(cst.metadata.ScopeProvider).values())\n",
     "for scope in scopes:\n",
@@ -176,7 +193,7 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "After the transform, we use ``.code`` to generate fixed code and all unused names are fixed as expected!"
+    "After the transform, we use ``.code`` to generate fixed code and all unused names are fixed as expected! The difflib is used to show only changed part and only import lines are updated as expected."
    ]
   },
   {
@@ -185,8 +202,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import difflib\n",
     "fixed_module = wrapper.module.visit(RemoveUnusedImportTransformer(unused_imports))\n",
-    "print(fixed_module.code)"
+    "\n",
+    "# Use difflib to show the changes to verify unused imports are removed as expected.\n",
+    "print(\n",
+    "    \"\".join(\n",
+    "        difflib.unified_diff(source.splitlines(1), fixed_module.code.splitlines(1))\n",
+    "    )\n",
+    ")"
    ]
   }
  ],

--- a/docs/source/scope_tutorial.ipynb
+++ b/docs/source/scope_tutorial.ipynb
@@ -1,0 +1,215 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "==============\n",
+    "Scope Analysis\n",
+    "==============\n",
+    "Scope analysis keeps track of assignments and accesses which could be useful for code automatic refactoring. If you're not familiar with Scope analysis, see :doc:`Metadata <metadata>` for more detail about Scope metadata. This tutorial demonstrates some use cases of Scope analysis. \n",
+    "Given source codes, Scope analysis parses all variable :class:`~libcst.metadata.Assignment` (or a :class:`~libcst.metadata.BuiltinAssignment` if it's a builtin) and :class:`~libcst.metadata.Access` to store in :class:`~libcst.metadata.Scope` containers.\n",
+    "\n",
+    "Given the following example source code contains a couple of unused imports (``f``, ``i``, ``m`` and ``n``) and undefined variable references (``func_undefined`` and ``var_undefined``). Scope analysis helps us identifying those unused imports and undefined variables to automatically provide warnings to developers to prevent bugs while they're developing.\n",
+    "With a parsed :class:`~libcst.Module`, we construct a :class:`~libcst.metadata.MetadataWrapper` object and it provides a :func:`~libcst.metadata.MetadataWrapper.resolve` function to resolve metadata given a metadata provider.\n",
+    ":class:`~libcst.metadata.ScopeProvider` is used here for analysing scope and there are three types of scopes (:class:`~libcst.metadata.GlobalScope`, :class:`~libcst.metadata.FunctionScope` and :class:`~libcst.metadata.ClassScope`) in this example.\n",
+    "\n",
+    ".. note::\n",
+    "   The scope analysis only handles local variable name access and cannot handle simple string type annotation forward references. See :class:`~libcst.metadata.Access`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append(\"../../\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import libcst as cst\n",
+    "\n",
+    "source = \"\"\"\\\n",
+    "import a, b, c as d, e as f  # expect to keep: a, c as d\n",
+    "from g import h, i, j as k, l as m  # expect to keep: h, j as k\n",
+    "from n import o  # expect to be removed entirely\n",
+    "\n",
+    "a()\n",
+    "\n",
+    "def fun():\n",
+    "    d()\n",
+    "\n",
+    "class Cls:\n",
+    "    att = h.something\n",
+    "    \n",
+    "    def __new__(self) -> \"Cls\":\n",
+    "        var = k.method()\n",
+    "        func_undefined(var_undefined)\n",
+    "\"\"\"\n",
+    "wrapper = cst.metadata.MetadataWrapper(cst.parse_module(source))\n",
+    "scopes = set(wrapper.resolve(cst.metadata.ScopeProvider).values())\n",
+    "for scope in scopes:\n",
+    "    print(scope)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "Warn on unused imports and undefined references\n",
+    "===============================================\n",
+    "To find all unused imports, we iterate through :attr:`~libcst.metadata.Scope.assignments` and an assignment is unused when its :attr:`~libcst.metadata.BaseAssignment.references` is empty. To find all undefined references, we iterate through :attr:`~libcst.metadata.Scope.accesses` (we focus on :class:`~libcst.Import`/:class:`~libcst.ImportFrom` assignments) and an access is undefined reference when its :attr:`~libcst.metadata.Access.referents` is empty. When reporting the warning to developer, we'll want to report the line number and column offset along with the suggestion to make it more clear. We can get position information from :class:`~libcst.metadata.SyntacticPositionProvider` and print the warnings as follows.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from collections import defaultdict\n",
+    "from typing import Dict, Union, Set\n",
+    "\n",
+    "unused_imports: Dict[Union[cst.Import, cst.ImportFrom], Set[str]] = defaultdict(set)\n",
+    "undefined_references: Dict[cst.CSTNode, Set[str]] = defaultdict(set)\n",
+    "ranges = wrapper.resolve(cst.metadata.SyntacticPositionProvider)\n",
+    "for scope in scopes:\n",
+    "    for assignment in scope.assignments:\n",
+    "        node = assignment.node\n",
+    "        if isinstance(assignment, cst.metadata.Assignment) and isinstance(\n",
+    "            node, (cst.Import, cst.ImportFrom)\n",
+    "        ):\n",
+    "            if len(assignment.references) == 0:\n",
+    "                unused_imports[node].add(assignment.name)\n",
+    "                location = ranges[node].start\n",
+    "                print(\n",
+    "                    f\"Warning on line {location.line:2d}, column {location.column:2d}: Imported name `{assignment.name}` is unused.\"\n",
+    "                )\n",
+    "\n",
+    "    for access in scope.accesses:\n",
+    "        if len(access.referents) == 0:\n",
+    "            node = access.node\n",
+    "            location = ranges[node].start\n",
+    "            print(\n",
+    "                f\"Warning on line {location.line:2d}, column {location.column:2d}: Name reference `{node.value}` is not defined.\"\n",
+    "            )\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "Automatically Remove Unused Import\n",
+    "==================================\n",
+    "Unused import is a commmon code suggestion provided by lint tool like `flake8 F401 <https://lintlyci.github.io/Flake8Rules/rules/F401.html>`_ ``imported but unused``.\n",
+    "Even though reporing unused import is already useful, with LibCST we can provide automatic fix to remove unused import. That can make the suggestion more actionable and save developer's time.\n",
+    "\n",
+    "An import statement may import multiple names, we want to remove those unused names from the import statement. If all the names in the import statement are not used, we remove the entire import.\n",
+    "To remove the unused name, we implement ``RemoveUnusedImportTransformer`` by subclassing :class:`~libcst.CSTTransformer`. We overwrite ``leave_Import`` and ``leave_ImportFrom`` to modify the import statements.\n",
+    "When we find the import node in lookup table, we iterate through all ``names`` and keep used names in ``names_to_keep``.\n",
+    "If ``names_to_keep`` is empty, all names are unused and we remove the entire import node.\n",
+    "Otherwise, we update the import node and just removing partial names."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class RemoveUnusedImportTransformer(cst.CSTTransformer):\n",
+    "    def __init__(\n",
+    "        self, unused_imports: Dict[Union[cst.Import, cst.ImportFrom], Set[str]]\n",
+    "    ) -> None:\n",
+    "        self.unused_imports = unused_imports\n",
+    "\n",
+    "    def leave_import_alike(\n",
+    "        self,\n",
+    "        original_node: Union[cst.Import, cst.ImportFrom],\n",
+    "        updated_node: Union[cst.Import, cst.ImportFrom],\n",
+    "    ) -> Union[cst.Import, cst.ImportFrom, cst.RemovalSentinel]:\n",
+    "        if original_node not in self.unused_imports:\n",
+    "            return updated_node\n",
+    "        names_to_keep = []\n",
+    "        for name in updated_node.names:\n",
+    "            asname = name.asname\n",
+    "            if asname is not None:\n",
+    "                name_value = asname.name.value\n",
+    "            else:\n",
+    "                name_value = name.name.value\n",
+    "            if name_value not in self.unused_imports[original_node]:\n",
+    "                names_to_keep.append(name.with_changes(comma=cst.MaybeSentinel.DEFAULT))\n",
+    "        if len(names_to_keep) == 0:\n",
+    "            return cst.RemoveFromParent()\n",
+    "        else:\n",
+    "            return updated_node.with_changes(names=names_to_keep)\n",
+    "\n",
+    "    def leave_Import(\n",
+    "        self, original_node: cst.Import, updated_node: cst.Import\n",
+    "    ) -> cst.Import:\n",
+    "        return self.leave_import_alike(original_node, updated_node)\n",
+    "\n",
+    "    def leave_ImportFrom(\n",
+    "        self, original_node: cst.ImportFrom, updated_node: cst.ImportFrom\n",
+    "    ) -> cst.ImportFrom:\n",
+    "        return self.leave_import_alike(original_node, updated_node)\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "After the transform, we use ``.code`` to generate fixed code and all unused names are fixed as expected!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fixed_module = wrapper.module.visit(RemoveUnusedImportTransformer(unused_imports))\n",
+    "print(fixed_module.code)"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Raw Cell Format",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/libcst/metadata/__init__.py
+++ b/libcst/metadata/__init__.py
@@ -21,7 +21,9 @@ from libcst.metadata.position_provider import (
 )
 from libcst.metadata.scope_provider import (
     Access,
+    Accesses,
     Assignment,
+    Assignments,
     BaseAssignment,
     BuiltinAssignment,
     ClassScope,
@@ -33,8 +35,6 @@ from libcst.metadata.scope_provider import (
     QualifiedNameSource,
     Scope,
     ScopeProvider,
-    Assignments,
-    Accesses,
 )
 from libcst.metadata.wrapper import MetadataWrapper
 

--- a/libcst/metadata/__init__.py
+++ b/libcst/metadata/__init__.py
@@ -33,6 +33,8 @@ from libcst.metadata.scope_provider import (
     QualifiedNameSource,
     Scope,
     ScopeProvider,
+    Assignments,
+    Accesses,
 )
 from libcst.metadata.wrapper import MetadataWrapper
 
@@ -60,4 +62,6 @@ __all__ = [
     "VisitorMetadataProvider",
     "QualifiedNameProvider",
     "ProviderT",
+    "Assignments",
+    "Accesses",
 ]

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -37,6 +37,16 @@ from libcst.metadata.expression_context_provider import (
 class Access:
     """
     An Access records an access of an assignment.
+
+    .. warning::
+       This scope analysis only analyze access via a :class:`~libcst.Name` or  a :class:`~libcst.Name`
+       node embedded in other node like :class:`~libcst.Call` or :class:`~libcst.Attribute`.
+       It doesn't support type anontation using :class:`~libcst.SimpleString` literal for forward
+       reference. E.g. in this example, the ``"Tree"`` isn't parsed as as an access::
+
+           class Tree:
+               def __new__(cls) -> "Tree":
+                   ...
     """
 
     #: The name node of the access. A name is an access when the expression context is
@@ -584,7 +594,8 @@ class ScopeVisitor(cst.CSTVisitor):
         return self._visit_import_alike(node)
 
     def visit_Name(self, node: cst.Name) -> Optional[bool]:
-        context = self.provider.get_metadata(ExpressionContextProvider, node)
+        # not all Name have ExpressionContext
+        context = self.provider.get_metadata(ExpressionContextProvider, node, None)
         if context == ExpressionContext.STORE:
             self.scope.record_assignment(node.value, node)
         elif context == ExpressionContext.LOAD:

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -39,10 +39,10 @@ class Access:
     An Access records an access of an assignment.
 
     .. note::
-       This scope analysis only analyze access via a :class:`~libcst.Name` or  a :class:`~libcst.Name`
+       This scope analysis only analyzes access via a :class:`~libcst.Name` or  a :class:`~libcst.Name`
        node embedded in other node like :class:`~libcst.Call` or :class:`~libcst.Attribute`.
-       It doesn't support type anontation using :class:`~libcst.SimpleString` literal for forward
-       reference. E.g. in this example, the ``"Tree"`` isn't parsed as as an access::
+       It doesn't support type annontation using :class:`~libcst.SimpleString` literal for forward
+       references. E.g. in this example, the ``"Tree"`` isn't parsed as as an access::
 
            class Tree:
                def __new__(cls) -> "Tree":
@@ -300,9 +300,9 @@ class Scope(abc.ABC):
 
     .. note::
        This scope analysis module only analyzes local variable names and it doesn't handle
-       attribute names; for example, given a.b.c = 1, local variable name ``a`` is recorded
+       attribute names; for example, given ``a.b.c = 1``, local variable name ``a`` is recorded
        as an assignment instead of ``c`` or ``a.b.c``. To analyze the assignment/access of
-       arbitrary object attributes, we leave the the job to type inference metadata provider
+       arbitrary object attributes, we leave the job to type inference metadata provider
        coming in the future.
     """
 

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -38,7 +38,7 @@ class Access:
     """
     An Access records an access of an assignment.
 
-    .. warning::
+    .. note::
        This scope analysis only analyze access via a :class:`~libcst.Name` or  a :class:`~libcst.Name`
        node embedded in other node like :class:`~libcst.Call` or :class:`~libcst.Attribute`.
        It doesn't support type anontation using :class:`~libcst.SimpleString` literal for forward
@@ -102,8 +102,10 @@ class BaseAssignment(abc.ABC):
     @property
     def accesses(self) -> Tuple[Access, ...]:
         """Return all accesses of the assignment.
-        Deprecated: This will be removed soon. Please use
-        :attr:`~libcst.metadata.BaseAssignment.references` instead!
+
+        .. warning::
+           Deprecated: This will be removed soon. Please use
+           :attr:`~libcst.metadata.BaseAssignment.references` instead!
         """
         # we don't want to publicly expose the mutable version of this
         warnings.warn(
@@ -296,7 +298,7 @@ class Scope(abc.ABC):
     Use ``name in scope`` to check whether a name is viewable in the scope.
     Use ``scope[name]`` to retrieve all viewable assignments in the scope.
 
-    .. warning::
+    .. note::
        This scope analysis module only analyzes local variable names and it doesn't handle
        attribute names; for example, given a.b.c = 1, local variable name ``a`` is recorded
        as an assignment instead of ``c`` or ``a.b.c``. To analyze the assignment/access of

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -282,8 +282,16 @@ class Scope(abc.ABC):
     A scope has a parent scope which represents the inheritance relationship. That means
     an assignment in parent scope is viewable to the child scope and the child scope may
     overwrites the assignment by using the same name.
+
     Use ``name in scope`` to check whether a name is viewable in the scope.
     Use ``scope[name]`` to retrieve all viewable assignments in the scope.
+
+    .. warning::
+       This scope analysis module only analyzes local variable names and it doesn't handle
+       attribute names; for example, given a.b.c = 1, local variable name ``a`` is recorded
+       as an assignment instead of ``c`` or ``a.b.c``. To analyze the assignment/access of
+       arbitrary object attributes, we leave the the job to type inference metadata provider
+       coming in the future.
     """
 
     #: Parent scope. Note the parent scope of a GlobalScope is itself.

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -33,6 +33,7 @@ from libcst.metadata.expression_context_provider import (
     ExpressionContext,
     ExpressionContextProvider,
 )
+import warnings
 
 
 @add_slots
@@ -74,6 +75,16 @@ class BaseAssignment(abc.ABC):
         # we don't want to publicly expose the mutable version of this
         return set(self.__accesses)
 
+    @property
+    def accesses(self) -> Tuple[Access, ...]:
+        """Return all accesses of the assignment."""
+        # we don't want to publicly expose the mutable version of this
+        warnings.warn(
+            "This will be removed soon. Please use `.references` instead!",
+            DeprecationWarning,
+        )
+        return tuple(self.__accesses)
+
 
 class Assignment(BaseAssignment):
     """An assignment records the name, CSTNode and its accesses."""
@@ -85,6 +96,9 @@ class Assignment(BaseAssignment):
     def __init__(self, name: str, scope: "Scope", node: cst.CSTNode) -> None:
         self.node = node
         super().__init__(name, scope)
+
+    def __hash__(self) -> int:
+        return id(self)
 
 
 # even though we don't override the constructor.

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -316,10 +316,12 @@ class Scope(abc.ABC):
         self.record_assignment(name, node)
 
     def __contains__(self, name: str) -> bool:
+        """ Check if the name str exist in current scope by ``name in scope``. """
         return len(self[name]) > 0
 
     @abc.abstractmethod
     def __getitem__(self, name: str) -> Tuple[BaseAssignment, ...]:
+        """ Get assignments given a name str by ``scope[name]``. """
         ...
 
     def __hash__(self) -> int:
@@ -358,8 +360,7 @@ class Scope(abc.ABC):
         An imported name may be used for type annotation with :class:`~libcst.SimpleString` and
         currently resolving the qualified given :class:`~libcst.SimpleString` is not supported
         considering it could be a complex type annotation in the string which is hard to
-        resolve, e.g.
-        ``List[Union[int, str]]``.
+        resolve, e.g. ``List[Union[int, str]]``.
         """
         results = set()
         full_name = _NameUtil.get_full_name_for(node)

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -92,7 +92,10 @@ class BaseAssignment(abc.ABC):
 
     @property
     def accesses(self) -> Tuple[Access, ...]:
-        """Return all accesses of the assignment."""
+        """Return all accesses of the assignment.
+        Deprecated: This will be removed soon. Please use
+        :attr:`~libcst.metadata.BaseAssignment.references` instead!
+        """
         # we don't want to publicly expose the mutable version of this
         warnings.warn(
             "This will be removed soon. Please use `.references` instead!",
@@ -381,10 +384,12 @@ class Scope(abc.ABC):
 
     @property
     def assignments(self) -> Assignments:
+        """Return an :class:`~libcst.metadata.Assignments` contains all assignmens in current scope."""
         return Assignments(self._assignments)
 
     @property
     def accesses(self) -> Accesses:
+        """Return an :class:`~libcst.metadata.Accesses` contains all accesses in current scope."""
         return Accesses(self._accesses)
 
 

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -15,7 +15,6 @@ from enum import Enum, auto
 from typing import (
     Collection,
     Dict,
-    Generator,
     Iterator,
     List,
     Mapping,
@@ -137,7 +136,7 @@ class Assignments:
     def __init__(self, assignments: Mapping[str, Collection[BaseAssignment]]) -> None:
         self._assignments = assignments
 
-    def __iter__(self) -> Generator[BaseAssignment, None, None]:
+    def __iter__(self) -> Iterator[BaseAssignment]:
         """Iterate through all assignments by ``for i in scope.assignments``."""
         for assignments in self._assignments.values():
             for assignment in assignments:
@@ -159,7 +158,7 @@ class Accesses:
     def __init__(self, accesses: Mapping[str, Collection[Access]]) -> None:
         self._accesses = accesses
 
-    def __iter__(self) -> Generator[Access, None, None]:
+    def __iter__(self) -> Iterator[Access]:
         """Iterate through all accesses by ``for i in scope.accesses``."""
         for accesses in self._accesses.values():
             for access in accesses:
@@ -189,9 +188,11 @@ class QualifiedName:
 
 class _NameUtil:
     @staticmethod
-    def get_full_name_for(node: cst.CSTNode) -> Optional[str]:
+    def get_full_name_for(node: Union[str, cst.CSTNode]) -> Optional[str]:
         if isinstance(node, cst.Name):
             return node.value
+        elif isinstance(node, str):
+            return node
         elif isinstance(node, cst.Attribute):
             return f"{_NameUtil.get_full_name_for(node.value)}.{node.attr.value}"
         elif isinstance(node, cst.Call):
@@ -332,7 +333,9 @@ class Scope(abc.ABC):
     def record_nonlocal_overwrite(self, name: str) -> None:
         ...
 
-    def get_qualified_names_for(self, node: cst.CSTNode) -> Collection[QualifiedName]:
+    def get_qualified_names_for(
+        self, node: Union[str, cst.CSTNode]
+    ) -> Collection[QualifiedName]:
         """ Get all :class:`~libcst.metadata.QualifiedName` in current scope given a
         :class:`~libcst.CSTNode`.
         The source of a qualified name can be either :attr:`QualifiedNameSource.IMPORT`,

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -773,6 +773,13 @@ class ScopeProviderTest(UnitTest):
                 QualifiedName(name="d.e", source=QualifiedNameSource.IMPORT),
             },
         )
+        self.assertEqual(
+            scope.get_qualified_names_for("c"),
+            {
+                QualifiedName(name="a.b", source=QualifiedNameSource.IMPORT),
+                QualifiedName(name="d.e", source=QualifiedNameSource.IMPORT),
+            },
+        )
 
     def test_assignemnts_and_accesses(self) -> None:
         m, scopes = get_scope_metadata_provider(

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -802,10 +802,21 @@ class ScopeProviderTest(UnitTest):
         self.assertEqual(
             cast(Assignment, list(a_outer_assignments)[0]).node, a_outer_assign
         )
+        self.assertEqual(
+            {i.node for i in list(a_outer_assignments)[0].accesses}, {a_outer_access}
+        )
+        self.assertEqual(
+            {i.node for i in list(a_outer_assignments)[0].references}, {a_outer_access}
+        )
 
         a_outer_assesses = scope_of_module.accesses[a_outer_assign]
         self.assertEqual(len(a_outer_assesses), 1)
         self.assertEqual(list(a_outer_assesses)[0].node, a_outer_access)
+
+        self.assertEqual(
+            {cast(Assignment, i).node for i in list(a_outer_assesses)[0].referents},
+            {a_outer_assign},
+        )
 
         self.assertTrue(a_outer_assign in scope_of_module.accesses)
         self.assertTrue(a_outer_assign in scope_of_module.assignments)
@@ -860,3 +871,5 @@ class ScopeProviderTest(UnitTest):
             {cast(Assignment, i).node for i in scope_of_g.assignments},
             {b_inner_most_assign},
         )
+
+        self.assertEqual(len(set(scopes.values())), 3)


### PR DESCRIPTION
## Summary
Add `Scope.assignments` returns a `Assignments` which supports `__contains__`, `__iter__`, `__getitem__`.
Add `Scope.accesses` returns a`Accesses` which supports `__contains__`, `__iter__`, `__getitem__`.

Add `Access.referents` and `Assignment.references` to link an assignment to an access and vice versa.

Add scope analysis tutorial to demonstrate use cases: find unused import and undefined access; autofix unused import.
https://2960-200896124-gh.circle-artifacts.com/0/doc/index.html

## Test Plan
unit test.
