### PR TITLE
Use import libcst as cst and explicit keyword arg for consistency and readability

### DIFF
--- a/libcst/matchers/tests/test_matchers.py
+++ b/libcst/matchers/tests/test_matchers.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
-import libcst
+import libcst as cst
 import libcst.matchers as m
 from libcst.matchers import matches
 from libcst.testing.utils import UnitTest
@@ -16,22 +16,22 @@ class MatchersMatcherTest(UnitTest):
 
     def test_simple_matcher_true(self) -> None:
         # Match based on identical attributes.
-        self.assertTrue(matches(libcst.Name("foo"), m.Name("foo")))
+        self.assertTrue(matches(cst.Name("foo"), m.Name("foo")))
 
     def test_simple_matcher_false(self) -> None:
         # Fail to match due to incorrect value on Name.
-        self.assertFalse(matches(libcst.Name("foo"), m.Name("bar")))
+        self.assertFalse(matches(cst.Name("foo"), m.Name("bar")))
 
     def test_complex_matcher_true(self) -> None:
         # Match on any Call, not caring about arguments.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(),
@@ -40,12 +40,12 @@ class MatchersMatcherTest(UnitTest):
         # Match on any Call to a function named "foo".
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(m.Name("foo")),
@@ -54,48 +54,48 @@ class MatchersMatcherTest(UnitTest):
         # Match on any Call to a function named "foo" with three arguments.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
-                m.Call(m.Name("foo"), (m.Arg(), m.Arg(), m.Arg())),
+                m.Call(func=m.Name("foo"), args=(m.Arg(), m.Arg(), m.Arg())),
             )
         )
         # Match any Call to a function named "foo" with three integer arguments.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"),
-                    (m.Arg(m.Integer()), m.Arg(m.Integer()), m.Arg(m.Integer())),
+                    func=m.Name("foo"),
+                    args=(m.Arg(m.Integer()), m.Arg(m.Integer()), m.Arg(m.Integer())),
                 ),
             )
         )
         # Match any Call to a function named "foo" with integer arguments 1, 2, 3.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"),
-                    (
+                    func=m.Name("foo"),
+                    args=(
                         m.Arg(m.Integer("1")),
                         m.Arg(m.Integer("2")),
                         m.Arg(m.Integer("3")),
@@ -107,16 +107,17 @@ class MatchersMatcherTest(UnitTest):
         # being the integer 3.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"), (m.DoNotCare(), m.DoNotCare(), m.Arg(m.Integer("3")))
+                    func=m.Name("foo"),
+                    args=(m.DoNotCare(), m.DoNotCare(), m.Arg(m.Integer("3"))),
                 ),
             )
         )
