### PR TITLE
Remove parsing Subscript slice directly into Index/Slice

### DIFF
--- a/libcst/_nodes/base.py
+++ b/libcst/_nodes/base.py
@@ -402,7 +402,7 @@ class CSTNode(ABC):
 
     def with_deep_changes(
         self: _CSTNodeSelfT, old_node: "CSTNode", **changes: Any
-    ) -> Union[_CSTNodeSelfT, "CSTNode"]:
+    ) -> _CSTNodeSelfT:
         """
         A convenience method for applying :attr:`with_changes` to a child node. Use
         this to avoid chains of :attr:`with_changes` or combinations of

--- a/libcst/_nodes/tests/test_assign.py
+++ b/libcst/_nodes/tests/test_assign.py
@@ -144,7 +144,10 @@ class AnnAssignTest(CSTNodeTest):
                 "node": cst.AnnAssign(
                     cst.Name("foo"),
                     cst.Annotation(
-                        cst.Subscript(cst.Name("Optional"), cst.Index(cst.Name("str")))
+                        cst.Subscript(
+                            cst.Name("Optional"),
+                            (cst.SubscriptElement(cst.Index(cst.Name("str"))),),
+                        )
                     ),
                     cst.Integer("5"),
                 ),
@@ -197,7 +200,8 @@ class AnnAssignTest(CSTNodeTest):
                             target=cst.Name("foo"),
                             annotation=cst.Annotation(
                                 annotation=cst.Subscript(
-                                    cst.Name("Optional"), cst.Index(cst.Name("str"))
+                                    cst.Name("Optional"),
+                                    (cst.SubscriptElement(cst.Index(cst.Name("str"))),),
                                 ),
                                 whitespace_before_indicator=cst.SimpleWhitespace(""),
                             ),
@@ -216,7 +220,8 @@ class AnnAssignTest(CSTNodeTest):
                     target=cst.Name("foo"),
                     annotation=cst.Annotation(
                         annotation=cst.Subscript(
-                            cst.Name("Optional"), cst.Index(cst.Name("str"))
+                            cst.Name("Optional"),
+                            (cst.SubscriptElement(cst.Index(cst.Name("str"))),),
                         ),
                         whitespace_before_indicator=cst.SimpleWhitespace(" "),
                         whitespace_after_indicator=cst.SimpleWhitespace("  "),
@@ -238,7 +243,8 @@ class AnnAssignTest(CSTNodeTest):
                             target=cst.Name("foo"),
                             annotation=cst.Annotation(
                                 annotation=cst.Subscript(
-                                    cst.Name("Optional"), cst.Index(cst.Name("str"))
+                                    cst.Name("Optional"),
+                                    (cst.SubscriptElement(cst.Index(cst.Name("str"))),),
                                 ),
                                 whitespace_before_indicator=cst.SimpleWhitespace(" "),
                                 whitespace_after_indicator=cst.SimpleWhitespace("  "),

--- a/libcst/_nodes/tests/test_subscript.py
+++ b/libcst/_nodes/tests/test_subscript.py
@@ -17,7 +17,10 @@ class SubscriptTest(CSTNodeTest):
         (
             # Simple subscript expression
             (
-                cst.Subscript(cst.Name("foo"), cst.Index(cst.Integer("5"))),
+                cst.Subscript(
+                    cst.Name("foo"),
+                    (cst.SubscriptElement(cst.Index(cst.Integer("5"))),),
+                ),
                 "foo[5]",
                 True,
             ),
@@ -25,10 +28,14 @@ class SubscriptTest(CSTNodeTest):
             (
                 cst.Subscript(
                     cst.Name("foo"),
-                    cst.Slice(
-                        lower=cst.Integer("1"),
-                        upper=cst.Integer("2"),
-                        step=cst.Integer("3"),
+                    (
+                        cst.SubscriptElement(
+                            cst.Slice(
+                                lower=cst.Integer("1"),
+                                upper=cst.Integer("2"),
+                                step=cst.Integer("3"),
+                            )
+                        ),
                     ),
                 ),
                 "foo[1:2:3]",
@@ -56,12 +63,16 @@ class SubscriptTest(CSTNodeTest):
             (
                 cst.Subscript(
                     cst.Name("foo"),
-                    cst.Slice(
-                        lower=cst.Integer("1"),
-                        first_colon=cst.Colon(),
-                        upper=cst.Integer("2"),
-                        second_colon=cst.Colon(),
-                        step=cst.Integer("3"),
+                    (
+                        cst.SubscriptElement(
+                            cst.Slice(
+                                lower=cst.Integer("1"),
+                                first_colon=cst.Colon(),
+                                upper=cst.Integer("2"),
+                                second_colon=cst.Colon(),
+                                step=cst.Integer("3"),
+                            )
+                        ),
                     ),
                 ),
                 "foo[1:2:3]",
@@ -91,21 +102,35 @@ class SubscriptTest(CSTNodeTest):
             (
                 cst.Subscript(
                     cst.Name("foo"),
-                    cst.Slice(lower=cst.Integer("1"), upper=cst.Integer("2")),
+                    (
+                        cst.SubscriptElement(
+                            cst.Slice(lower=cst.Integer("1"), upper=cst.Integer("2"))
+                        ),
+                    ),
                 ),
                 "foo[1:2]",
                 True,
             ),
             (
                 cst.Subscript(
-                    cst.Name("foo"), cst.Slice(lower=cst.Integer("1"), upper=None)
+                    cst.Name("foo"),
+                    (
+                        cst.SubscriptElement(
+                            cst.Slice(lower=cst.Integer("1"), upper=None)
+                        ),
+                    ),
                 ),
                 "foo[1:]",
                 True,
             ),
             (
                 cst.Subscript(
-                    cst.Name("foo"), cst.Slice(lower=None, upper=cst.Integer("2"))
+                    cst.Name("foo"),
+                    (
+                        cst.SubscriptElement(
+                            cst.Slice(lower=None, upper=cst.Integer("2"))
+                        ),
+                    ),
                 ),
                 "foo[:2]",
                 True,
@@ -113,8 +138,14 @@ class SubscriptTest(CSTNodeTest):
             (
                 cst.Subscript(
                     cst.Name("foo"),
-                    cst.Slice(
-                        lower=cst.Integer("1"), upper=None, step=cst.Integer("3")
+                    (
+                        cst.SubscriptElement(
+                            cst.Slice(
+                                lower=cst.Integer("1"),
+                                upper=None,
+                                step=cst.Integer("3"),
+                            )
+                        ),
                     ),
                 ),
                 "foo[1::3]",
@@ -123,7 +154,11 @@ class SubscriptTest(CSTNodeTest):
             (
                 cst.Subscript(
                     cst.Name("foo"),
-                    cst.Slice(lower=None, upper=None, step=cst.Integer("3")),
+                    (
+                        cst.SubscriptElement(
+                            cst.Slice(lower=None, upper=None, step=cst.Integer("3"))
+                        ),
+                    ),
                 ),
                 "foo[::3]",
                 False,
@@ -133,21 +168,35 @@ class SubscriptTest(CSTNodeTest):
             (
                 cst.Subscript(
                     cst.Name("foo"),
-                    cst.Slice(lower=cst.Integer("1"), upper=cst.Integer("2")),
+                    (
+                        cst.SubscriptElement(
+                            cst.Slice(lower=cst.Integer("1"), upper=cst.Integer("2"))
+                        ),
+                    ),
                 ),
                 "foo[1:2]",
                 True,
             ),
             (
                 cst.Subscript(
-                    cst.Name("foo"), cst.Slice(lower=cst.Integer("1"), upper=None)
+                    cst.Name("foo"),
+                    (
+                        cst.SubscriptElement(
+                            cst.Slice(lower=cst.Integer("1"), upper=None)
+                        ),
+                    ),
                 ),
                 "foo[1:]",
                 True,
             ),
             (
                 cst.Subscript(
-                    cst.Name("foo"), cst.Slice(lower=None, upper=cst.Integer("2"))
+                    cst.Name("foo"),
+                    (
+                        cst.SubscriptElement(
+                            cst.Slice(lower=None, upper=cst.Integer("2"))
+                        ),
+                    ),
                 ),
                 "foo[:2]",
                 True,
@@ -155,11 +204,15 @@ class SubscriptTest(CSTNodeTest):
             (
                 cst.Subscript(
                     cst.Name("foo"),
-                    cst.Slice(
-                        lower=cst.Integer("1"),
-                        upper=None,
-                        second_colon=cst.Colon(),
-                        step=cst.Integer("3"),
+                    (
+                        cst.SubscriptElement(
+                            cst.Slice(
+                                lower=cst.Integer("1"),
+                                upper=None,
+                                second_colon=cst.Colon(),
+                                step=cst.Integer("3"),
+                            )
+                        ),
                     ),
                 ),
                 "foo[1::3]",
@@ -168,11 +221,15 @@ class SubscriptTest(CSTNodeTest):
             (
                 cst.Subscript(
                     cst.Name("foo"),
-                    cst.Slice(
-                        lower=None,
-                        upper=None,
-                        second_colon=cst.Colon(),
-                        step=cst.Integer("3"),
+                    (
+                        cst.SubscriptElement(
+                            cst.Slice(
+                                lower=None,
+                                upper=None,
+                                second_colon=cst.Colon(),
+                                step=cst.Integer("3"),
+                            )
+                        ),
                     ),
                 ),
                 "foo[::3]",
@@ -180,15 +237,25 @@ class SubscriptTest(CSTNodeTest):
             ),
             # Valid list clone operations rendering
             (
-                cst.Subscript(cst.Name("foo"), cst.Slice(lower=None, upper=None)),
+                cst.Subscript(
+                    cst.Name("foo"),
+                    (cst.SubscriptElement(cst.Slice(lower=None, upper=None)),),
+                ),
                 "foo[:]",
                 True,
             ),
             (
                 cst.Subscript(
                     cst.Name("foo"),
-                    cst.Slice(
-                        lower=None, upper=None, second_colon=cst.Colon(), step=None
+                    (
+                        cst.SubscriptElement(
+                            cst.Slice(
+                                lower=None,
+                                upper=None,
+                                second_colon=cst.Colon(),
+                                step=None,
+                            )
+                        ),
                     ),
                 ),
                 "foo[::]",
@@ -196,15 +263,25 @@ class SubscriptTest(CSTNodeTest):
             ),
             # Valid list clone operations parsing
             (
-                cst.Subscript(cst.Name("foo"), cst.Slice(lower=None, upper=None)),
+                cst.Subscript(
+                    cst.Name("foo"),
+                    (cst.SubscriptElement(cst.Slice(lower=None, upper=None)),),
+                ),
                 "foo[:]",
                 True,
             ),
             (
                 cst.Subscript(
                     cst.Name("foo"),
-                    cst.Slice(
-                        lower=None, upper=None, second_colon=cst.Colon(), step=None
+                    (
+                        cst.SubscriptElement(
+                            cst.Slice(
+                                lower=None,
+                                upper=None,
+                                second_colon=cst.Colon(),
+                                step=None,
+                            )
+                        ),
                     ),
                 ),
                 "foo[::]",
@@ -215,7 +292,7 @@ class SubscriptTest(CSTNodeTest):
                 cst.Subscript(
                     lpar=(cst.LeftParen(),),
                     value=cst.Name("foo"),
-                    slice=cst.Index(cst.Integer("5")),
+                    slice=(cst.SubscriptElement(cst.Index(cst.Integer("5"))),),
                     rpar=(cst.RightParen(),),
                 ),
                 "(foo[5])",
@@ -229,7 +306,7 @@ class SubscriptTest(CSTNodeTest):
                     lbracket=cst.LeftSquareBracket(
                         whitespace_after=cst.SimpleWhitespace(" ")
                     ),
-                    slice=cst.Index(cst.Integer("5")),
+                    slice=(cst.SubscriptElement(cst.Index(cst.Integer("5"))),),
                     rbracket=cst.RightSquareBracket(
                         whitespace_before=cst.SimpleWhitespace(" ")
                     ),
@@ -246,18 +323,22 @@ class SubscriptTest(CSTNodeTest):
                     lbracket=cst.LeftSquareBracket(
                         whitespace_after=cst.SimpleWhitespace(" ")
                     ),
-                    slice=cst.Slice(
-                        lower=cst.Integer("1"),
-                        first_colon=cst.Colon(
-                            whitespace_before=cst.SimpleWhitespace(" "),
-                            whitespace_after=cst.SimpleWhitespace(" "),
+                    slice=(
+                        cst.SubscriptElement(
+                            cst.Slice(
+                                lower=cst.Integer("1"),
+                                first_colon=cst.Colon(
+                                    whitespace_before=cst.SimpleWhitespace(" "),
+                                    whitespace_after=cst.SimpleWhitespace(" "),
+                                ),
+                                upper=cst.Integer("2"),
+                                second_colon=cst.Colon(
+                                    whitespace_before=cst.SimpleWhitespace(" "),
+                                    whitespace_after=cst.SimpleWhitespace(" "),
+                                ),
+                                step=cst.Integer("3"),
+                            )
                         ),
-                        upper=cst.Integer("2"),
-                        second_colon=cst.Colon(
-                            whitespace_before=cst.SimpleWhitespace(" "),
-                            whitespace_after=cst.SimpleWhitespace(" "),
-                        ),
-                        step=cst.Integer("3"),
                     ),
                     rbracket=cst.RightSquareBracket(
                         whitespace_before=cst.SimpleWhitespace(" ")
@@ -358,7 +439,7 @@ class SubscriptTest(CSTNodeTest):
             (
                 lambda: cst.Subscript(
                     cst.Name("foo"),
-                    cst.Index(cst.Integer("5")),
+                    (cst.SubscriptElement(cst.Index(cst.Integer("5"))),),
                     lpar=(cst.LeftParen(),),
                 ),
                 "left paren without right paren",
@@ -366,7 +447,7 @@ class SubscriptTest(CSTNodeTest):
             (
                 lambda: cst.Subscript(
                     cst.Name("foo"),
-                    cst.Index(cst.Integer("5")),
+                    (cst.SubscriptElement(cst.Index(cst.Integer("5"))),),
                     rpar=(cst.RightParen(),),
                 ),
                 "right paren without left paren",

--- a/libcst/_parser/conversions/expression.py
+++ b/libcst/_parser/conversions/expression.py
@@ -693,32 +693,27 @@ def convert_trailer_subscriptlist(
 def convert_subscriptlist(
     config: ParserConfig, children: typing.Sequence[typing.Any]
 ) -> typing.Any:
-    if len(children) > 1:
-        # This is a list of SubscriptElement, so construct as such by grouping every
-        # subscript with an optional comma and adding to a list.
-        elements = []
-        for slice, comma in grouper(children, 2):
-            if comma is None:
-                elements.append(SubscriptElement(slice=slice.value))
-            else:
-                elements.append(
-                    SubscriptElement(
-                        slice=slice.value,
-                        comma=Comma(
-                            whitespace_before=parse_parenthesizable_whitespace(
-                                config, comma.whitespace_before
-                            ),
-                            whitespace_after=parse_parenthesizable_whitespace(
-                                config, comma.whitespace_after
-                            ),
+    # This is a list of SubscriptElement, so construct as such by grouping every
+    # subscript with an optional comma and adding to a list.
+    elements = []
+    for slice, comma in grouper(children, 2):
+        if comma is None:
+            elements.append(SubscriptElement(slice=slice.value))
+        else:
+            elements.append(
+                SubscriptElement(
+                    slice=slice.value,
+                    comma=Comma(
+                        whitespace_before=parse_parenthesizable_whitespace(
+                            config, comma.whitespace_before
                         ),
-                    )
+                        whitespace_after=parse_parenthesizable_whitespace(
+                            config, comma.whitespace_after
+                        ),
+                    ),
                 )
-        return WithLeadingWhitespace(elements, children[0].whitespace_before)
-    else:
-        # This is an Index or Slice, as parsed in the child.
-        (index_or_slice,) = children
-        return index_or_slice
+            )
+    return WithLeadingWhitespace(elements, children[0].whitespace_before)
 
 
 @with_production("subscript", "test | [test] ':' [test] [sliceop]")

--- a/libcst/tests/test_deprecate_extslice.py
+++ b/libcst/tests/test_deprecate_extslice.py
@@ -41,6 +41,24 @@ class ExtSliceDeprecatedUseTest(UnitTest):
 
         self.assertEqual(module.code, "foo[1, 2]\n")
 
+    def test_deprecated_non_element_construction(self) -> None:
+        module = cst.Module(
+            body=[
+                cst.SimpleStatementLine(
+                    body=[
+                        cst.Expr(
+                            value=cst.Subscript(
+                                value=cst.Name(value="foo"),
+                                slice=cst.Index(value=cst.Integer(value="1")),
+                            )
+                        )
+                    ]
+                )
+            ]
+        )
+
+        self.assertEqual(module.code, "foo[1]\n")
+
     def test_deprecated_matching(self) -> None:
         class DeprecatedDecoratorTest(m.MatcherDecoratableVisitor):
             def __init__(self) -> None:


### PR DESCRIPTION
## Summary

This makes sure we always wrap elements in a SubscriptElement, even when there
is only one element. This makes things more regular while still being backwards
compatible with existing creation. The meat of this is in two halves, which can't
be split due to not wanting to break the build between commits. The first half
is just the changes to the parser and updates to tests. This includes a test to
be sure we can still render code that uses old construction types. The second half
is changes to codegen which made assumptions about `Subscript` and demonstrates
the need to make this change in the first place. This includes a fix to
`CSTNode.with_deep_changes` type to make it more correct and also more usable in
transforms without additional type assertions.

## Test Plan

Existing tests, added another deprecation test.