### PR TITLE
More explicit fuzz testing environments

### DIFF
--- a/libcst/tests/test_fuzz.py
+++ b/libcst/tests/test_fuzz.py
@@ -27,7 +27,7 @@ import libcst
 hypothesis.settings.register_profile(
     name="settings-for-unit-tests",
     print_blob=True,
-    deadline=timedelta(seconds=60),
+    deadline=timedelta(seconds=1800),
     suppress_health_check=[
         hypothesis.HealthCheck.too_slow,
         hypothesis.HealthCheck.filter_too_much,
@@ -41,7 +41,7 @@ hypothesis.settings.load_profile("settings-for-unit-tests")
 hypothesis.settings.register_profile(
     name="settings-for-fuzzing",
     parent=hypothesis.settings.get_profile("settings-for-unit-tests"),
-    max_examples=1_000_000,
+    max_examples=1_000_000_000,
     phases=(hypothesis.Phase.generate, hypothesis.Phase.shrink),
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -45,14 +45,25 @@ commands =
     coverage run setup.py test
     codecov
 
-[testenv:fuzz]
+[testenv:fuzz36]
+basepython = python3.6
 deps =
     -rrequirements.txt
     -rrequirements-dev.txt
 setenv =
     HYPOTHESIS = 1
 commands =
-    python -m unittest libcst/tests/test_fuzz.py
+    python3.6 -m unittest libcst/tests/test_fuzz.py
+
+[testenv:fuzz37]
+basepython = python3.7
+deps =
+    -rrequirements.txt
+    -rrequirements-dev.txt
+setenv =
+    HYPOTHESIS = 1
+commands =
+    python3.7 -m unittest libcst/tests/test_fuzz.py
 
 [testenv:codegen]
 deps =


### PR DESCRIPTION
## Summary

Let's split from just fuzzing on the default python to having a separate fuzzer for each version of python we support. This should help us catch any issues should they arise in differences with grammars across releases. Right now we're fuzz-clean as well, so I also bumped up the thresholds to stress test LibCST more. I anticipate that this will be useful when we begin work on 3.8 support.

## Test Plan

`tox -e fuzz36 ; tox -e fuzz37` which complete in about 90 seconds each.