### PR TITLE
Use official release of Black now that it is out.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-git+https://github.com/psf/black.git@03766f5
+black==19.10b0
 codecov==2.0.15
 coverage==4.5.4
 flake8==3.7.8


### PR DESCRIPTION
## Summary

We don't need to worry about formatting changes since we already paid the cost
in b3253de9b8b08bd9df00193a749e88e5a19d6d95. So, now that there's a new 3.8-compatible
Black, lets use it!

## Test Plan

tox