### PR TITLE
Rename position provider classes

### DIFF
--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -12,16 +12,16 @@ LibCST ships with a metadata interface that defines a standardized way to
 associate nodes in a CST with arbitrary metadata while maintaining the immutability
 of the tree. The metadata interface is designed to be declarative and type safe.
 Here's a quick example of using the metadata interface to get line and column
-numbers of nodes through the :class:`~libcst.metadata.SyntacticPositionProvider`:
+numbers of nodes through the :class:`~libcst.metadata.PositionProvider`:
 
 .. _libcst-metadata-position-example:
 .. code-block:: python
 
     class NamePrinter(cst.CSTVisitor):
-        METADATA_DEPENDENCIES = (cst.SyntacticPositionProvider,)
+        METADATA_DEPENDENCIES = (cst.PositionProvider,)
 
         def visit_Name(self, node: cst.Name) -> None:
-            pos = self.get_metadata(cst.SyntacticPositionProvider, node).start
+            pos = self.get_metadata(cst.PositionProvider, node).start
             print(f"{node.value} found at line {pos.line}, column {pos.column}")
 
     wrapper = cst.metadata.MetadataWrapper(cst.parse_module("x = 1"))
@@ -49,13 +49,17 @@ metadata dependencies will be automatically computed when visited by a
 Providing Metadata
 ------------------
 
-Metadata is generated through provider classes that can be declared as a dependency
-by a subclass of :class:`~libcst.MetadataDependent`. These providers are then
-resolved automatically using methods provided by :class:`~libcst.metadata.MetadataWrapper`.
-In most cases, you should extend :class:`~libcst.BatchableMetadataProvider` when
-writing a provider, unless you have a particular reason to not to use a
-batchable visitor. Only extend from :class:`~libcst.BaseMetadataProvider` if
-your provider does not use the visitor pattern for computing metadata for a tree.
+Metadata is generated through provider classes that can be be passed to
+:meth:`MetadataWrapper.resolve() <libcst.metadata.MetadataWrapper.resolve>` or
+declared as a dependency of a :class:`~libcst.metadata.MetadataDependent`. These
+providers are then resolved automatically using methods provided by
+:class:`~libcst.metadata.MetadataWrapper`.
+
+In most cases, you should extend
+:class:`~libcst.metadata.BatchableMetadataProvider` when writing a provider,
+unless you have a particular reason to not to use a batchable visitor. Only
+extend from :class:`~libcst.metadata.BaseMetadataProvider` if your provider does
+not use the visitor pattern for computing metadata for a tree.
 
 .. autoclass:: libcst.BaseMetadataProvider
 .. autoclass:: libcst.metadata.BatchableMetadataProvider
@@ -66,7 +70,7 @@ your provider does not use the visitor pattern for computing metadata for a tree
 ------------------
 Metadata Providers
 ------------------
-:class:`~libcst.metadata.BasicPositionProvider`, :class:`~libcst.metadata.SyntacticPositionProvider`,
+:class:`~libcst.metadata.WhitespaceInclusivePositionProvider`, :class:`~libcst.metadata.PositionProvider`,
 :class:`~libcst.metadata.ExpressionContextProvider`, :class:`~libcst.metadata.ScopeProvider`,
 :class:`~libcst.metadata.QualifiedNameProvider` and :class:`~libcst.metadata.ParentNodeProvider`
 are currently provided. Each metadata provider may has its own custom data structure.
@@ -75,13 +79,14 @@ Position Metadata
 -----------------
 Position (line and column numbers) metadata are accessible through the metadata
 interface by declaring the one of the following providers as a dependency. For
-most cases, :class:`~libcst.SyntacticPositionProvider` is what you probably want.
-Accessing position metadata through the :class:`~libcst.MetadataDepedent`
-interface will return a :class:`~libcst.CodeRange` object. See
+most cases, :class:`~libcst.metadata.PositionProvider` is what you probably
+want.
+
+Node positions are is represented with :class:`~libcst.CodeRange` objects. See
 :ref:`the above example<libcst-metadata-position-example>`.
 