@@ -125,12 +126,12 @@ class MatchersMatcherTest(UnitTest):
         # Fail to match since this is a Call, not a FunctionDef.
         self.assertFalse(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.FunctionDef(),
@@ -139,12 +140,12 @@ class MatchersMatcherTest(UnitTest):
         # Fail to match a function named "bar".
         self.assertFalse(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(m.Name("bar")),
@@ -153,32 +154,32 @@ class MatchersMatcherTest(UnitTest):
         # Fail to match a function named "foo" with two arguments.
         self.assertFalse(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
-                m.Call(m.Name("foo"), (m.Arg(), m.Arg())),
+                m.Call(func=m.Name("foo"), args=(m.Arg(), m.Arg())),
             )
         )
         # Fail to match a function named "foo" with three integer arguments
         # 3, 2, 1.
         self.assertFalse(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"),
-                    (
+                    func=m.Name("foo"),
+                    args=(
                         m.Arg(m.Integer("3")),
                         m.Arg(m.Integer("2")),
                         m.Arg(m.Integer("1")),
@@ -190,16 +191,17 @@ class MatchersMatcherTest(UnitTest):
         # being the integer 1.
         self.assertFalse(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"), (m.DoNotCare(), m.DoNotCare(), m.Arg(m.Integer("1")))
+                    func=m.Name("foo"),
+                    args=(m.DoNotCare(), m.DoNotCare(), m.Arg(m.Integer("1"))),
                 ),
             )
         )
@@ -207,31 +209,29 @@ class MatchersMatcherTest(UnitTest):
     def test_or_matcher_true(self) -> None:
         # Match on either True or False identifier.
         self.assertTrue(
-            matches(libcst.Name("True"), m.OneOf(m.Name("True"), m.Name("False")))
+            matches(cst.Name("True"), m.OneOf(m.Name("True"), m.Name("False")))
         )
         # Match any assignment that assigns a value of True or False to an
         # unspecified target.
         self.assertTrue(
             matches(
-                libcst.Assign(
-                    (libcst.AssignTarget(libcst.Name("x")),), libcst.Name("True")
-                ),
+                cst.Assign((cst.AssignTarget(cst.Name("x")),), cst.Name("True")),
                 m.Assign(value=m.OneOf(m.Name("True"), m.Name("False"))),
             )
         )
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"),
-                    m.OneOf(
+                    func=m.Name("foo"),
+                    args=m.OneOf(
                         (
                             m.Arg(m.Integer("3")),
                             m.Arg(m.Integer("2")),
@@ -250,31 +250,29 @@ class MatchersMatcherTest(UnitTest):
     def test_or_matcher_false(self) -> None:
         # Fail to match since None is not True or False.
         self.assertFalse(
-            matches(libcst.Name("None"), m.OneOf(m.Name("True"), m.Name("False")))
+            matches(cst.Name("None"), m.OneOf(m.Name("True"), m.Name("False")))
         )
         # Fail to match since assigning None to a target is not the same as
         # assigning True or False to a target.
         self.assertFalse(
             matches(
-                libcst.Assign(
-                    (libcst.AssignTarget(libcst.Name("x")),), libcst.Name("None")
-                ),
+                cst.Assign((cst.AssignTarget(cst.Name("x")),), cst.Name("None")),
                 m.Assign(value=m.OneOf(m.Name("True"), m.Name("False"))),
             )
         )
         self.assertFalse(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"),
-                    m.OneOf(
+                    func=m.Name("foo"),
+                    args=m.OneOf(
                         (
                             m.Arg(m.Integer("3")),
                             m.Arg(m.Integer("2")),
@@ -292,36 +290,30 @@ class MatchersMatcherTest(UnitTest):
 
     def test_or_operator_matcher_true(self) -> None:
         # Match on either True or False identifier.
-        self.assertTrue(matches(libcst.Name("True"), m.Name("True") | m.Name("False")))
+        self.assertTrue(matches(cst.Name("True"), m.Name("True") | m.Name("False")))
         # Match on either True or False identifier.
-        self.assertTrue(matches(libcst.Name("False"), m.Name("True") | m.Name("False")))
+        self.assertTrue(matches(cst.Name("False"), m.Name("True") | m.Name("False")))
         # Match on either True, False or None identifier.
         self.assertTrue(
-            matches(
-                libcst.Name("None"), m.Name("True") | m.Name("False") | m.Name("None")
-            )
+            matches(cst.Name("None"), m.Name("True") | m.Name("False") | m.Name("None"))
         )
         # Match any assignment that assigns a value of True or False to an
         # unspecified target.
         self.assertTrue(
             matches(
-                libcst.Assign(
-                    (libcst.AssignTarget(libcst.Name("x")),), libcst.Name("True")
-                ),
+                cst.Assign((cst.AssignTarget(cst.Name("x")),), cst.Name("True")),
                 m.Assign(value=m.Name("True") | m.Name("False")),
             )
         )
 
     def test_or_operator_matcher_false(self) -> None:
         # Fail to match since None is not True or False.
-        self.assertFalse(matches(libcst.Name("None"), m.Name("True") | m.Name("False")))
+        self.assertFalse(matches(cst.Name("None"), m.Name("True") | m.Name("False")))
         # Fail to match since assigning None to a target is not the same as
         # assigning True or False to a target.
         self.assertFalse(
             matches(
-                libcst.Assign(
-                    (libcst.AssignTarget(libcst.Name("x")),), libcst.Name("None")
-                ),
+                cst.Assign((cst.AssignTarget(cst.Name("x")),), cst.Name("None")),
                 m.Assign(value=m.Name("True") | m.Name("False")),
             )
         )
@@ -331,32 +323,34 @@ class MatchersMatcherTest(UnitTest):
         # long as the first one is an integer with the value 1.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
-                m.Call(m.Name("foo"), (m.Arg(m.Integer("1")), m.ZeroOrMore())),
+                m.Call(
+                    func=m.Name("foo"), args=(m.Arg(m.Integer("1")), m.ZeroOrMore())
+                ),
             )
         )
         # Match a function call to "foo" with any number of arguments as
         # long as one of them is an integer with the value 1.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"),
-                    (m.ZeroOrMore(), m.Arg(m.Integer("1")), m.ZeroOrMore()),
+                    func=m.Name("foo"),
+                    args=(m.ZeroOrMore(), m.Arg(m.Integer("1")), m.ZeroOrMore()),
                 ),
             )
         )
@@ -364,17 +358,17 @@ class MatchersMatcherTest(UnitTest):
         # long as one of them is an integer with the value 2.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"),
-                    (m.ZeroOrMore(), m.Arg(m.Integer("2")), m.ZeroOrMore()),
+                    func=m.Name("foo"),
+                    args=(m.ZeroOrMore(), m.Arg(m.Integer("2")), m.ZeroOrMore()),
                 ),
             )
         )
@@ -382,17 +376,17 @@ class MatchersMatcherTest(UnitTest):
         # long as one of them is an integer with the value 3.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"),
-                    (m.ZeroOrMore(), m.Arg(m.Integer("3")), m.ZeroOrMore()),
+                    func=m.Name("foo"),
+                    args=(m.ZeroOrMore(), m.Arg(m.Integer("3")), m.ZeroOrMore()),
                 ),
             )
         )
@@ -400,15 +394,17 @@ class MatchersMatcherTest(UnitTest):
         # long as the last one is an integer with the value 3.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
-                m.Call(m.Name("foo"), (m.ZeroOrMore(), m.Arg(m.Integer("3")))),
+                m.Call(
+                    func=m.Name("foo"), args=(m.ZeroOrMore(), m.Arg(m.Integer("3")))
+                ),
             )
         )
         # Match a function call to "foo" with any number of arguments as
@@ -416,17 +412,17 @@ class MatchersMatcherTest(UnitTest):
         # in the argument list, respecting order.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"),
