### PR TITLE
Export CodePosition and CodeRange from metadata

### DIFF
--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -85,14 +85,14 @@ interface by declaring the one of the following providers as a dependency. For
 most cases, :class:`~libcst.metadata.PositionProvider` is what you probably
 want.
 
-Node positions are is represented with :class:`~libcst.CodeRange` objects. See
-:ref:`the above example<libcst-metadata-position-example>`.
+Node positions are is represented with :class:`~libcst.metadata.CodeRange`
+objects. See :ref:`the above example<libcst-metadata-position-example>`.
 
 .. autoclass:: libcst.metadata.PositionProvider
 .. autoclass:: libcst.metadata.WhitespaceInclusivePositionProvider
 
-.. autoclass:: libcst.CodeRange
-.. autoclass:: libcst.CodePosition
+.. autoclass:: libcst.metadata.CodeRange
+.. autoclass:: libcst.metadata.CodePosition
 
 
 Expression Context Metadata

--- a/libcst/__init__.py
+++ b/libcst/__init__.py
@@ -77,7 +77,6 @@ from libcst._nodes.expression import (
     UnaryOperation,
     Yield,
 )
-from libcst._nodes.internal import CodePosition, CodeRange
 from libcst._nodes.module import Module
 from libcst._nodes.op import (
     Add,
@@ -185,6 +184,7 @@ from libcst._nodes.whitespace import (
 )
 from libcst._parser.entrypoints import parse_expression, parse_module, parse_statement
 from libcst._parser.types.config import PartialParserConfig
+from libcst._position import CodePosition, CodeRange
 from libcst._removal_sentinel import RemovalSentinel, RemoveFromParent
 from libcst._visitors import CSTNodeT, CSTTransformer, CSTVisitor, CSTVisitorT
 from libcst.metadata.base_provider import (
@@ -202,8 +202,8 @@ ExtSlice = SubscriptElement
 
 __all__ = [
     "BatchableCSTVisitor",
-    "CodePosition",
-    "CodeRange",
+    "CodePosition",  # Deprecated export, import from libcst.metadata instead
+    "CodeRange",  # Deprecated export, import from libcst.metadata instead
     "CSTNodeT",
     "CSTTransformer",
     "CSTValidationError",

--- a/libcst/_nodes/base.py
+++ b/libcst/_nodes/base.py
@@ -20,7 +20,8 @@ from typing import (
     cast,
 )
 
-from libcst._nodes.internal import CodegenState, CodePosition, CodeRange
+from libcst._nodes.internal import CodegenState
+from libcst._position import CodePosition, CodeRange
 from libcst._removal_sentinel import RemovalSentinel
 from libcst._type_enforce import is_value_of_type
 from libcst._types import CSTNodeT

--- a/libcst/_nodes/internal.py
+++ b/libcst/_nodes/internal.py
@@ -16,14 +16,11 @@ from typing import (
     Optional,
     Pattern,
     Sequence,
-    Tuple,
     Union,
-    cast,
-    overload,
 )
 
-from libcst._add_slots import add_slots
 from libcst._maybe_sentinel import MaybeSentinel
+from libcst._position import CodePosition, CodeRange
 from libcst._removal_sentinel import RemovalSentinel
 from libcst._types import CSTNodeT
 
@@ -39,46 +36,7 @@ if TYPE_CHECKING:
     )
 
 
-_CodePositionT = Union[Tuple[int, int], "CodePosition"]
-
-
 NEWLINE_RE: Pattern[str] = re.compile(r"\r\n?|\n")
-
-
-@add_slots
-@dataclass(frozen=True)
-class CodePosition:
-    #: Line numbers are 1-indexed.
-    line: int
-    #: Column numbers are 0-indexed.
-    column: int
-
-
-@add_slots
-@dataclass(frozen=True)
-class CodeRange:
-    #: Starting position of a node (inclusive).
-    start: CodePosition
-    #: Ending position of a node (exclusive).
-    end: CodePosition
-
-    @overload
-    def __init__(self, start: CodePosition, end: CodePosition) -> None:
-        ...
-
-    @overload
-    def __init__(self, start: Tuple[int, int], end: Tuple[int, int]) -> None:
-        ...
-
-    def __init__(self, start: _CodePositionT, end: _CodePositionT) -> None:
-        if isinstance(start, tuple) and isinstance(end, tuple):
-            object.__setattr__(self, "start", CodePosition(start[0], start[1]))
-            object.__setattr__(self, "end", CodePosition(end[0], end[1]))
-        else:
-            start = cast(CodePosition, start)
-            end = cast(CodePosition, end)
-            object.__setattr__(self, "start", start)
-            object.__setattr__(self, "end", end)
 
 
 @dataclass(frozen=False)

--- a/libcst/_nodes/tests/base.py
+++ b/libcst/_nodes/tests/base.py
@@ -11,10 +11,10 @@ from typing import Any, Callable, Iterable, List, Optional, Sequence, Type
 from unittest.mock import patch
 
 import libcst as cst
-from libcst._nodes.internal import CodegenState, CodeRange, visit_required
+from libcst._nodes.internal import CodegenState, visit_required
 from libcst._types import CSTNodeT
 from libcst._visitors import CSTTransformer, CSTVisitorT
-from libcst.metadata.position_provider import PositionProvider
+from libcst.metadata import CodeRange, PositionProvider
 from libcst.testing.utils import UnitTest
 
 

--- a/libcst/_nodes/tests/test_assert.py
+++ b/libcst/_nodes/tests/test_assert.py
@@ -8,9 +8,10 @@
 from typing import Any
 
 import libcst as cst
-from libcst import CodeRange, parse_statement
+from libcst import parse_statement
 from libcst._helpers import ensure_type
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_assign.py
+++ b/libcst/_nodes/tests/test_assign.py
@@ -7,8 +7,9 @@
 from typing import Any
 
 import libcst as cst
-from libcst import CodeRange, parse_statement
+from libcst import parse_statement
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_atom.py
+++ b/libcst/_nodes/tests/test_atom.py
@@ -8,8 +8,9 @@
 from typing import Any
 
 import libcst as cst
-from libcst import CodeRange, parse_expression
+from libcst import parse_expression
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_attribute.py
+++ b/libcst/_nodes/tests/test_attribute.py
@@ -7,8 +7,9 @@
 from typing import Any
 
 import libcst as cst
-from libcst import CodeRange, parse_expression
+from libcst import parse_expression
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_await.py
+++ b/libcst/_nodes/tests/test_await.py
@@ -7,8 +7,9 @@
 from typing import Any
 
 import libcst as cst
-from libcst import CodeRange, PartialParserConfig, parse_expression, parse_statement
+from libcst import PartialParserConfig, parse_expression, parse_statement
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_binary_op.py
+++ b/libcst/_nodes/tests/test_binary_op.py
@@ -7,8 +7,9 @@
 from typing import Any
 
 import libcst as cst
-from libcst import CodeRange, parse_expression
+from libcst import parse_expression
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_boolean_op.py
+++ b/libcst/_nodes/tests/test_boolean_op.py
@@ -7,8 +7,9 @@
 from typing import Any
 
 import libcst as cst
-from libcst import CodeRange, parse_expression
+from libcst import parse_expression
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_call.py
+++ b/libcst/_nodes/tests/test_call.py
@@ -7,8 +7,9 @@
 from typing import Any
 
 import libcst as cst
-from libcst import CodeRange, parse_expression
+from libcst import parse_expression
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_classdef.py
+++ b/libcst/_nodes/tests/test_classdef.py
@@ -7,8 +7,9 @@
 from typing import Any, Callable
 
 import libcst as cst
-from libcst import CodeRange, parse_statement
+from libcst import parse_statement
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_comparison.py
+++ b/libcst/_nodes/tests/test_comparison.py
@@ -7,8 +7,9 @@
 from typing import Callable, Optional
 
 import libcst as cst
-from libcst import CodeRange, parse_expression
+from libcst import parse_expression
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_del.py
+++ b/libcst/_nodes/tests/test_del.py
@@ -7,8 +7,9 @@
 from typing import Any
 
 import libcst as cst
-from libcst import CodeRange, parse_statement
+from libcst import parse_statement
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_dict.py
+++ b/libcst/_nodes/tests/test_dict.py
@@ -7,8 +7,9 @@
 from typing import Any
 
 import libcst as cst
-from libcst import CodeRange, parse_expression
+from libcst import parse_expression
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_dict_comp.py
+++ b/libcst/_nodes/tests/test_dict_comp.py
@@ -7,8 +7,9 @@
 from typing import Any
 
 import libcst as cst
-from libcst import CodeRange, parse_expression
+from libcst import parse_expression
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_else.py
+++ b/libcst/_nodes/tests/test_else.py
@@ -7,8 +7,8 @@
 from typing import Any
 
 import libcst as cst
-from libcst import CodeRange
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_for.py
+++ b/libcst/_nodes/tests/test_for.py
@@ -7,8 +7,9 @@
 from typing import Any
 
 import libcst as cst
-from libcst import CodeRange, PartialParserConfig, parse_statement
+from libcst import PartialParserConfig, parse_statement
 from libcst._nodes.tests.base import CSTNodeTest, DummyIndentedBlock
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_funcdef.py
+++ b/libcst/_nodes/tests/test_funcdef.py
@@ -7,8 +7,9 @@
 from typing import Any, Callable
 
 import libcst as cst
-from libcst import CodeRange, parse_statement
+from libcst import parse_statement
 from libcst._nodes.tests.base import CSTNodeTest, DummyIndentedBlock
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_global.py
+++ b/libcst/_nodes/tests/test_global.py
@@ -7,9 +7,10 @@
 from typing import Any
 
 import libcst as cst
-from libcst import CodeRange, parse_statement
+from libcst import parse_statement
 from libcst._helpers import ensure_type
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_if.py
+++ b/libcst/_nodes/tests/test_if.py
@@ -7,8 +7,9 @@
 from typing import Any
 
 import libcst as cst
-from libcst import CodeRange, parse_statement
+from libcst import parse_statement
 from libcst._nodes.tests.base import CSTNodeTest, DummyIndentedBlock
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_ifexp.py
+++ b/libcst/_nodes/tests/test_ifexp.py
@@ -7,8 +7,9 @@
 from typing import Callable, Optional
 
 import libcst as cst
-from libcst import CodeRange, parse_expression
+from libcst import parse_expression
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_import.py
+++ b/libcst/_nodes/tests/test_import.py
@@ -7,9 +7,10 @@
 from typing import Any
 
 import libcst as cst
-from libcst import CodeRange, parse_statement
+from libcst import parse_statement
 from libcst._helpers import ensure_type
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_internal.py
+++ b/libcst/_nodes/tests/test_internal.py
@@ -9,11 +9,10 @@ from typing import Tuple
 import libcst as cst
 from libcst._nodes.internal import (
     CodegenState,
-    CodePosition,
-    CodeRange,
     PositionProvidingCodegenState,
     WhitespaceInclusivePositionProvidingCodegenState,
 )
+from libcst.metadata import CodePosition, CodeRange
 from libcst.metadata.position_provider import (
     PositionProvider,
     WhitespaceInclusivePositionProvider,
@@ -72,7 +71,7 @@ class InternalTest(UnitTest):
         state.add_indent_tokens()
         self.assertEqual(position(state), (1, 8))
 
-    def test_position(self) -> None:
+    def test_whitespace_inclusive_position(self) -> None:
         # create a dummy node
         node = cst.Pass()
 
@@ -92,7 +91,7 @@ class InternalTest(UnitTest):
         # check whitespace is correctly recorded
         self.assertEqual(state.provider._computed[node], CodeRange((1, 0), (1, 6)))
 
-    def test_syntactic_position(self) -> None:
+    def test_position(self) -> None:
         # create a dummy node
         node = cst.Pass()
 

--- a/libcst/_nodes/tests/test_lambda.py
+++ b/libcst/_nodes/tests/test_lambda.py
@@ -7,8 +7,9 @@
 from typing import Callable, Optional
 
 import libcst as cst
-from libcst import CodeRange, parse_expression
+from libcst import parse_expression
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_list.py
+++ b/libcst/_nodes/tests/test_list.py
@@ -7,8 +7,9 @@
 from typing import Any, Callable
 
 import libcst as cst
-from libcst import CodeRange, parse_expression, parse_statement
+from libcst import parse_expression, parse_statement
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_module.py
+++ b/libcst/_nodes/tests/test_module.py
@@ -7,9 +7,9 @@
 from typing import Tuple, cast
 
 import libcst as cst
-from libcst import CodeRange, parse_module, parse_statement
+from libcst import parse_module, parse_statement
 from libcst._nodes.tests.base import CSTNodeTest
-from libcst.metadata.position_provider import PositionProvider
+from libcst.metadata import CodeRange, PositionProvider
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_nonlocal.py
+++ b/libcst/_nodes/tests/test_nonlocal.py
@@ -7,9 +7,10 @@
 from typing import Any
 
 import libcst as cst
-from libcst import CodeRange, parse_statement
+from libcst import parse_statement
 from libcst._helpers import ensure_type
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_number.py
+++ b/libcst/_nodes/tests/test_number.py
@@ -7,8 +7,9 @@
 from typing import Callable, Optional
 
 import libcst as cst
-from libcst import CodeRange, parse_expression
+from libcst import parse_expression
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_raise.py
+++ b/libcst/_nodes/tests/test_raise.py
@@ -7,9 +7,10 @@
 from typing import Any
 
 import libcst as cst
-from libcst import CodeRange, parse_statement
+from libcst import parse_statement
 from libcst._helpers import ensure_type
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_return.py
+++ b/libcst/_nodes/tests/test_return.py
@@ -7,8 +7,9 @@
 from typing import Any
 
 import libcst as cst
-from libcst import CodeRange, parse_statement
+from libcst import parse_statement
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_simple_comp.py
+++ b/libcst/_nodes/tests/test_simple_comp.py
@@ -7,8 +7,9 @@
 from typing import Any, Callable
 
 import libcst as cst
-from libcst import CodeRange, PartialParserConfig, parse_expression, parse_statement
+from libcst import PartialParserConfig, parse_expression, parse_statement
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_simple_statement.py
+++ b/libcst/_nodes/tests/test_simple_statement.py
@@ -7,8 +7,9 @@
 from typing import Any
 
 import libcst as cst
-from libcst import CodeRange, parse_statement
+from libcst import parse_statement
 from libcst._nodes.tests.base import CSTNodeTest, DummyIndentedBlock
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_small_statement.py
+++ b/libcst/_nodes/tests/test_small_statement.py
@@ -7,8 +7,8 @@
 from typing import Any
 
 import libcst as cst
-from libcst import CodeRange
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_subscript.py
+++ b/libcst/_nodes/tests/test_subscript.py
@@ -7,8 +7,9 @@
 from typing import Callable, Optional
 
 import libcst as cst
-from libcst import CodeRange, parse_expression
+from libcst import parse_expression
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_try.py
+++ b/libcst/_nodes/tests/test_try.py
@@ -7,8 +7,9 @@
 from typing import Any
 
 import libcst as cst
-from libcst import CodeRange, parse_statement
+from libcst import parse_statement
 from libcst._nodes.tests.base import CSTNodeTest, DummyIndentedBlock
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_tuple.py
+++ b/libcst/_nodes/tests/test_tuple.py
@@ -7,8 +7,9 @@
 from typing import Any, Callable
 
 import libcst as cst
-from libcst import CodeRange, parse_expression, parse_statement
+from libcst import parse_expression, parse_statement
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_unary_op.py
+++ b/libcst/_nodes/tests/test_unary_op.py
@@ -7,8 +7,9 @@
 from typing import Callable, Optional
 
 import libcst as cst
-from libcst import CodeRange, parse_expression
+from libcst import parse_expression
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_while.py
+++ b/libcst/_nodes/tests/test_while.py
@@ -7,8 +7,9 @@
 from typing import Any
 
 import libcst as cst
-from libcst import CodeRange, parse_statement
+from libcst import parse_statement
 from libcst._nodes.tests.base import CSTNodeTest, DummyIndentedBlock
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_with.py
+++ b/libcst/_nodes/tests/test_with.py
@@ -7,8 +7,9 @@
 from typing import Any
 
 import libcst as cst
-from libcst import CodeRange, PartialParserConfig, parse_statement
+from libcst import PartialParserConfig, parse_statement
 from libcst._nodes.tests.base import CSTNodeTest, DummyIndentedBlock
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_nodes/tests/test_yield.py
+++ b/libcst/_nodes/tests/test_yield.py
@@ -7,9 +7,10 @@
 from typing import Callable, Optional
 
 import libcst as cst
-from libcst import CodeRange, parse_statement
+from libcst import parse_statement
 from libcst._helpers import ensure_type
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
 

--- a/libcst/_position.py
+++ b/libcst/_position.py
@@ -1,0 +1,58 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Data structures used for storing position information.
+
+These are publicly exported by metadata, but their implementation lives outside of
+metadata, because they're used internally by the codegen logic, which computes position
+locations.
+"""
+
+from dataclasses import dataclass
+from typing import Tuple, Union, cast, overload
+
+from libcst._add_slots import add_slots
+
+
+_CodePositionT = Union[Tuple[int, int], "CodePosition"]
+
+
+@add_slots
+@dataclass(frozen=True)
+class CodePosition:
+    #: Line numbers are 1-indexed.
+    line: int
+    #: Column numbers are 0-indexed.
+    column: int
+
+
+@add_slots
+@dataclass(frozen=True)
+class CodeRange:
+    #: Starting position of a node (inclusive).
+    start: CodePosition
+    #: Ending position of a node (exclusive).
+    end: CodePosition
+
+    @overload
+    def __init__(self, start: CodePosition, end: CodePosition) -> None:
+        ...
+
+    @overload
+    def __init__(self, start: Tuple[int, int], end: Tuple[int, int]) -> None:
+        ...
+
+    def __init__(self, start: _CodePositionT, end: _CodePositionT) -> None:
+        if isinstance(start, tuple) and isinstance(end, tuple):
+            object.__setattr__(self, "start", CodePosition(start[0], start[1]))
+            object.__setattr__(self, "end", CodePosition(end[0], end[1]))
+        else:
+            start = cast(CodePosition, start)
+            end = cast(CodePosition, end)
+            object.__setattr__(self, "start", start)
+            object.__setattr__(self, "end", end)

--- a/libcst/metadata/__init__.py
+++ b/libcst/metadata/__init__.py
@@ -5,6 +5,7 @@
 
 # pyre-strict
 
+from libcst._position import CodePosition, CodeRange
 from libcst.metadata.base_provider import (
     BatchableMetadataProvider,
     ProviderT,
@@ -42,6 +43,8 @@ from libcst.metadata.wrapper import MetadataWrapper
 
 
 __all__ = [
+    "CodePosition",
+    "CodeRange",
     "WhitespaceInclusivePositionProvider",
     "PositionProvider",
     "BasicPositionProvider",  # deprecated name for backwards compatibility

--- a/libcst/metadata/tests/test_position_provider.py
+++ b/libcst/metadata/tests/test_position_provider.py
@@ -5,10 +5,10 @@
 
 # pyre-strict
 import libcst as cst
-from libcst import CodeRange, parse_module
+from libcst import parse_module
 from libcst._batched_visitor import BatchableCSTVisitor
 from libcst._visitors import CSTTransformer
-from libcst.metadata import MetadataWrapper, PositionProvider
+from libcst.metadata import CodeRange, MetadataWrapper, PositionProvider
 from libcst.testing.utils import UnitTest
 
 


### PR DESCRIPTION
## Summary

While these classes are used by the codegen implementation, conceptually they're part of `libcst.metadata`, so we should export them from `libcst.metadata` instead of the top-level `libcst` package.

These classes are still exported from `libcst` for backwards compatibility, but we can remove them from `libcst` in the next major version bump.

I cleaned up all of the internal imports by hand with the help of ripgrep.

This work is roughly related to the position provider renames I did in #114.

## Test Plan

Pyre, unit tests, lint.