-.. autoclass:: libcst.metadata.BasicPositionProvider
-.. autoclass:: libcst.metadata.SyntacticPositionProvider
+.. autoclass:: libcst.metadata.WhitespaceInclusivePositionProvider
+.. autoclass:: libcst.metadata.PositionProvider
 
 .. autoclass:: libcst.CodeRange
 .. autoclass:: libcst.CodePosition

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -70,9 +70,12 @@ not use the visitor pattern for computing metadata for a tree.
 ------------------
 Metadata Providers
 ------------------
-:class:`~libcst.metadata.WhitespaceInclusivePositionProvider`, :class:`~libcst.metadata.PositionProvider`,
-:class:`~libcst.metadata.ExpressionContextProvider`, :class:`~libcst.metadata.ScopeProvider`,
-:class:`~libcst.metadata.QualifiedNameProvider` and :class:`~libcst.metadata.ParentNodeProvider`
+:class:`~libcst.metadata.PositionProvider`,
+:class:`~libcst.metadata.WhitespaceInclusivePositionProvider`,
+:class:`~libcst.metadata.ExpressionContextProvider`,
+:class:`~libcst.metadata.ScopeProvider`,
+:class:`~libcst.metadata.QualifiedNameProvider`, and
+:class:`~libcst.metadata.ParentNodeProvider`
 are currently provided. Each metadata provider may has its own custom data structure.
 
 Position Metadata
@@ -85,8 +88,8 @@ want.
 Node positions are is represented with :class:`~libcst.CodeRange` objects. See
 :ref:`the above example<libcst-metadata-position-example>`.
 
-.. autoclass:: libcst.metadata.WhitespaceInclusivePositionProvider
 .. autoclass:: libcst.metadata.PositionProvider
+.. autoclass:: libcst.metadata.WhitespaceInclusivePositionProvider
 
 .. autoclass:: libcst.CodeRange
 .. autoclass:: libcst.CodePosition

--- a/libcst/_nodes/internal.py
+++ b/libcst/_nodes/internal.py
@@ -33,9 +33,9 @@ if TYPE_CHECKING:
     from libcst._nodes.base import CSTNode  # noqa: F401
     from libcst._visitors import CSTVisitorT
     from libcst.metadata.position_provider import (  # noqa: F401
-        BasicPositionProvider,
-        SyntacticPositionProvider,
+        WhitespaceInclusivePositionProvider,
         PositionProvider,
+        _PositionProviderUnion,
     )
 
 
@@ -87,7 +87,7 @@ class CodegenState:
     default_indent: str
     default_newline: str
 
-    provider: Optional["PositionProvider"]
+    provider: Optional["_PositionProviderUnion"]
 
     indent_tokens: List[str] = field(default_factory=list)
     tokens: List[str] = field(default_factory=list)
@@ -122,12 +122,13 @@ class CodegenState:
 
 
 @dataclass(frozen=False)
-class BasicCodegenState(CodegenState):
+class WhitespaceInclusivePositionProvidingCodegenState(CodegenState):
     """
-    Pass to codegen to record the basic position of nodes.
+    Used by the codegen to handle
+    `~libcst.metadata.WhitespaceInclusivePositionProvider`.
     """
 
-    provider: "PositionProvider"
+    provider: "_PositionProviderUnion"
 
     def add_indent_tokens(self) -> None:
         self.tokens.extend(self.indent_tokens)
@@ -158,9 +159,10 @@ class BasicCodegenState(CodegenState):
             self.provider._computed[node] = position
 
 
-class SyntacticCodegenState(BasicCodegenState):
+@dataclass(frozen=False)
+class PositionProvidingCodegenState(WhitespaceInclusivePositionProvidingCodegenState):
     """
-    Pass to codegen to record the syntatic position of nodes.
+    Used by the codegen to handle `~libcst.metadata.PositionProvider`.
     """
 
     @contextmanager