-                    (
+                    func=m.Name("foo"),
+                    args=(
                         m.ZeroOrMore(),
                         m.Arg(m.Integer("1")),
                         m.ZeroOrMore(),
@@ -441,17 +437,17 @@ class MatchersMatcherTest(UnitTest):
         # in the argument list, respecting order.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"),
-                    (
+                    func=m.Name("foo"),
+                    args=(
                         m.ZeroOrMore(),
                         m.Arg(m.Integer("1")),
                         m.ZeroOrMore(),
@@ -468,73 +464,77 @@ class MatchersMatcherTest(UnitTest):
         # Match a function call to "foo" with at least one argument.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
-                m.Call(m.Name("foo"), (m.AtLeastN(n=1),)),
+                m.Call(func=m.Name("foo"), args=(m.AtLeastN(n=1),)),
             )
         )
         # Match a function call to "foo" with at least two arguments.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
-                m.Call(m.Name("foo"), (m.AtLeastN(n=2),)),
+                m.Call(func=m.Name("foo"), args=(m.AtLeastN(n=2),)),
             )
         )
         # Match a function call to "foo" with at least three arguments.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
-                m.Call(m.Name("foo"), (m.AtLeastN(n=3),)),
+                m.Call(func=m.Name("foo"), args=(m.AtLeastN(n=3),)),
             )
         )
         # Match a function call to "foo" with at least two arguments the
         # first one being the integer 1.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
-                m.Call(m.Name("foo"), (m.Arg(m.Integer("1")), m.AtLeastN(n=1))),
+                m.Call(
+                    func=m.Name("foo"), args=(m.Arg(m.Integer("1")), m.AtLeastN(n=1))
+                ),
             )
         )
         # Match a function call to "foo" with at least three arguments the
         # first one being the integer 1.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
-                m.Call(m.Name("foo"), (m.Arg(m.Integer("1")), m.AtLeastN(n=2))),
+                m.Call(
+                    func=m.Name("foo"), args=(m.Arg(m.Integer("1")), m.AtLeastN(n=2))
+                ),
             )
         )
         # Match a function call to "foo" with at least three arguments. The
@@ -542,17 +542,17 @@ class MatchersMatcherTest(UnitTest):
         # at least one argument before and one argument after.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"),
-                    (m.AtLeastN(n=1), m.Arg(m.Integer("2")), m.AtLeastN(n=1)),
+                    func=m.Name("foo"),
+                    args=(m.AtLeastN(n=1), m.Arg(m.Integer("2")), m.AtLeastN(n=1)),
                 ),
             )
         )
@@ -560,30 +560,34 @@ class MatchersMatcherTest(UnitTest):
         # one being the value 3.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
-                m.Call(m.Name("foo"), (m.AtLeastN(n=1), m.Arg(m.Integer("3")))),
+                m.Call(
+                    func=m.Name("foo"), args=(m.AtLeastN(n=1), m.Arg(m.Integer("3")))
+                ),
             )
         )
         # Match a function call to "foo" with at least three arguments, the last
         # one being the value 3.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
-                m.Call(m.Name("foo"), (m.AtLeastN(n=2), m.Arg(m.Integer("3")))),
+                m.Call(
+                    func=m.Name("foo"), args=(m.AtLeastN(n=2), m.Arg(m.Integer("3")))
+                ),
             )
         )
 
@@ -591,45 +595,49 @@ class MatchersMatcherTest(UnitTest):
         # Fail to match a function call to "foo" with at least four arguments.
         self.assertFalse(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
-                m.Call(m.Name("foo"), (m.AtLeastN(n=4),)),
+                m.Call(func=m.Name("foo"), args=(m.AtLeastN(n=4),)),
             )
         )
         # Fail to match a function call to "foo" with at least four arguments,
         # the first one being the value 1.
         self.assertFalse(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
-                m.Call(m.Name("foo"), (m.Arg(m.Integer("1")), m.AtLeastN(n=3))),
+                m.Call(
+                    func=m.Name("foo"), args=(m.Arg(m.Integer("1")), m.AtLeastN(n=3))
+                ),
             )
         )
         # Fail to match a function call to "foo" with at least three arguments,
         # the last one being the value 2.
         self.assertFalse(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
-                m.Call(m.Name("foo"), (m.AtLeastN(n=2), m.Arg(m.Integer("2")))),
+                m.Call(
+                    func=m.Name("foo"), args=(m.AtLeastN(n=2), m.Arg(m.Integer("2")))
+                ),
             )
         )
 
@@ -638,32 +646,35 @@ class MatchersMatcherTest(UnitTest):
         # value 1, and the rest of the arguements are wildcards.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
-                m.Call(m.Name("foo"), (m.Arg(m.Integer("1")), m.ZeroOrMore(m.Arg()))),
+                m.Call(
+                    func=m.Name("foo"),
+                    args=(m.Arg(m.Integer("1")), m.ZeroOrMore(m.Arg())),
+                ),
             )
         )
         # Match a function call to "foo" where the first argument is the integer
         # value 1, and the rest of the arguements are integers of any value.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"),
-                    (m.Arg(m.Integer("1")), m.ZeroOrMore(m.Arg(m.Integer()))),
+                    func=m.Name("foo"),
+                    args=(m.Arg(m.Integer("1")), m.ZeroOrMore(m.Arg(m.Integer()))),
                 ),
             )
         )
@@ -673,17 +684,17 @@ class MatchersMatcherTest(UnitTest):
         # matcher.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"),
