### PR TITLE
Make `BaseMetadataProvider[T]` covariant over `T`

### DIFF
--- a/libcst/_metadata_dependent.py
+++ b/libcst/_metadata_dependent.py
@@ -41,9 +41,6 @@ class MetadataDependent(ABC):
     extend this class.
     """
 
-    # pyre-ignore[4]: Attribute `metadata` of class
-    # `libcst.metadata.dependent.MetadataDependent` must have a type that
-    # does not contain `Any`.
     #: A cached copy of metadata computed by :func:`~libcst.MetadataDependent.resolve`.
     #: Prefer using :func:`~libcst.MetadataDependent.get_metadata` over accessing
     #: this attribute directly.


### PR DESCRIPTION
## Summary

Because we'd consider `BaseMetadataProvider[int]` to be a subtype of
`BaseMetadataProvider[object]`, it should be covariant over its
typevar, rather than invariant.

This isn't entirely correct because we have a mutable data structure
(`_computed`) that depends on the typevar, and pyre points this out
(though with a really confusing error message). However, it's not
correct to say that `BaseMetadataProvider` is invariant either, so I
think this is the lesser evil.

I don't think it's practical to redesign this API to avoid the variance
issue, so I'm ignoring the new type error that results from this change.

I think this may resolve some of the issues we've seen internally with
D17820032.

## Test Plan

```
pyre check
```