--- a/libcst/_nodes/module.py
+++ b/libcst/_nodes/module.py
@@ -144,10 +144,9 @@ class Module(CSTNode):
         method of Module, not CSTNode, because we need to know the module's default
         indentation and newline formats.
 
-        This can also be used with a
-        :class:`~libcst.metadata.WhitespaceInclusivePositionProvider` or
-        :class:`~libcst.metadata.PositionProvider` to compute position information, but
-        that's an implementation detail, and you should use
+        This can also be used with a :class:`~libcst.metadata.PositionProvider` or a
+        :class:`~libcst.metadata.WhitespaceInclusivePositionProvider` to compute
+        position information, but that's an implementation detail, and you should use
         :meth:`MetadataWrapper.resolve() <libcst.metadata.MetadataWrapper.resolve>`
         instead.
 

--- a/libcst/_nodes/tests/base.py
+++ b/libcst/_nodes/tests/base.py
@@ -14,7 +14,7 @@ import libcst as cst
 from libcst._nodes.internal import CodegenState, CodeRange, visit_required
 from libcst._types import CSTNodeT
 from libcst._visitors import CSTTransformer, CSTVisitorT
-from libcst.metadata.position_provider import SyntacticPositionProvider
+from libcst.metadata.position_provider import PositionProvider
 from libcst.testing.utils import UnitTest
 
 