-                    (
+                    func=m.Name("foo"),
+                    args=(
                         m.ZeroOrMore(m.Arg(m.OneOf(m.Integer("1"), m.Integer("2")))),
                         m.Arg(m.Integer("2")),
                         m.ZeroOrMore(),
@@ -696,17 +707,17 @@ class MatchersMatcherTest(UnitTest):
         # 2 or 3.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"),
-                    (
+                    func=m.Name("foo"),
+                    args=(
                         m.Arg(m.Integer("1")),
                         m.ZeroOrMore(m.Arg(m.OneOf(m.Integer("2"), m.Integer("3")))),
                     ),
@@ -719,17 +730,17 @@ class MatchersMatcherTest(UnitTest):
         # integer value 1, and the rest of the arguments are strings.
         self.assertFalse(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"),
-                    (m.Arg(m.Integer("1")), m.ZeroOrMore(m.Arg(m.SimpleString()))),
+                    func=m.Name("foo"),
+                    args=(m.Arg(m.Integer("1")), m.ZeroOrMore(m.Arg(m.SimpleString()))),
                 ),
             )
         )
@@ -738,17 +749,17 @@ class MatchersMatcherTest(UnitTest):
         # value 2.
         self.assertFalse(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"),
-                    (m.Arg(m.Integer("1")), m.ZeroOrMore(m.Arg(m.Integer("2")))),
+                    func=m.Name("foo"),
+                    args=(m.Arg(m.Integer("1")), m.ZeroOrMore(m.Arg(m.Integer("2")))),
                 ),
             )
         )
@@ -758,16 +769,17 @@ class MatchersMatcherTest(UnitTest):
         # value 1, and there are at least two wildcard arguments after.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"), (m.Arg(m.Integer("1")), m.AtLeastN(m.Arg(), n=2))
+                    func=m.Name("foo"),
+                    args=(m.Arg(m.Integer("1")), m.AtLeastN(m.Arg(), n=2)),
                 ),
             )
         )
@@ -776,17 +788,17 @@ class MatchersMatcherTest(UnitTest):
         # after.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"),
-                    (m.Arg(m.Integer("1")), m.AtLeastN(m.Arg(m.Integer()), n=2)),
+                    func=m.Name("foo"),
+                    args=(m.Arg(m.Integer("1")), m.AtLeastN(m.Arg(m.Integer()), n=2)),
                 ),
             )
         )
@@ -795,17 +807,17 @@ class MatchersMatcherTest(UnitTest):
         # value 2 or 3 after.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"),
-                    (
+                    func=m.Name("foo"),
+                    args=(
                         m.Arg(m.Integer("1")),
                         m.AtLeastN(m.Arg(m.OneOf(m.Integer("2"), m.Integer("3"))), n=2),
                     ),
@@ -819,17 +831,20 @@ class MatchersMatcherTest(UnitTest):
         # strings.
         self.assertFalse(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"),
-                    (m.Arg(m.Integer("1")), m.AtLeastN(m.Arg(m.SimpleString()), n=2)),
+                    func=m.Name("foo"),
+                    args=(
+                        m.Arg(m.Integer("1")),
+                        m.AtLeastN(m.Arg(m.SimpleString()), n=2),
+                    ),
                 ),
             )
         )
@@ -837,16 +852,17 @@ class MatchersMatcherTest(UnitTest):
         # value 1, and there are at least three wildcard arguments after.
         self.assertFalse(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"), (m.Arg(m.Integer("1")), m.AtLeastN(m.Arg(), n=3))
+                    func=m.Name("foo"),
+                    args=(m.Arg(m.Integer("1")), m.AtLeastN(m.Arg(), n=3)),
                 ),
             )
         )
@@ -855,17 +871,20 @@ class MatchersMatcherTest(UnitTest):
         # the value 2 after.
         self.assertFalse(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"),
-                    (m.Arg(m.Integer("1")), m.AtLeastN(m.Arg(m.Integer("2")), n=2)),
+                    func=m.Name("foo"),
+                    args=(
+                        m.Arg(m.Integer("1")),
+                        m.AtLeastN(m.Arg(m.Integer("2")), n=2),
+                    ),
                 ),
             )
         )
@@ -874,59 +893,65 @@ class MatchersMatcherTest(UnitTest):
         # Match a function call to "foo" with at most two arguments.
         self.assertTrue(
             matches(
-                libcst.Call(libcst.Name("foo"), (libcst.Arg(libcst.Integer("1")),)),
-                m.Call(m.Name("foo"), (m.AtMostN(n=2),)),
+                cst.Call(func=cst.Name("foo"), args=(cst.Arg(cst.Integer("1")),)),
+                m.Call(func=m.Name("foo"), args=(m.AtMostN(n=2),)),
             )
         )
         # Match a function call to "foo" with at most two arguments.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (libcst.Arg(libcst.Integer("1")), libcst.Arg(libcst.Integer("2"))),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(cst.Arg(cst.Integer("1")), cst.Arg(cst.Integer("2"))),
                 ),
-                m.Call(m.Name("foo"), (m.AtMostN(n=2),)),
+                m.Call(func=m.Name("foo"), args=(m.AtMostN(n=2),)),
             )
         )
         # Match a function call to "foo" with at most six arguments, the last
         # one being the integer 1.
         self.assertTrue(
             matches(
-                libcst.Call(libcst.Name("foo"), (libcst.Arg(libcst.Integer("1")),)),
-                m.Call(m.Name("foo"), [m.AtMostN(n=5), m.Arg(m.Integer("1"))]),
+                cst.Call(func=cst.Name("foo"), args=(cst.Arg(cst.Integer("1")),)),
+                m.Call(
+                    func=m.Name("foo"), args=[m.AtMostN(n=5), m.Arg(m.Integer("1"))]
+                ),
             )
         )
         # Match a function call to "foo" with at most six arguments, the last
         # one being the integer 1.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (libcst.Arg(libcst.Integer("1")), libcst.Arg(libcst.Integer("2"))),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(cst.Arg(cst.Integer("1")), cst.Arg(cst.Integer("2"))),
                 ),
