### PR TITLE
Clean up on-call specification leftover from open-sourcing

### DIFF
--- a/libcst/matchers/tests/test_decorators.py
+++ b/libcst/matchers/tests/test_decorators.py
@@ -26,9 +26,6 @@ def fixture(code: str) -> cst.Module:
 
 
 class MatchersGatingDecoratorsTest(UnitTest):
-
-    ONCALL_SHORTNAME = "instagram_server_framework"
-
     def test_call_if_inside_transform_simple(self) -> None:
         # Set up a simple visitor with a call_if_inside decorator.
         class TestVisitor(MatcherDecoratableTransformer):
@@ -379,9 +376,6 @@ class MatchersGatingDecoratorsTest(UnitTest):
 
 
 class MatchersVisitLeaveDecoratorsTest(UnitTest):
-
-    ONCALL_SHORTNAME = "instagram_server_framework"
-
     def test_visit_transform(self) -> None:
         # Set up a simple visitor with a visit and leave decorator.
         class TestVisitor(MatcherDecoratableTransformer):

--- a/libcst/matchers/tests/test_matchers.py
+++ b/libcst/matchers/tests/test_matchers.py
@@ -11,9 +11,6 @@ from libcst.testing.utils import UnitTest
 
 
 class MatchersMatcherTest(UnitTest):
-
-    ONCALL_SHORTNAME = "instagram_server_framework"
-
     def test_simple_matcher_true(self) -> None:
         # Match based on identical attributes.
         self.assertTrue(matches(libcst.Name("foo"), m.Name("foo")))

--- a/libcst/matchers/tests/test_visitors.py
+++ b/libcst/matchers/tests/test_visitors.py
@@ -19,9 +19,6 @@ from libcst.testing.utils import UnitTest
 
 
 class MatchersVisitLeaveDecoratorTypingTest(UnitTest):
-
-    ONCALL_SHORTNAME = "instagram_server_framework"
-
     def test_valid_collector_simple(self) -> None:
         class TestVisitor(MatcherDecoratableVisitor):
             @visit(m.SimpleString())


### PR DESCRIPTION
## Summary

As it says on the tin!

## Test Plan

Grepped for `ONCALL`, deleted instances.