@@ -91,7 +91,7 @@ class CSTNodeTest(UnitTest):
         Verifies that the given node's `_codegen` method is correct.
         """
         module = cst.Module([])
-        provider = None if expected_position is None else SyntacticPositionProvider()
+        provider = None if expected_position is None else PositionProvider()
 
         self.assertEqual(module.code_for_node(node, provider=provider), expected)
 

--- a/libcst/_nodes/tests/test_internal.py
+++ b/libcst/_nodes/tests/test_internal.py
@@ -8,50 +8,63 @@ from typing import Tuple
 
 import libcst as cst
 from libcst._nodes.internal import (
-    BasicCodegenState,
+    CodegenState,
     CodePosition,
     CodeRange,
-    SyntacticCodegenState,
+    PositionProvidingCodegenState,
+    WhitespaceInclusivePositionProvidingCodegenState,
 )
 from libcst.metadata.position_provider import (
-    BasicPositionProvider,
-    SyntacticPositionProvider,
+    PositionProvider,
+    WhitespaceInclusivePositionProvider,
 )
 from libcst.testing.utils import UnitTest
 
 
-def position(state: BasicCodegenState) -> Tuple[int, int]:
+def position(state: CodegenState) -> Tuple[int, int]:
     return state.line, state.column
 
 
 class InternalTest(UnitTest):
     def test_codegen_initial_position(self) -> None:
-        state = BasicCodegenState(" " * 4, "\n", BasicPositionProvider())
+        state = WhitespaceInclusivePositionProvidingCodegenState(
+            " " * 4, "\n", WhitespaceInclusivePositionProvider()
+        )
         self.assertEqual(position(state), (1, 0))
 
     def test_codegen_add_token(self) -> None:
-        state = BasicCodegenState(" " * 4, "\n", BasicPositionProvider())
+        state = WhitespaceInclusivePositionProvidingCodegenState(
+            " " * 4, "\n", WhitespaceInclusivePositionProvider()
+        )
         state.add_token("1234")
         self.assertEqual(position(state), (1, 4))
 
     def test_codegen_add_tokens(self) -> None:
-        state = BasicCodegenState(" " * 4, "\n", BasicPositionProvider())
+        state = WhitespaceInclusivePositionProvidingCodegenState(
+            " " * 4, "\n", WhitespaceInclusivePositionProvider()
+        )
         state.add_token("1234\n1234")
         self.assertEqual(position(state), (2, 4))
 
     def test_codegen_add_newline(self) -> None:
-        state = BasicCodegenState(" " * 4, "\n", BasicPositionProvider())
+        state = WhitespaceInclusivePositionProvidingCodegenState(
+            " " * 4, "\n", WhitespaceInclusivePositionProvider()
+        )
         state.add_token("\n")
         self.assertEqual(position(state), (2, 0))
 
     def test_codegen_add_indent_tokens(self) -> None:
-        state = BasicCodegenState(" " * 4, "\n", BasicPositionProvider())
+        state = WhitespaceInclusivePositionProvidingCodegenState(
+            " " * 4, "\n", WhitespaceInclusivePositionProvider()
+        )
         state.increase_indent(state.default_indent)
         state.add_indent_tokens()
         self.assertEqual(position(state), (1, 4))
 
     def test_codegen_decrease_indent(self) -> None:
-        state = BasicCodegenState(" " * 4, "\n", BasicPositionProvider())
+        state = WhitespaceInclusivePositionProvidingCodegenState(
+            " " * 4, "\n", WhitespaceInclusivePositionProvider()
+        )
         state.increase_indent(state.default_indent)
         state.increase_indent(state.default_indent)
         state.increase_indent(state.default_indent)
@@ -65,7 +78,9 @@ class InternalTest(UnitTest):
 
         # simulate codegen behavior for the dummy node
         # generates the code " pass "
-        state = BasicCodegenState(" " * 4, "\n", BasicPositionProvider())
+        state = WhitespaceInclusivePositionProvidingCodegenState(
+            " " * 4, "\n", WhitespaceInclusivePositionProvider()
+        )
         start = CodePosition(state.line, state.column)
         state.add_token(" ")
         with state.record_syntactic_position(node):
@@ -83,7 +98,7 @@ class InternalTest(UnitTest):
 
         # simulate codegen behavior for the dummy node
         # generates the code " pass "
-        state = SyntacticCodegenState(" " * 4, "\n", SyntacticPositionProvider())
+        state = PositionProvidingCodegenState(" " * 4, "\n", PositionProvider())
         start = CodePosition(state.line, state.column)
         state.add_token(" ")
         with state.record_syntactic_position(node):

--- a/libcst/_nodes/tests/test_module.py
+++ b/libcst/_nodes/tests/test_module.py
@@ -9,7 +9,7 @@ from typing import Tuple, cast
 import libcst as cst
 from libcst import CodeRange, parse_module, parse_statement
 from libcst._nodes.tests.base import CSTNodeTest
-from libcst.metadata.position_provider import SyntacticPositionProvider
+from libcst.metadata.position_provider import PositionProvider
 from libcst.testing.utils import data_provider
 
 
@@ -133,7 +133,7 @@ class ModuleTest(CSTNodeTest):
     )
     def test_module_position(self, *, code: str, expected: CodeRange) -> None:
         module = parse_module(code)
-        provider = SyntacticPositionProvider()
+        provider = PositionProvider()
         module.code_for_node(module, provider)
 
         self.assertEqual(provider._computed[module], expected)
@@ -145,7 +145,7 @@ class ModuleTest(CSTNodeTest):
 
     def test_function_position(self) -> None:
         module = parse_module("def foo():\n    pass")
-        provider = SyntacticPositionProvider()
+        provider = PositionProvider()
         module.code_for_node(module, provider)
 
         fn = cast(cst.FunctionDef, module.body[0])
@@ -158,7 +158,7 @@ class ModuleTest(CSTNodeTest):
         module = parse_module(
             "if True:\n    if False:\n        x = 1\nelse:\n    return"
         )
-        provider = SyntacticPositionProvider()
+        provider = PositionProvider()
         module.code_for_node(module, provider)
 
         outer_if = cast(cst.If, module.body[0])
@@ -176,7 +176,7 @@ class ModuleTest(CSTNodeTest):
 
     def test_multiline_string_position(self) -> None:
         module = parse_module('"abc"\\\n"def"')
-        provider = SyntacticPositionProvider()
+        provider = PositionProvider()
         module.code_for_node(module, provider)
 
         stmt = cast(cst.SimpleStatementLine, module.body[0])

--- a/libcst/metadata/__init__.py
+++ b/libcst/metadata/__init__.py
@@ -17,7 +17,9 @@ from libcst.metadata.expression_context_provider import (
 from libcst.metadata.parent_node_provider import ParentNodeProvider
 from libcst.metadata.position_provider import (
     BasicPositionProvider,
+    PositionProvider,
     SyntacticPositionProvider,
+    WhitespaceInclusivePositionProvider,
 )
 from libcst.metadata.scope_provider import (
     Access,
@@ -40,8 +42,10 @@ from libcst.metadata.wrapper import MetadataWrapper
 
 
 __all__ = [
-    "BasicPositionProvider",
-    "SyntacticPositionProvider",
+    "WhitespaceInclusivePositionProvider",
+    "PositionProvider",
+    "BasicPositionProvider",  # deprecated name for backwards compatibility
+    "SyntacticPositionProvider",  # deprecated name for backwards compatibility
     "ExpressionContext",
     "ExpressionContextProvider",
     "BaseAssignment",

--- a/libcst/metadata/position_provider.py
+++ b/libcst/metadata/position_provider.py
@@ -11,22 +11,39 @@ from libcst._nodes.module import _ModuleSelfT as _ModuleT
 from libcst.metadata.base_provider import BaseMetadataProvider
 
 
-PositionProvider = Union["BasicPositionProvider", "SyntacticPositionProvider"]
+_PositionProviderUnion = Union[
+    "WhitespaceInclusivePositionProvider", "PositionProvider"
+]
 
 
-class BasicPositionProvider(BaseMetadataProvider[CodeRange]):
+class WhitespaceInclusivePositionProvider(BaseMetadataProvider[CodeRange]):
     """