-                m.Call(m.Name("foo"), (m.AtMostN(n=5), m.Arg(m.Integer("2")))),
+                m.Call(
+                    func=m.Name("foo"), args=(m.AtMostN(n=5), m.Arg(m.Integer("2")))
+                ),
             )
         )
         # Match a function call to "foo" with at most six arguments, the first
         # one being the integer 1.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (libcst.Arg(libcst.Integer("1")), libcst.Arg(libcst.Integer("2"))),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(cst.Arg(cst.Integer("1")), cst.Arg(cst.Integer("2"))),
                 ),
-                m.Call(m.Name("foo"), (m.Arg(m.Integer("1")), m.AtMostN(n=5))),
+                m.Call(
+                    func=m.Name("foo"), args=(m.Arg(m.Integer("1")), m.AtMostN(n=5))
+                ),
             )
         )
         # Match a function call to "foo" with at most six arguments, the first
         # one being the integer 1.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (libcst.Arg(libcst.Integer("1")), libcst.Arg(libcst.Integer("2"))),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(cst.Arg(cst.Integer("1")), cst.Arg(cst.Integer("2"))),
                 ),
-                m.Call(m.Name("foo"), (m.Arg(m.Integer("1")), m.ZeroOrOne())),
+                m.Call(func=m.Name("foo"), args=(m.Arg(m.Integer("1")), m.ZeroOrOne())),
             )
         )
 
@@ -934,45 +959,47 @@ class MatchersMatcherTest(UnitTest):
         # Fail to match a function call to "foo" with at most two arguments.
         self.assertFalse(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
-                m.Call(m.Name("foo"), (m.AtMostN(n=2),)),
+                m.Call(func=m.Name("foo"), args=(m.AtMostN(n=2),)),
             )
         )
         # Fail to match a function call to "foo" with at most two arguments,
         # the last one being the integer 3.
         self.assertFalse(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
-                m.Call(m.Name("foo"), (m.AtMostN(n=1), m.Arg(m.Integer("3")))),
+                m.Call(
+                    func=m.Name("foo"), args=(m.AtMostN(n=1), m.Arg(m.Integer("3")))
+                ),
             )
         )
         # Fail to match a function call to "foo" with at most two arguments,
         # the last one being the integer 3.
         self.assertFalse(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
-                m.Call(m.Name("foo"), (m.ZeroOrOne(), m.Arg(m.Integer("3")))),
+                m.Call(func=m.Name("foo"), args=(m.ZeroOrOne(), m.Arg(m.Integer("3")))),
             )
         )
 
@@ -981,21 +1008,25 @@ class MatchersMatcherTest(UnitTest):
         # are the integer 1.
         self.assertTrue(
             matches(
-                libcst.Call(libcst.Name("foo"), (libcst.Arg(libcst.Integer("1")),)),
-                m.Call(m.Name("foo"), (m.AtMostN(m.Arg(m.Integer("1")), n=2),)),
+                cst.Call(func=cst.Name("foo"), args=(cst.Arg(cst.Integer("1")),)),
+                m.Call(
+                    func=m.Name("foo"), args=(m.AtMostN(m.Arg(m.Integer("1")), n=2),)
+                ),
             )
         )
         # Match a function call to "foo" with at most two arguments, both of which
         # can be the integer 1 or 2.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (libcst.Arg(libcst.Integer("1")), libcst.Arg(libcst.Integer("2"))),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(cst.Arg(cst.Integer("1")), cst.Arg(cst.Integer("2"))),
                 ),
                 m.Call(
-                    m.Name("foo"),
-                    (m.AtMostN(m.Arg(m.OneOf(m.Integer("1"), m.Integer("2"))), n=2),),
+                    func=m.Name("foo"),
+                    args=(
+                        m.AtMostN(m.Arg(m.OneOf(m.Integer("1"), m.Integer("2"))), n=2),
+                    ),
                 ),
             )
         )
@@ -1004,13 +1035,13 @@ class MatchersMatcherTest(UnitTest):
         # integer 2.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (libcst.Arg(libcst.Integer("1")), libcst.Arg(libcst.Integer("2"))),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(cst.Arg(cst.Integer("1")), cst.Arg(cst.Integer("2"))),
                 ),
                 m.Call(
-                    m.Name("foo"),
-                    (m.Arg(m.Integer("1")), m.ZeroOrOne(m.Arg(m.Integer("2")))),
+                    func=m.Name("foo"),
+                    args=(m.Arg(m.Integer("1")), m.ZeroOrOne(m.Arg(m.Integer("2")))),
                 ),
             )
         )
@@ -1019,13 +1050,13 @@ class MatchersMatcherTest(UnitTest):
         # integer 2.
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (libcst.Arg(libcst.Integer("1")), libcst.Arg(libcst.Integer("2"))),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(cst.Arg(cst.Integer("1")), cst.Arg(cst.Integer("2"))),
                 ),
                 m.Call(
-                    m.Name("foo"),
-                    (m.Arg(m.Integer("1")), m.ZeroOrOne(m.Arg(m.Integer("2")))),
+                    func=m.Name("foo"),
+                    args=(m.Arg(m.Integer("1")), m.ZeroOrOne(m.Arg(m.Integer("2")))),
                 ),
             )
         )
