### PR TITLE
Add a reentrant (incremental) codegen API

### DIFF
--- a/docs/source/experimental.rst
+++ b/docs/source/experimental.rst
@@ -1,0 +1,15 @@
+.. _libcst-experimental:
+
+=================
+Experimental APIs
+=================
+
+These APIs may change at any time (including in minor releases) with no notice. You 
+probably shouldn't use them, but if you do, you should pin your application to an exact
+release of LibCST to avoid breakages.
+
+Reentrant Code Generation
+-------------------------
+
+.. autoclass:: libcst.metadata.ExperimentalReentrantCodegenProvider
+.. autoclass:: libcst.metadata.CodegenPartial

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -39,6 +39,7 @@ LibCST
    visitors
    metadata
    matchers
+   experimental
 
 
 Indices and tables

--- a/libcst/_nodes/internal.py
+++ b/libcst/_nodes/internal.py
@@ -32,9 +32,6 @@ class CodegenState:
     indent_tokens: List[str] = field(default_factory=list)
     tokens: List[str] = field(default_factory=list)
 
-    line: int = 1  # one-indexed
-    column: int = 0  # zero-indexed
-
     def increase_indent(self, value: str) -> None:
         self.indent_tokens.append(value)
 
@@ -52,6 +49,16 @@ class CodegenState:
 
     def after_codegen(self, node: "CSTNode") -> None:
         pass
