### PR TITLE
Update tutorial to use renamed PositionProvider

### DIFF
--- a/docs/source/metadata_tutorial.ipynb
+++ b/docs/source/metadata_tutorial.ipynb
@@ -108,15 +108,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from libcst.metadata import SyntacticPositionProvider\n",
+    "from libcst.metadata import PositionProvider\n",
     "\n",
     "class ParamPrinter(cst.CSTVisitor):\n",
-    "    METADATA_DEPENDENCIES = (IsParamProvider, SyntacticPositionProvider,)\n",
+    "    METADATA_DEPENDENCIES = (IsParamProvider, PositionProvider,)\n",
     "\n",
     "    def visit_Name(self, node: cst.Name) -> None:\n",
     "        # Only print out names that are parameters\n",
     "        if self.get_metadata(IsParamProvider, node):\n",
-    "            pos = self.get_metadata(SyntacticPositionProvider, node).start\n",
+    "            pos = self.get_metadata(PositionProvider, node).start\n",
     "            print(f\"{node.value} found at line {pos.line}, column {pos.column}\")\n",
     "\n",
     "\n",
@@ -124,13 +124,6 @@
     "wrapper = cst.MetadataWrapper(module)\n",
     "result = wrapper.visit(ParamPrinter())"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

I missed this in #114 when renaming `SyntacticPositionProvider` to
`PositionProvider` because it's a different file extension and I was
only grepping for rst and py files.

## Test Plan

```
tox -e docs
```