@@ -1035,15 +1066,17 @@ class MatchersMatcherTest(UnitTest):
         # all of which are the integer 4.
         self.assertFalse(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
-                m.Call(m.Name("foo"), (m.AtMostN(m.Arg(m.Integer("4")), n=3),)),
+                m.Call(
+                    func=m.Name("foo"), args=(m.AtMostN(m.Arg(m.Integer("4")), n=3),)
+                ),
             )
         )
 
@@ -1051,8 +1084,7 @@ class MatchersMatcherTest(UnitTest):
         # Match based on identical attributes.
         self.assertTrue(
             matches(
-                libcst.Name("foo"),
-                m.Name(value=m.MatchIfTrue(lambda value: "o" in value)),
+                cst.Name("foo"), m.Name(value=m.MatchIfTrue(lambda value: "o" in value))
             )
         )
 
@@ -1060,44 +1092,38 @@ class MatchersMatcherTest(UnitTest):
         # Fail to match due to incorrect value on Name.
         self.assertFalse(
             matches(
-                libcst.Name("foo"),
-                m.Name(value=m.MatchIfTrue(lambda value: "a" in value)),
+                cst.Name("foo"), m.Name(value=m.MatchIfTrue(lambda value: "a" in value))
             )
         )
 
     def test_regex_matcher_true(self) -> None:
         # Match based on identical attributes.
-        self.assertTrue(
-            matches(libcst.Name("foo"), m.Name(value=m.MatchRegex(r".*o.*")))
-        )
+        self.assertTrue(matches(cst.Name("foo"), m.Name(value=m.MatchRegex(r".*o.*"))))
 
     def test_regex_matcher_false(self) -> None:
         # Fail to match due to incorrect value on Name.