+
+    def pop_trailing_newline(self) -> None:
+        """
+        Called by :meth:`libcst.Module._codegen_impl` at the end of the file to remove
+        the last token (a trailing newline), assuming the file isn't empty.
+        """
+        if len(self.tokens) > 0:
+            # EmptyLine and all statements generate newlines, so we can be sure that the
+            # last token (if we're not an empty file) is a newline.
+            self.tokens.pop()
 
     @contextmanager
     def record_syntactic_position(

--- a/libcst/_nodes/module.py
+++ b/libcst/_nodes/module.py
@@ -102,10 +102,7 @@ class Module(CSTNode):
                 # to preserve the trailing newline.
                 state.add_token(state.default_newline)
         else:  # has_trailing_newline is false
-            if len(state.tokens) > 0:
-                # EmptyLine and all statements generate newlines, so we can be sure that
-                # the last token (if we're not an empty file) is a newline.
-                state.tokens.pop()
+            state.pop_trailing_newline()
 
     @property
     def code(self) -> str:

--- a/libcst/_nodes/tests/test_namedexpr.py
+++ b/libcst/_nodes/tests/test_namedexpr.py
@@ -67,10 +67,10 @@ class NamedExprTest(CSTNodeTest):
             {
                 "node": cst.While(
                     test=cst.NamedExpr(
-                        target=cst.Name(value="x",),
-                        value=cst.Call(func=cst.Name(value="some_input",),),
+                        target=cst.Name(value="x"),
+                        value=cst.Call(func=cst.Name(value="some_input")),
                     ),
-                    body=cst.SimpleStatementSuite(body=[cst.Pass(),],),
+                    body=cst.SimpleStatementSuite(body=[cst.Pass()]),
                 ),
                 "code": "while x := some_input(): pass\n",
                 "parser": _parse_statement_force_38,
@@ -79,10 +79,10 @@ class NamedExprTest(CSTNodeTest):
             {
                 "node": cst.If(
                     test=cst.NamedExpr(
-                        target=cst.Name(value="x",),
-                        value=cst.Call(func=cst.Name(value="some_input",),),
+                        target=cst.Name(value="x"),
+                        value=cst.Call(func=cst.Name(value="some_input")),
                     ),
-                    body=cst.SimpleStatementSuite(body=[cst.Pass(),],),
+                    body=cst.SimpleStatementSuite(body=[cst.Pass()]),
                 ),
                 "code": "if x := some_input(): pass\n",
                 "parser": _parse_statement_force_38,
@@ -98,7 +98,7 @@ class NamedExprTest(CSTNodeTest):
             {
                 "get_node": (
                     lambda: cst.NamedExpr(
-                        cst.Name("foo"), cst.Name("bar"), lpar=(cst.LeftParen(),),
+                        cst.Name("foo"), cst.Name("bar"), lpar=(cst.LeftParen(),)
                     )
                 ),
                 "expected_re": "left paren without right paren",
@@ -106,7 +106,7 @@ class NamedExprTest(CSTNodeTest):
             {
                 "get_node": (
                     lambda: cst.NamedExpr(
-                        cst.Name("foo"), cst.Name("bar"), rpar=(cst.RightParen(),),
+                        cst.Name("foo"), cst.Name("bar"), rpar=(cst.RightParen(),)
                     )
                 ),
                 "expected_re": "right paren without left paren",

--- a/libcst/metadata/__init__.py
+++ b/libcst/metadata/__init__.py
@@ -23,6 +23,10 @@ from libcst.metadata.position_provider import (
     SyntacticPositionProvider,
     WhitespaceInclusivePositionProvider,
 )
+from libcst.metadata.reentrant_codegen import (
+    CodegenPartial,
+    ExperimentalReentrantCodegenProvider,
+)
 from libcst.metadata.scope_provider import (
     Access,
     Accesses,
@@ -73,4 +77,7 @@ __all__ = [
     "ProviderT",
     "Assignments",
     "Accesses",
+    # Experimental APIs:
+    "ExperimentalReentrantCodegenProvider",
+    "CodegenPartial",
 ]

--- a/libcst/metadata/position_provider.py
+++ b/libcst/metadata/position_provider.py
@@ -24,7 +24,16 @@ NEWLINE_RE: Pattern[str] = re.compile(r"\r\n?|\n")
 @add_slots
 @dataclass(frozen=False)
 class WhitespaceInclusivePositionProvidingCodegenState(CodegenState):
+    # These are derived from a Module
+    default_indent: str
+    default_newline: str
     provider: BaseMetadataProvider[CodeRange]
+
+    indent_tokens: List[str] = field(default_factory=list)
+    tokens: List[str] = field(default_factory=list)
+
+    line: int = 1  # one-indexed
+    column: int = 0  # zero-indexed
     _stack: List[CodePosition] = field(init=False, default_factory=list)
 
     def add_indent_tokens(self) -> None:

--- a/libcst/metadata/reentrant_codegen.py
+++ b/libcst/metadata/reentrant_codegen.py
@@ -56,7 +56,7 @@ class CodegenPartial:
         """
         return self.get_original_module_code().encode(self._prev_codegen_state.encoding)
 
-    def get_original_node_code(self) -> str:
+    def get_original_statement_code(self) -> str:
         """
         Equivalent to :meth:`libcst.Module.code_for_node` on the current statement,
         except that it uses the cached result from our previous code generation pass,
@@ -64,7 +64,7 @@ class CodegenPartial:
         """
         return self._prev_codegen_state.get_code()[self.start_offset : self.end_offset]
 
-    def get_modified_node_code(self, node: BaseStatement) -> str:
+    def get_modified_statement_code(self, node: BaseStatement) -> str:
         """
         Gets the new code for ``node`` as if it were in same location as the old
         statement being replaced. This means that it inherits details like the old
@@ -86,7 +86,7 @@ class CodegenPartial:
         the supplied replacement ``node`` in its place.
         """
         original = self.get_original_module_code()
-        patch = self.get_modified_node_code(node)
+        patch = self.get_modified_statement_code(node)
         return f"{original[:self.start_offset]}{patch}{original[self.end_offset:]}"
 
     def get_modified_module_bytes(self, node: BaseStatement) -> bytes:

--- a/libcst/metadata/reentrant_codegen.py
+++ b/libcst/metadata/reentrant_codegen.py
@@ -1,0 +1,210 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Sequence
+
+from libcst import BaseStatement, CSTNode, Module
+from libcst._add_slots import add_slots
+from libcst._nodes.internal import CodegenState
+from libcst.metadata import BaseMetadataProvider
+
+
+class CodegenPartial:
+    """
+    Provided by :class:`ExperimentalReentrantCodegenProvider`.
+
+    Stores enough information to generate either a small patch
+    (:meth:`get_modified_code_range`) or a new file (:meth:`get_modified_code`) by
+    replacing the old node at this position.
+    """
+
+    __slots__ = [
+        "start_offset",
+        "end_offset",
+        "has_trailing_newline",
+        "_indent_tokens",
+        "_prev_codegen_state",
+    ]
+
+    def __init__(self, state: "_ReentrantCodegenState") -> None:
+        # store a frozen copy of these values, since they change over time
+        self.start_offset: int = state.start_offset_stack[-1]
+        self.end_offset: int = state.char_offset
+        self.has_trailing_newline: bool = True  # this may get updated to False later
+        self._indent_tokens: Sequence[str] = tuple(state.indent_tokens)
+        # everything else can be accessed from the codegen state object
+        self._prev_codegen_state: _ReentrantCodegenState = state
+
+    def get_original_module_code(self) -> str:
+        """
+        Equivalent to :meth:`libcst.Module.bytes` on the top-level module that contains
+        this statement, except that it uses the cached result from our previous code
+        generation pass, so it's faster.
+        """
+        return self._prev_codegen_state.get_code()
+
+    def get_original_module_bytes(self) -> bytes:
+        """
+        Equivalent to :meth:`libcst.Module.bytes` on the top-level module that contains
+        this statement, except that it uses the cached result from our previous code
+        generation pass, so it's faster.
+        """
+        return self.get_original_module_code().encode(self._prev_codegen_state.encoding)
+
+    def get_original_node_code(self) -> str:
+        """
+        Equivalent to :meth:`libcst.Module.code_for_node` on the current statement,
+        except that it uses the cached result from our previous code generation pass,
+        so it's faster.
+        """
+        return self._prev_codegen_state.get_code()[self.start_offset : self.end_offset]
+
+    def get_modified_node_code(self, node: BaseStatement) -> str:
+        """
+        Gets the new code for ``node`` as if it were in same location as the old
+        statement being replaced. This means that it inherits details like the old
+        statement's indentation.
+        """
+        new_codegen_state = CodegenState(
+            default_indent=self._prev_codegen_state.default_indent,
+            default_newline=self._prev_codegen_state.default_newline,
+            indent_tokens=list(self._indent_tokens),
+        )
+        node._codegen(new_codegen_state)
+        if not self.has_trailing_newline:
+            new_codegen_state.pop_trailing_newline()
+        return "".join(new_codegen_state.tokens)
+
+    def get_modified_module_code(self, node: BaseStatement) -> str:
+        """
+        Gets the new code for the module at the root of this statement's tree, but with
+        the supplied replacement ``node`` in its place.
+        """
+        original = self.get_original_module_code()
+        patch = self.get_modified_node_code(node)
+        return f"{original[:self.start_offset]}{patch}{original[self.end_offset:]}"
+
+    def get_modified_module_bytes(self, node: BaseStatement) -> bytes:
+        """
+        Gets the new bytes for the module at the root of this statement's tree, but with
+        the supplied replacement ``node`` in its place.
+        """
+        return self.get_modified_module_code(node).encode(
+            self._prev_codegen_state.encoding
+        )
+
+
+@add_slots
+@dataclass(frozen=False)
+class _ReentrantCodegenState(CodegenState):
+    provider: BaseMetadataProvider[CodegenPartial]
+    encoding: str = "utf-8"
+    indent_size: int = 0
+    char_offset: int = 0
+    start_offset_stack: List[int] = field(default_factory=list)
+    cached_code: Optional[str] = None
+    trailing_partials: List[CodegenPartial] = field(default_factory=list)
+
+    def increase_indent(self, value: str) -> None:
+        super(_ReentrantCodegenState, self).increase_indent(value)
+        self.indent_size += len(value)
+
+    def decrease_indent(self) -> None:
+        self.indent_size -= len(self.indent_tokens[-1])
+        super(_ReentrantCodegenState, self).decrease_indent()
+
+    def add_indent_tokens(self) -> None:
+        super(_ReentrantCodegenState, self).add_indent_tokens()
+        self.char_offset += self.indent_size
+
+    def add_token(self, value: str) -> None:
+        super(_ReentrantCodegenState, self).add_token(value)
+        self.char_offset += len(value)
+        self.trailing_partials.clear()
+
+    def before_codegen(self, node: CSTNode) -> None:
+        if not isinstance(node, BaseStatement):
+            return
+
+        self.start_offset_stack.append(self.char_offset)
+
+    def after_codegen(self, node: CSTNode) -> None:
+        if not isinstance(node, BaseStatement):
+            return
+
+        partial = CodegenPartial(self)
+        self.provider.set_metadata(node, partial)
+        self.start_offset_stack.pop()
+        self.trailing_partials.append(partial)
+
+    def pop_trailing_newline(self) -> None:
+        """
+        :class:`libcst.Module` contains a hack where it removes the last token (a
+        newline) if the original file didn't have a newline.
+
+        If this happens, we need to go back through every node at the end of the file,
+        and fix their `end_offset`.
+        """
+        for tp in self.trailing_partials:
+            tp.end_offset -= len(self.tokens[-1])
+            tp.has_trailing_newline = False
+        super(_ReentrantCodegenState, self).pop_trailing_newline()
+
+    def get_code(self) -> str:
+        # Ideally this would use functools.cached_property, but that's only in
+        # Python 3.8+.
+        #
+        # This is a little ugly to make pyre's attribute refinement checks happy.
+        cached_code = self.cached_code
+        if cached_code is not None:
+            return cached_code
+        cached_code = "".join(self.tokens)
+        self.cached_code = cached_code
+        return cached_code
+
+
+class ExperimentalReentrantCodegenProvider(BaseMetadataProvider[CodegenPartial]):
+    """
+    An experimental API that allows fast generation of modified code by recording an
+    initial code-generation pass, and incrementally applying updates. It is a
+    performance optimization for a few niche use-cases and is not user-friendly.
+
+    **This API may change at any time without warning (including in minor releases).**
+
+    This is rarely useful. Instead you should make multiple modifications to a single
+    syntax tree, and generate the code once. However, we can think of a few use-cases
+    for this API (hence, why it exists):
+
+    - When linting a file, you might generate multiple independent patches that a user
+      can accept or reject. Depending on your architecture, it may be advantageous to
+      avoid regenerating the file when computing each patch.
+
+    - You might want to call out to an external utility (e.g. a typechecker, such as
+      pyre or mypy) to validate a small change. You may need to generate and test lots
+      of these patches.
+
+    Restrictions:
+
+    - For safety and sanity reasons, the smallest/only level of granularity is a
+      statement. If you need to patch part of a statement, you regenerate the entire
+      statement. If you need to regenerate an entire module, just call
+      :meth:`libcst.Module.code`.
+
+    - This does not (currently) operate recursively. You can patch an unpatched piece
+      of code multiple times, but you can't layer additional patches on an already
+      patched piece of code.
+    """
+
+    def _gen_impl(self, module: Module) -> None:
+        state = _ReentrantCodegenState(
+            default_indent=module.default_indent,
+            default_newline=module.default_newline,
+            provider=self,
+            encoding=module.encoding,
+        )
+        module._codegen(state)

--- a/libcst/metadata/tests/test_position_provider.py
+++ b/libcst/metadata/tests/test_position_provider.py
@@ -10,7 +10,6 @@ from typing import Tuple
 import libcst as cst
 from libcst import parse_module
 from libcst._batched_visitor import BatchableCSTVisitor
-from libcst._nodes.internal import CodegenState
 from libcst._visitors import CSTTransformer
 from libcst.metadata import (
     CodeRange,
@@ -25,7 +24,9 @@ from libcst.metadata.position_provider import (
 from libcst.testing.utils import UnitTest
 
 
-def position(state: CodegenState) -> Tuple[int, int]:
+def position(
+    state: WhitespaceInclusivePositionProvidingCodegenState,
+) -> Tuple[int, int]:
     return state.line, state.column
 
 

--- a/libcst/metadata/tests/test_reentrant_codegen.py
+++ b/libcst/metadata/tests/test_reentrant_codegen.py
@@ -1,0 +1,109 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from textwrap import dedent
+from typing import Callable
+
+import libcst as cst
+from libcst.metadata import ExperimentalReentrantCodegenProvider, MetadataWrapper
+from libcst.testing.utils import UnitTest, data_provider
+
+
+class ExperimentalReentrantCodegenProviderTest(UnitTest):
+    @data_provider(
+        {
+            "simple_top_level_statement": {
+                "old_module": (
+                    """\
+                    import math
+                    c = math.sqrt(a*a + b*b)
+                    """
+                ),
+                "new_module": (
+                    """\
+                    import math
+                    c = math.hypot(a, b)
+                    """
+                ),
+                "old_node": lambda m: m.body[1],
+                "new_node": cst.parse_statement("c = math.hypot(a, b)"),
+            },
+            "replacement_inside_block": {
+                "old_module": (
+                    """\
+                    import math
+                    def do_math(a, b):
+                        c = math.sqrt(a*a + b*b)
+                        return c
+                    """
+                ),
+                "new_module": (
+                    """\
+                    import math
+                    def do_math(a, b):
+                        c = math.hypot(a, b)
+                        return c
+                    """
+                ),
+                "old_node": lambda m: m.body[1].body.body[0],
+                "new_node": cst.parse_statement("c = math.hypot(a, b)"),
+            },
+            "missing_trailing_newline": {
+                "old_module": "old_fn()",  # this module has no trailing newline
+                "new_module": "new_fn()",
+                "old_node": lambda m: m.body[0],
+                "new_node": cst.parse_statement("new_fn()\n"),
+            },
+            "nested_blocks_with_missing_trailing_newline": {
+                "old_module": (
+                    """\
+                    if outer:
+                        if inner:
+                            old_fn()"""  # this module has no trailing newline
+                ),
+                "new_module": (
+                    """\
+                    if outer:
+                        if inner:
+                            new_fn()"""
+                ),
+                "old_node": lambda m: m.body[0].body.body[0].body.body[0],
+                "new_node": cst.parse_statement("new_fn()\n"),
+            },
+        }
+    )
+    def test_provider(
+        self,
+        old_module: str,
+        new_module: str,
+        old_node: Callable[[cst.Module], cst.CSTNode],
+        new_node: cst.BaseStatement,
+    ) -> None:
+        old_module = dedent(old_module)
+        new_module = dedent(new_module)
+
+        mw = MetadataWrapper(cst.parse_module(old_module))
+        codegen_partial = mw.resolve(ExperimentalReentrantCodegenProvider)[
+            old_node(mw.module)
+        ]
+
+        self.assertEqual(codegen_partial.get_original_module_code(), old_module)
+        self.assertEqual(codegen_partial.get_modified_module_code(new_node), new_module)
+
+    def test_byte_conversion(self,) -> None:
+        module_bytes = "fn()\n".encode("utf-16")
+        mw = MetadataWrapper(
+            cst.parse_module("fn()\n", cst.PartialParserConfig(encoding="utf-16"))
+        )
+        codegen_partial = mw.resolve(ExperimentalReentrantCodegenProvider)[
+            mw.module.body[0]
+        ]
+        self.assertEqual(codegen_partial.get_original_module_bytes(), module_bytes)
+        self.assertEqual(
+            codegen_partial.get_modified_module_bytes(cst.parse_statement("fn2()\n")),
+            "fn2()\n".encode("utf-16"),
+        )


### PR DESCRIPTION
## Summary

**Context:** This is an experimental performance optimization that we're
hoping to use for our internal linter at Instagram. I added some
documentation, but it's unsupported, and isn't very user-friendly.

This adds `ExperimentalReentrantCodegenProvider`, which tracks the
codegen's internal state (indentation level, character offsets,
encoding, etc.) and for each statement, it stores a `CodegenPartial`
object.

The `CodegenPartial` object has enough information about the previous
codegen pass to run the codegen on part of a tree and patch the result
back into the original module's string.

In cases where we need to generate a bunch of small independent patches
for the same file (and we can't just generate a new tree with each patch
applied), this *should* be a faster alternative.

I don't have any performance numbers because I still need to test this
end-to-end with our internal codebase, but I'd be shocked if it was
slower than what we're doing.

This could theoretically live outside of LibCST, but it depends on a
whole bunch of LibCST internals, so there's some value in making sure
that this is in sync with the rest of LibCST.

## Test Plan

- Unit tests
- Pyre

![Screenshot_2019-10-28 Experimental APIs — LibCST documentation](https://user-images.githubusercontent.com/180404/67716202-9dcf7c80-f988-11e9-9dbd-a0219f542683.png)
