### PR TITLE
[doc] add docstring to QualifiedName

### DIFF
--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -27,6 +27,7 @@ from typing import (
 )
 
 import libcst as cst
+from libcst._add_slots import add_slots
 from libcst.metadata.base_provider import BatchableMetadataProvider
 from libcst.metadata.expression_context_provider import (
     ExpressionContext,
@@ -192,9 +193,14 @@ class QualifiedNameSource(Enum):
     LOCAL = auto()
 
 
+@add_slots
 @dataclass(frozen=True)
 class QualifiedName:
+    #: Qualified name, e.g. ``a.b.c`` or ``fn.<locals>.var``.
     name: str
+
+    #: Source of the name, either :attr:`QualifiedNameSource.IMPORT`, :attr:`QualifiedNameSource.BUILTIN`
+    #: or :attr:`QualifiedNameSource.LOCAL`.
     source: QualifiedNameSource
 
 


### PR DESCRIPTION
## Summary
Previously the docstring was missing and it's not clear what's inside QualifiedName. Added the docstring.

## Test Plan
Before
![image](https://user-images.githubusercontent.com/3840867/66447254-b809e080-ea02-11e9-9491-a16e7d0b4f55.png)

After
![image](https://user-images.githubusercontent.com/3840867/66447451-2b135700-ea03-11e9-9f58-79846578e798.png)