-        self.assertFalse(
-            matches(libcst.Name("foo"), m.Name(value=m.MatchRegex(r".*a.*")))
-        )
+        self.assertFalse(matches(cst.Name("foo"), m.Name(value=m.MatchRegex(r".*a.*"))))
 
     def test_and_matcher_true(self) -> None:
         # Match on True identifier in roundabout way.
         self.assertTrue(
             matches(
-                libcst.Name("True"),
-                m.AllOf(m.Name(), m.Name(value=m.MatchRegex(r"True"))),
+                cst.Name("True"), m.AllOf(m.Name(), m.Name(value=m.MatchRegex(r"True")))
             )
         )
         self.assertTrue(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"),
-                    m.AllOf(
+                    func=m.Name("foo"),
+                    args=m.AllOf(
                         (m.Arg(), m.Arg(), m.Arg()),
                         (
                             m.Arg(m.Integer("1")),
@@ -1112,21 +1138,21 @@ class MatchersMatcherTest(UnitTest):
     def test_and_matcher_false(self) -> None:
         # Fail to match since True and False cannot match.
         self.assertFalse(
-            matches(libcst.Name("None"), m.AllOf(m.Name("True"), m.Name("False")))
+            matches(cst.Name("None"), m.AllOf(m.Name("True"), m.Name("False")))
         )
         self.assertFalse(
             matches(
-                libcst.Call(
-                    libcst.Name("foo"),
-                    (
-                        libcst.Arg(libcst.Integer("1")),
-                        libcst.Arg(libcst.Integer("2")),
-                        libcst.Arg(libcst.Integer("3")),
+                cst.Call(
+                    func=cst.Name("foo"),
+                    args=(
+                        cst.Arg(cst.Integer("1")),
+                        cst.Arg(cst.Integer("2")),
+                        cst.Arg(cst.Integer("3")),
                     ),
                 ),
                 m.Call(
-                    m.Name("foo"),
-                    m.AllOf(
+                    func=m.Name("foo"),
+                    args=m.AllOf(
                         (m.Arg(), m.Arg(), m.Arg()),
                         (
                             m.Arg(m.Integer("3")),
@@ -1141,60 +1167,60 @@ class MatchersMatcherTest(UnitTest):
     def test_and_operator_matcher_true(self) -> None:
         # Match on True identifier in roundabout way.
         self.assertTrue(
-            matches(libcst.Name("True"), m.Name() & m.Name(value=m.MatchRegex(r"True")))
+            matches(cst.Name("True"), m.Name() & m.Name(value=m.MatchRegex(r"True")))
         )
         # Match in a really roundabout way that verifies the __or__ behavior on
         # AllOf itself.
         self.assertTrue(
             matches(
-                libcst.Name("True"),
+                cst.Name("True"),
                 m.Name() & m.Name(value=m.MatchRegex(r"True")) & m.Name("True"),
             )
         )
         # Verify that MatchIfTrue works with __and__ behavior properly.
         self.assertTrue(
             matches(
-                libcst.Name("True"),
-                m.MatchIfTrue(lambda x: isinstance(x, libcst.Name))
+                cst.Name("True"),
+                m.MatchIfTrue(lambda x: isinstance(x, cst.Name))
                 & m.Name(value=m.MatchRegex(r"True")),
             )
         )
         self.assertTrue(
             matches(
-                libcst.Name("True"),
+                cst.Name("True"),
                 m.Name(value=m.MatchRegex(r"True"))
-                & m.MatchIfTrue(lambda x: isinstance(x, libcst.Name)),
+                & m.MatchIfTrue(lambda x: isinstance(x, cst.Name)),
             )
         )
 
     def test_and_operator_matcher_false(self) -> None:
         # Fail to match since True and False cannot match.
-        self.assertFalse(matches(libcst.Name("None"), m.Name("True") & m.Name("False")))
+        self.assertFalse(matches(cst.Name("None"), m.Name("True") & m.Name("False")))
 
     def test_does_not_match_true(self) -> None:
         # Match on any call that takes one argument that isn't the value None.
         self.assertTrue(
             matches(
-                libcst.Call(libcst.Name("foo"), (libcst.Arg(libcst.Name("True")),)),
+                cst.Call(func=cst.Name("foo"), args=(cst.Arg(cst.Name("True")),)),
                 m.Call(args=(m.Arg(value=m.DoesNotMatch(m.Name("None"))),)),
             )
         )
         self.assertTrue(
             matches(
-                libcst.Call(libcst.Name("foo"), (libcst.Arg(libcst.Integer("1")),)),
+                cst.Call(func=cst.Name("foo"), args=(cst.Arg(cst.Integer("1")),)),
                 m.Call(args=(m.DoesNotMatch(m.Arg(m.Name("None"))),)),
             )
         )
         self.assertTrue(
             matches(
-                libcst.Call(libcst.Name("foo"), (libcst.Arg(libcst.Integer("1")),)),
+                cst.Call(func=cst.Name("foo"), args=(cst.Arg(cst.Integer("1")),)),
                 m.Call(args=m.DoesNotMatch((m.Arg(m.Integer("2")),))),
             )
         )
         # Match any call that takes an argument which isn't True or False.
         self.assertTrue(
             matches(
-                libcst.Call(libcst.Name("foo"), (libcst.Arg(libcst.Integer("1")),)),
+                cst.Call(func=cst.Name("foo"), args=(cst.Arg(cst.Integer("1")),)),
                 m.Call(
                     args=(
                         m.Arg(
@@ -1209,8 +1235,7 @@ class MatchersMatcherTest(UnitTest):
         # Match any name node that doesn't match the regex for True
         self.assertTrue(
             matches(
-                libcst.Name("False"),
-                m.Name(value=m.DoesNotMatch(m.MatchRegex(r"True"))),
+                cst.Name("False"), m.Name(value=m.DoesNotMatch(m.MatchRegex(r"True")))
             )
         )
 
@@ -1218,72 +1243,72 @@ class MatchersMatcherTest(UnitTest):
         # Match on any call that takes one argument that isn't the value None.
         self.assertTrue(
             matches(
-                libcst.Call(libcst.Name("foo"), (libcst.Arg(libcst.Name("True")),)),
+                cst.Call(func=cst.Name("foo"), args=(cst.Arg(cst.Name("True")),)),
                 m.Call(args=(m.Arg(value=~m.Name("None")),)),
             )
         )
         self.assertTrue(
             matches(
-                libcst.Call(libcst.Name("foo"), (libcst.Arg(libcst.Integer("1")),)),
+                cst.Call(func=cst.Name("foo"), args=(cst.Arg(cst.Integer("1")),)),
                 m.Call(args=(~m.Arg(m.Name("None")),)),
             )
         )
         # Match any call that takes an argument which isn't True or False.
         self.assertTrue(
             matches(
-                libcst.Call(libcst.Name("foo"), (libcst.Arg(libcst.Integer("1")),)),
+                cst.Call(func=cst.Name("foo"), args=(cst.Arg(cst.Integer("1")),)),
                 m.Call(args=(m.Arg(value=~(m.Name("True") | m.Name("False"))),)),
             )
         )
         self.assertTrue(
             matches(
-                libcst.Call(libcst.Name("foo"), (libcst.Arg(libcst.Name("None")),)),
+                cst.Call(func=cst.Name("foo"), args=(cst.Arg(cst.Name("None")),)),
                 m.Call(args=(m.Arg(value=(~m.Name("True")) & (~m.Name("False"))),)),
             )
         )
         # Roundabout way to verify that or operator works with inverted nodes.
         self.assertTrue(
             matches(
-                libcst.Call(libcst.Name("foo"), (libcst.Arg(libcst.Name("False")),)),
+                cst.Call(func=cst.Name("foo"), args=(cst.Arg(cst.Name("False")),)),
                 m.Call(args=(m.Arg(value=(~m.Name("True")) | (~m.Name("True"))),)),
             )
         )
         # Roundabout way to verify that inverse operator works properly on AllOf.
         self.assertTrue(
             matches(
-                libcst.Call(libcst.Name("foo"), (libcst.Arg(libcst.Integer("1")),)),
+                cst.Call(func=cst.Name("foo"), args=(cst.Arg(cst.Integer("1")),)),
                 m.Call(args=(m.Arg(value=~(m.Name() & m.Name("True"))),)),
             )
         )
         # Match any name node that doesn't match the regex for True
         self.assertTrue(
-            matches(libcst.Name("False"), m.Name(value=~m.MatchRegex(r"True")))
+            matches(cst.Name("False"), m.Name(value=~m.MatchRegex(r"True")))
         )
 
     def test_does_not_match_false(self) -> None:
         # Match on any call that takes one argument that isn't the value None.
         self.assertFalse(
             matches(
-                libcst.Call(libcst.Name("foo"), (libcst.Arg(libcst.Name("None")),)),
+                cst.Call(func=cst.Name("foo"), args=(cst.Arg(cst.Name("None")),)),
                 m.Call(args=(m.Arg(value=m.DoesNotMatch(m.Name("None"))),)),
             )
         )
         self.assertFalse(
             matches(
-                libcst.Call(libcst.Name("foo"), (libcst.Arg(libcst.Integer("1")),)),
+                cst.Call(func=cst.Name("foo"), args=(cst.Arg(cst.Integer("1")),)),
                 m.Call(args=(m.DoesNotMatch(m.Arg(m.Integer("1"))),)),
             )
         )
         self.assertFalse(
             matches(
-                libcst.Call(libcst.Name("foo"), (libcst.Arg(libcst.Integer("1")),)),
+                cst.Call(func=cst.Name("foo"), args=(cst.Arg(cst.Integer("1")),)),
                 m.Call(args=m.DoesNotMatch((m.Arg(m.Integer("1")),))),
             )
         )
         # Match any call that takes an argument which isn't True or False.
         self.assertFalse(
             matches(
-                libcst.Call(libcst.Name("foo"), (libcst.Arg(libcst.Name("False")),)),
+                cst.Call(func=cst.Name("foo"), args=(cst.Arg(cst.Name("False")),)),
                 m.Call(
                     args=(
                         m.Arg(
@@ -1297,14 +1322,14 @@ class MatchersMatcherTest(UnitTest):
         )
         self.assertFalse(
             matches(
-                libcst.Call(libcst.Name("foo"), (libcst.Arg(libcst.Name("True")),)),
+                cst.Call(func=cst.Name("foo"), args=(cst.Arg(cst.Name("True")),)),
                 m.Call(args=(m.Arg(value=(~m.Name("True")) & (~m.Name("False"))),)),
             )
         )
         # Match any name node that doesn't match the regex for True
         self.assertFalse(
             matches(
-                libcst.Name("True"), m.Name(value=m.DoesNotMatch(m.MatchRegex(r"True")))
+                cst.Name("True"), m.Name(value=m.DoesNotMatch(m.MatchRegex(r"True")))
             )
         )
 
@@ -1312,40 +1337,40 @@ class MatchersMatcherTest(UnitTest):
         # Match on any call that takes one argument that isn't the value None.
         self.assertFalse(
             matches(
-                libcst.Call(libcst.Name("foo"), (libcst.Arg(libcst.Name("None")),)),
+                cst.Call(func=cst.Name("foo"), args=(cst.Arg(cst.Name("None")),)),
                 m.Call(args=(m.Arg(value=~m.Name("None")),)),
             )
         )
         self.assertFalse(
             matches(
-                libcst.Call(libcst.Name("foo"), (libcst.Arg(libcst.Integer("1")),)),
+                cst.Call(func=cst.Name("foo"), args=(cst.Arg(cst.Integer("1")),)),
                 m.Call(args=((~m.Arg(m.Integer("1"))),)),
             )
         )
         # Match any call that takes an argument which isn't True or False.
         self.assertFalse(
             matches(
-                libcst.Call(libcst.Name("foo"), (libcst.Arg(libcst.Name("False")),)),
+                cst.Call(func=cst.Name("foo"), args=(cst.Arg(cst.Name("False")),)),
                 m.Call(args=(m.Arg(value=~(m.Name("True") | m.Name("False"))),)),
             )
         )
         # Roundabout way of verifying ~(x&y) behavior.
         self.assertFalse(
             matches(
-                libcst.Call(libcst.Name("foo"), (libcst.Arg(libcst.Name("False")),)),
+                cst.Call(func=cst.Name("foo"), args=(cst.Arg(cst.Name("False")),)),
                 m.Call(args=(m.Arg(value=~(m.Name() & m.Name("False"))),)),
             )
         )
         # Roundabout way of verifying (~x)|(~y) behavior
         self.assertFalse(
             matches(
-                libcst.Call(libcst.Name("foo"), (libcst.Arg(libcst.Name("True")),)),
+                cst.Call(func=cst.Name("foo"), args=(cst.Arg(cst.Name("True")),)),
                 m.Call(args=(m.Arg(value=(~m.Name("True")) | (~m.Name("True"))),)),
             )
         )
         # Match any name node that doesn't match the regex for True
         self.assertFalse(
-            matches(libcst.Name("True"), m.Name(value=~m.MatchRegex(r"True")))
+            matches(cst.Name("True"), m.Name(value=~m.MatchRegex(r"True")))
         )
 
     def test_inverse_inverse_is_identity(self) -> None:


### PR DESCRIPTION
## Summary
As discussed offline, use tuple for Sequence may cause confusion when nested with many other parentheses.

This PR was generated using those two transformers.
```
module = cst.parse_module(src)

class CallTransformer(cst.CSTTransformer):
    def leave_Call(self, o, u):
        if m.matches(
            u,
            m.Call(
                func=m.Attribute(
                    value=m.Name("cst") | m.Name("m"), attr=m.Name("Call")
                ),
                args=[m.AtLeastN(n=2)],
            ),
        ):
            return u.with_changes(
                args=[
                    cst.Arg(keyword=cst.Name("func"), value=u.args[0].value),
                    cst.Arg(keyword=cst.Name("args"), value=u.args[1].value),
                ]
            )
        return u

class CSTImportTransformer(cst.CSTTransformer):
    def leave_Attribute(self, o, u):
        if m.matches(u, m.Attribute(value=m.Name("libcst"))):
            return u.with_changes(value=cst.Name("cst"))
        return u
```