### PR TITLE
Make the codegen enter/leave tracking more generic

### DIFF
--- a/libcst/_nodes/base.py
+++ b/libcst/_nodes/base.py
@@ -19,7 +19,6 @@ from typing import (
 )
 
 from libcst._nodes.internal import CodegenState
-from libcst._position import CodePosition, CodeRange
 from libcst._removal_sentinel import RemovalSentinel
 from libcst._type_enforce import is_value_of_type
 from libcst._types import CSTNodeT
@@ -297,10 +296,9 @@ class CSTNode(ABC):
         ...
 
     def _codegen(self, state: CodegenState, **kwargs: Any) -> None:
-        start = CodePosition(state.line, state.column)
+        state.before_visit(self)
         self._codegen_impl(state, **kwargs)
-        end = CodePosition(state.line, state.column)
-        state.record_position(self, CodeRange(start, end))
+        state.after_leave(self)
 
     def with_changes(self: _CSTNodeSelfT, **changes: Any) -> _CSTNodeSelfT:
         """

--- a/libcst/_nodes/base.py
+++ b/libcst/_nodes/base.py
@@ -296,9 +296,9 @@ class CSTNode(ABC):
         ...
 
     def _codegen(self, state: CodegenState, **kwargs: Any) -> None:
-        state.before_visit(self)
+        state.before_codegen(self)
         self._codegen_impl(state, **kwargs)
-        state.after_leave(self)
+        state.after_codegen(self)
 
     def with_changes(self: _CSTNodeSelfT, **changes: Any) -> _CSTNodeSelfT:
         """

--- a/libcst/_nodes/internal.py
+++ b/libcst/_nodes/internal.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Iterable, Iterator, List, Optional, Sequence, 
 
 from libcst._add_slots import add_slots
 from libcst._maybe_sentinel import MaybeSentinel
-from libcst._position import CodeRange
 from libcst._removal_sentinel import RemovalSentinel
 from libcst._types import CSTNodeT
 
@@ -48,7 +47,10 @@ class CodegenState:
     def add_token(self, value: str) -> None:
         self.tokens.append(value)
 
-    def record_position(self, node: "CSTNode", position: CodeRange) -> None:
+    def before_visit(self, node: "CSTNode") -> None:
+        pass
+
+    def after_leave(self, node: "CSTNode") -> None:
         pass
 
     @contextmanager

--- a/libcst/_nodes/internal.py
+++ b/libcst/_nodes/internal.py
@@ -47,10 +47,10 @@ class CodegenState:
     def add_token(self, value: str) -> None:
         self.tokens.append(value)
 
-    def before_visit(self, node: "CSTNode") -> None:
+    def before_codegen(self, node: "CSTNode") -> None:
         pass
 
-    def after_leave(self, node: "CSTNode") -> None:
+    def after_codegen(self, node: "CSTNode") -> None:
         pass
 
     @contextmanager

--- a/libcst/metadata/position_provider.py
+++ b/libcst/metadata/position_provider.py
@@ -49,10 +49,10 @@ class WhitespaceInclusivePositionProvidingCodegenState(CodegenState):
             # newline resets column back to 0, but a trailing token may shift column
             self.column = len(segments[-1])
 
-    def before_visit(self, node: "CSTNode") -> None:
+    def before_codegen(self, node: "CSTNode") -> None:
         self._stack.append(CodePosition(self.line, self.column))
 
-    def after_leave(self, node: "CSTNode") -> None:
+    def after_codegen(self, node: "CSTNode") -> None:
         # we must unconditionally pop the stack, else we could end up in a broken state
         start_pos = self._stack.pop()
 

--- a/libcst/metadata/tests/test_position_provider.py
+++ b/libcst/metadata/tests/test_position_provider.py
@@ -120,12 +120,12 @@ class PositionProvidingCodegenStateTest(UnitTest):
         state = WhitespaceInclusivePositionProvidingCodegenState(
             " " * 4, "\n", WhitespaceInclusivePositionProvider()
         )
-        state.before_visit(node)
+        state.before_codegen(node)
         state.add_token(" ")
         with state.record_syntactic_position(node):
             state.add_token("pass")
         state.add_token(" ")
-        state.after_leave(node)
+        state.after_codegen(node)
 
         # check whitespace is correctly recorded
         self.assertEqual(state.provider._computed[node], CodeRange((1, 0), (1, 6)))
@@ -137,12 +137,12 @@ class PositionProvidingCodegenStateTest(UnitTest):
         # simulate codegen behavior for the dummy node
         # generates the code " pass "
         state = PositionProvidingCodegenState(" " * 4, "\n", PositionProvider())
-        state.before_visit(node)
+        state.before_codegen(node)
         state.add_token(" ")
         with state.record_syntactic_position(node):
             state.add_token("pass")
         state.add_token(" ")
-        state.after_leave(node)
+        state.after_codegen(node)
 
         # check syntactic position ignores whitespace
         self.assertEqual(state.provider._computed[node], CodeRange((1, 1), (1, 5)))

--- a/libcst/metadata/tests/test_position_provider.py
+++ b/libcst/metadata/tests/test_position_provider.py
@@ -13,7 +13,6 @@ from libcst._batched_visitor import BatchableCSTVisitor
 from libcst._nodes.internal import CodegenState
 from libcst._visitors import CSTTransformer
 from libcst.metadata import (
-    CodePosition,
     CodeRange,
     MetadataWrapper,
     PositionProvider,
@@ -121,13 +120,12 @@ class PositionProvidingCodegenStateTest(UnitTest):
         state = WhitespaceInclusivePositionProvidingCodegenState(
             " " * 4, "\n", WhitespaceInclusivePositionProvider()
         )
-        start = CodePosition(state.line, state.column)
+        state.before_visit(node)
         state.add_token(" ")
         with state.record_syntactic_position(node):
             state.add_token("pass")
         state.add_token(" ")
-        end = CodePosition(state.line, state.column)
-        state.record_position(node, CodeRange(start, end))
+        state.after_leave(node)
 
         # check whitespace is correctly recorded
         self.assertEqual(state.provider._computed[node], CodeRange((1, 0), (1, 6)))
@@ -139,13 +137,12 @@ class PositionProvidingCodegenStateTest(UnitTest):
         # simulate codegen behavior for the dummy node
         # generates the code " pass "
         state = PositionProvidingCodegenState(" " * 4, "\n", PositionProvider())
-        start = CodePosition(state.line, state.column)
+        state.before_visit(node)
         state.add_token(" ")
         with state.record_syntactic_position(node):
             state.add_token("pass")
         state.add_token(" ")
-        end = CodePosition(state.line, state.column)
-        state.record_position(node, CodeRange(start, end))
+        state.after_leave(node)
 
         # check syntactic position ignores whitespace
         self.assertEqual(state.provider._computed[node], CodeRange((1, 1), (1, 5)))


### PR DESCRIPTION
## Summary

I need to do some additional work on visit/leave to make codegen
re-entrant, so this makes it more generic.

This should have an additional small positive effect of creating less
throwaway objects when we're doing codegen without position calculation.

## Test Plan

pyre/unit tests/lint