-    Generates basic line and column metadata. Basic position is defined by the
-    start and ending bounds of a node including all whitespace owned by that node.
+    Generates line and column metadata.
+
+    The start and ending bounds of the positions produced by this provider include all
+    whitespace owned by the node.
     """
 
     def _gen_impl(self, module: _ModuleT) -> None:
         module.code_for_node(module, provider=self)
 
 
-class SyntacticPositionProvider(BasicPositionProvider):
+class PositionProvider(WhitespaceInclusivePositionProvider):
     """
-    Generates syntactic line and column metadata. Syntactic position is defined
-    by the start and ending bounds of a node ignoring most instances of leading
-    and trailing whitespace when it is not syntactically significant.
+    Generates line and column metadata.
+
+    These positions are defined by the start and ending bounds of a node ignoring most
+    instances of leading and trailing whitespace when it is not syntactically
+    significant.
+
+    The positions provided by this provider should eventually match the positions used
+    by Pyre_ for equivalent nodes.
+
+    .. _Pyre: https://github.com/facebook/pyre-check
     """
+
+
+# DEPRECATED: These names are here for backwards compatibility and will be removed in
+# the future.
+BasicPositionProvider = WhitespaceInclusivePositionProvider
+SyntacticPositionProvider = PositionProvider

--- a/libcst/metadata/tests/test_position_provider.py
+++ b/libcst/metadata/tests/test_position_provider.py
@@ -8,7 +8,7 @@ import libcst as cst
 from libcst import CodeRange, parse_module
 from libcst._batched_visitor import BatchableCSTVisitor
 from libcst._visitors import CSTTransformer
-from libcst.metadata import MetadataWrapper, SyntacticPositionProvider
+from libcst.metadata import MetadataWrapper, PositionProvider
 from libcst.testing.utils import UnitTest
 
 
@@ -22,12 +22,11 @@ class PositionProviderTest(UnitTest):
         test = self
 
         class DependentVisitor(CSTTransformer):
-            METADATA_DEPENDENCIES = (SyntacticPositionProvider,)
+            METADATA_DEPENDENCIES = (PositionProvider,)
 
             def visit_Pass(self, node: cst.Pass) -> None:
                 test.assertEqual(
-                    self.get_metadata(SyntacticPositionProvider, node),
-                    CodeRange((1, 0), (1, 4)),
+                    self.get_metadata(PositionProvider, node), CodeRange((1, 0), (1, 4))
                 )
 
         wrapper = MetadataWrapper(parse_module("pass"))
@@ -37,12 +36,11 @@ class PositionProviderTest(UnitTest):
         test = self
 
         class ABatchable(BatchableCSTVisitor):
-            METADATA_DEPENDENCIES = (SyntacticPositionProvider,)
+            METADATA_DEPENDENCIES = (PositionProvider,)
 
             def visit_Pass(self, node: cst.Pass) -> None:
                 test.assertEqual(
-                    self.get_metadata(SyntacticPositionProvider, node),
-                    CodeRange((1, 0), (1, 4)),
+                    self.get_metadata(PositionProvider, node), CodeRange((1, 0), (1, 4))
                 )
 
         wrapper = MetadataWrapper(parse_module("pass"))


### PR DESCRIPTION
## Summary

I discussed the high-level idea here with @DragonMinded a few months
ago, but this isn't set in stone. If people have better ideas for names,
I'd love to hear it.

### Publicly-Visible Changes

- SyntacticPositionProvider is deprecated. The new name is
  PositionProvider.
- BasicPositionProvider is deprecated. The new name is
  WhitespaceInclusivePositionProvider.
- Documentation is updated to better explain these renamed providers and
  how to use them.

The prefixes "Syntactic" and "Basic" were pretty bad because they're
just concepts that we made up for LibCST.

The idea for the new names is that most users will want the
SyntacticPositionProvider, and so we should name things so that the user
will naturally gravitate towards the correct choice.

There's some argument that we shouldn't even bother exposing
WhitespaceInclusivePositionProvider, but we already need to implement it
as a fallback for PositionProvider, and it might be useful for some
niche use-cases.

Once we have another major version bump, we can remove the old class
names. The old class names have already be removed from the
documentation so that new users aren't tempted to use them.

### Internal-Only Changes

- `PositionProvider` is now `_PositionProviderUnion`. This type alias
  was never a public API (and probably never will be).
- `BasicCodegenState` is now
  `WhitespaceInclusivePositionProvidingCodegenState`.
- `SyntacticCodegenState` is now `PositionProvidingCodegenState`.

## Test Plan

The existing tests pass. I also tried testing this in the python shell, since I didn't write any unit tests for backwards compatibility. (the end goal is to just delete it)

### Backwards Compatibility

```
>>> print("\n".join(f"{type(k).__name__.ljust(20)}: {v}" for k, v in m.MetadataWrapper(cst.parse_module("((a).b)")).resolve(m.BasicPositionProvider).items()))
SimpleWhitespace    : CodeRange(start=CodePosition(line=1, column=1), end=CodePosition(line=1, column=1))
LeftParen           : CodeRange(start=CodePosition(line=1, column=0), end=CodePosition(line=1, column=1))
SimpleWhitespace    : CodeRange(start=CodePosition(line=1, column=2), end=CodePosition(line=1, column=2))
LeftParen           : CodeRange(start=CodePosition(line=1, column=1), end=CodePosition(line=1, column=2))
SimpleWhitespace    : CodeRange(start=CodePosition(line=1, column=3), end=CodePosition(line=1, column=3))
RightParen          : CodeRange(start=CodePosition(line=1, column=3), end=CodePosition(line=1, column=4))
Name                : CodeRange(start=CodePosition(line=1, column=1), end=CodePosition(line=1, column=4))
SimpleWhitespace    : CodeRange(start=CodePosition(line=1, column=4), end=CodePosition(line=1, column=4))
SimpleWhitespace    : CodeRange(start=CodePosition(line=1, column=5), end=CodePosition(line=1, column=5))
Dot                 : CodeRange(start=CodePosition(line=1, column=4), end=CodePosition(line=1, column=5))
Name                : CodeRange(start=CodePosition(line=1, column=5), end=CodePosition(line=1, column=6))
SimpleWhitespace    : CodeRange(start=CodePosition(line=1, column=6), end=CodePosition(line=1, column=6))
RightParen          : CodeRange(start=CodePosition(line=1, column=6), end=CodePosition(line=1, column=7))
Attribute           : CodeRange(start=CodePosition(line=1, column=0), end=CodePosition(line=1, column=7))
Expr                : CodeRange(start=CodePosition(line=1, column=0), end=CodePosition(line=1, column=7))
SimpleWhitespace    : CodeRange(start=CodePosition(line=1, column=7), end=CodePosition(line=1, column=7))
Newline             : CodeRange(start=CodePosition(line=1, column=7), end=CodePosition(line=2, column=0))
TrailingWhitespace  : CodeRange(start=CodePosition(line=1, column=7), end=CodePosition(line=2, column=0))
SimpleStatementLine : CodeRange(start=CodePosition(line=1, column=0), end=CodePosition(line=2, column=0))
Module              : CodeRange(start=CodePosition(line=1, column=0), end=CodePosition(line=2, column=0))
```

```
>>> print("\n".join(f"{type(k).__name__.ljust(20)}: {v}" for k, v in m.MetadataWrapper(cst.parse_module("((a).b)")).resolve(m.SyntacticPositionProvider).items()))
SimpleWhitespace    : CodeRange(start=CodePosition(line=1, column=1), end=CodePosition(line=1, column=1))
LeftParen           : CodeRange(start=CodePosition(line=1, column=0), end=CodePosition(line=1, column=1))
SimpleWhitespace    : CodeRange(start=CodePosition(line=1, column=2), end=CodePosition(line=1, column=2))
LeftParen           : CodeRange(start=CodePosition(line=1, column=1), end=CodePosition(line=1, column=2))
Name                : CodeRange(start=CodePosition(line=1, column=2), end=CodePosition(line=1, column=3))
SimpleWhitespace    : CodeRange(start=CodePosition(line=1, column=3), end=CodePosition(line=1, column=3))
RightParen          : CodeRange(start=CodePosition(line=1, column=3), end=CodePosition(line=1, column=4))
SimpleWhitespace    : CodeRange(start=CodePosition(line=1, column=4), end=CodePosition(line=1, column=4))
Dot                 : CodeRange(start=CodePosition(line=1, column=4), end=CodePosition(line=1, column=5))
SimpleWhitespace    : CodeRange(start=CodePosition(line=1, column=5), end=CodePosition(line=1, column=5))
Name                : CodeRange(start=CodePosition(line=1, column=5), end=CodePosition(line=1, column=6))
Attribute           : CodeRange(start=CodePosition(line=1, column=1), end=CodePosition(line=1, column=6))
SimpleWhitespace    : CodeRange(start=CodePosition(line=1, column=6), end=CodePosition(line=1, column=6))
RightParen          : CodeRange(start=CodePosition(line=1, column=6), end=CodePosition(line=1, column=7))
Expr                : CodeRange(start=CodePosition(line=1, column=0), end=CodePosition(line=1, column=7))
SimpleStatementLine : CodeRange(start=CodePosition(line=1, column=0), end=CodePosition(line=1, column=7))
SimpleWhitespace    : CodeRange(start=CodePosition(line=1, column=7), end=CodePosition(line=1, column=7))
Newline             : CodeRange(start=CodePosition(line=1, column=7), end=CodePosition(line=2, column=0))
TrailingWhitespace  : CodeRange(start=CodePosition(line=1, column=7), end=CodePosition(line=2, column=0))
Module              : CodeRange(start=CodePosition(line=1, column=0), end=CodePosition(line=2, column=0))
```

### Updated Documentation

![Screenshot from 2019-10-16 16-49-05](https://user-images.githubusercontent.com/180404/66967218-09ceee00-f035-11e9-8fd9-28be5fa2410f.png)

---

![Screenshot from 2019-10-16 16-49-24](https://user-images.githubusercontent.com/180404/66967229-13585600-f035-11e9-8bc9-c25fa1c3a55a.png)

---

![Screenshot from 2019-10-16 16-49-54](https://user-images.githubusercontent.com/180404/66967234-1bb09100-f035-11e9-920f-402804fecee5.png)