### PR TITLE
Fix trailing newline detection around continuation

### DIFF
--- a/libcst/_parser/tests/test_detect_config.py
+++ b/libcst/_parser/tests/test_detect_config.py
@@ -190,6 +190,62 @@ class TestDetectConfig(UnitTest):
                     version=PythonVersionInfo(3, 7),
                 ),
             },
+            "detect_trailing_newline_missing_newline": {
+                "source": b"test",
+                "partial": PartialParserConfig(python_version="3.7"),
+                "detect_trailing_newline": True,
+                "detect_default_newline": True,
+                "expected_config": ParserConfig(
+                    lines=["test\n", ""],
+                    encoding="utf-8",
+                    default_indent="    ",
+                    default_newline="\n",
+                    has_trailing_newline=False,
+                    version=PythonVersionInfo(3, 7),
+                ),
+            },
+            "detect_trailing_newline_has_newline": {
+                "source": b"test\n",
+                "partial": PartialParserConfig(python_version="3.7"),
+                "detect_trailing_newline": True,
+                "detect_default_newline": True,
+                "expected_config": ParserConfig(
+                    lines=["test\n", ""],
+                    encoding="utf-8",
+                    default_indent="    ",
+                    default_newline="\n",
+                    has_trailing_newline=True,
+                    version=PythonVersionInfo(3, 7),
+                ),
+            },
+            "detect_trailing_newline_missing_newline_after_line_continuation": {
+                "source": b"test\\\n",
+                "partial": PartialParserConfig(python_version="3.7"),
+                "detect_trailing_newline": True,
+                "detect_default_newline": True,
+                "expected_config": ParserConfig(
+                    lines=["test\\\n", "\n", ""],
+                    encoding="utf-8",
+                    default_indent="    ",
+                    default_newline="\n",
+                    has_trailing_newline=False,
+                    version=PythonVersionInfo(3, 7),
+                ),
+            },
+            "detect_trailing_newline_has_newline_after_line_continuation": {
+                "source": b"test\\\n\n",
+                "partial": PartialParserConfig(python_version="3.7"),
+                "detect_trailing_newline": True,
+                "detect_default_newline": True,
+                "expected_config": ParserConfig(
+                    lines=["test\\\n", "\n", ""],
+                    encoding="utf-8",
+                    default_indent="    ",
+                    default_newline="\n",
+                    has_trailing_newline=True,
+                    version=PythonVersionInfo(3, 7),
+                ),
+            },
         }
     )
     def test_detect_module_config(


### PR DESCRIPTION
## Summary

If you have such a program like "pass\\\n", this is technically a program without a trailing newline, since line continuations are defined as being a `\` followed by a newline. We were misdetecting this as having a trailing newline, thus making it impossible to parse the continuation. Add some tests to verify this behavior and then fix the problem.

Note that this was found via hypothesis.

## Test Plan

tox
