### PR TITLE
Add an unsafe_skip_copy option to MetadataWrapper

### DIFF
--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -38,6 +38,7 @@ The wrapper provides a :func:`~libcst.metadata.MetadataWrapper.resolve` function
 :func:`~libcst.metadata.MetadataWrapper.resolve_many` function to generate metadata.
 
 .. autoclass:: libcst.metadata.MetadataWrapper
+   :special-members: __init__
 
 If you're working with visitors, which extend :class:`~libcst.MetadataDependent`, 
 metadata dependencies will be automatically computed when visited by a 

--- a/libcst/metadata/tests/test_metadata_wrapper.py
+++ b/libcst/metadata/tests/test_metadata_wrapper.py
@@ -1,0 +1,43 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import libcst as cst
+from libcst.metadata import MetadataWrapper
+from libcst.testing.utils import UnitTest
+
+
+class MetadataWrapperTest(UnitTest):
+    def test_copies_tree(self) -> None:
+        m = cst.parse_module("pass")
+        mw = MetadataWrapper(m)
+        self.assertTrue(mw.module.deep_equals(m))
+        self.assertIsNot(mw.module, m)
+
+    def test_unsafe_skip_copy(self) -> None:
+        m = cst.parse_module("pass")
+        mw = MetadataWrapper(m, unsafe_skip_copy=True)
+        self.assertIs(mw.module, m)
+
+    def test_equality_by_identity(self) -> None:
+        m = cst.parse_module("pass")
+        mw1 = MetadataWrapper(m)
+        mw2 = MetadataWrapper(m)
+        self.assertEqual(mw1, mw1)
+        self.assertEqual(mw2, mw2)
+        self.assertNotEqual(mw1, mw2)
+
+    def test_hash_by_identity(self) -> None:
+        m = cst.parse_module("pass")
+        mw1 = MetadataWrapper(m)
+        mw2 = MetadataWrapper(m, unsafe_skip_copy=True)
+        mw3 = MetadataWrapper(m, unsafe_skip_copy=True)
+        self.assertEqual(hash(mw1), hash(mw1))
+        self.assertEqual(hash(mw2), hash(mw2))
+        self.assertEqual(hash(mw3), hash(mw3))
+        self.assertNotEqual(hash(mw1), hash(mw2))
+        self.assertNotEqual(hash(mw1), hash(mw3))
+        self.assertNotEqual(hash(mw2), hash(mw3))


### PR DESCRIPTION
## Summary

In certain cases (e.g. inside Instagram's lint framework) we know that
our tree originates from the parser, so we know that there shouldn't be
any duplicate nodes in our tree.

MetadataWrapper exists to copy the tree ensuring that there's no
duplicate nodes.

This diff provides an escape hatch on MetadataWrapper that allows us to
save a little time and avoid a copy when we know that it's safe to skip
the copy.

As part of this, I ran into some issues with `InitVar` and pyre, so I
removed `@dataclass` from the class. This means that this is techincally
a breaking change if someone depended on the `MetadataWrapper` being an
actual dataclass, but I think this is unlikely. I implemented `__repr__`
and added tests for hashing/equality behavior.

## Test Plan

Unit tests!

![Screenshot from 2019-10-29 11-13-46](https://user-images.githubusercontent.com/180404/67806561-5ad8dc00-fa50-11e9-96bf-cc2913f16810.png)

![Screenshot from 2019-10-29 13-16-24](https://user-images.githubusercontent.com/180404/67806133-89a28280-fa4f-11e9-8c72-2979447e42a0.png)