### PR TITLE
Implement `findall` in matcher API.

### DIFF
--- a/docs/source/matchers.rst
+++ b/docs/source/matchers.rst
@@ -25,11 +25,12 @@ Matcher APIs
 Functions
 ^^^^^^^^^
 
-Matchers can be used either by calling :func:`~libcst.matchers.matches` directly,
-usually in an ``if`` statement, or by using various decorators to selectively control
-when LibCST calls visitor functions.
+Matchers can be used either by calling :func:`~libcst.matchers.matches` or
+:func:`~libcst.matchers.findall` directly, or by using various decorators to
+selectively control when LibCST calls visitor functions.
 
 .. autofunction:: libcst.matchers.matches
+.. autofunction:: libcst.matchers.findall
 
 .. _libcst-matcher-decorators:
 

--- a/libcst/codegen/gen_matcher_classes.py
+++ b/libcst/codegen/gen_matcher_classes.py
@@ -464,7 +464,7 @@ generated_code.append("from typing_extensions import Literal")
 generated_code.append("import libcst as cst")
 generated_code.append("")
 generated_code.append(
-    "from libcst.matchers._matcher_base import BaseMatcherNode, DoNotCareSentinel, DoNotCare, OneOf, AllOf, DoesNotMatch, MatchIfTrue, MatchRegex, MatchMetadata, ZeroOrMore, AtLeastN, ZeroOrOne, AtMostN, matches"
+    "from libcst.matchers._matcher_base import BaseMatcherNode, DoNotCareSentinel, DoNotCare, OneOf, AllOf, DoesNotMatch, MatchIfTrue, MatchRegex, MatchMetadata, ZeroOrMore, AtLeastN, ZeroOrOne, AtMostN, findall, matches"
 )
 all_exports.update(
     [
@@ -481,6 +481,7 @@ all_exports.update(
         "AtLeastN",
         "ZeroOrOne",
         "AtMostN",
+        "findall",
         "matches",
     ]
 )

--- a/libcst/matchers/__init__.py
+++ b/libcst/matchers/__init__.py
@@ -28,6 +28,7 @@ from libcst.matchers._matcher_base import (
     OneOf,
     ZeroOrMore,
     ZeroOrOne,
+    findall,
     matches,
 )
 from libcst.matchers._visitors import (
@@ -9268,6 +9269,7 @@ __all__ = [
     "ZeroOrOne",
     "call_if_inside",
     "call_if_not_inside",
+    "findall",
     "leave",
     "matches",
     "visit",

--- a/libcst/matchers/_visitors.py
+++ b/libcst/matchers/_visitors.py
@@ -33,8 +33,11 @@ from libcst.matchers._matcher_base import (
     AtLeastN,
     AtMostN,
     BaseMatcherNode,
+    InverseOf,
     MatchIfTrue,
+    MatchMetadata,
     OneOf,
+    findall,
     matches,
 )
 from libcst.matchers._return_types import TYPED_FUNCTION_RETURN_MAPPING
@@ -541,6 +544,27 @@ class MatcherDecoratableTransformer(CSTTransformer):
         """
         return matches(node, matcher, metadata_resolver=self)
 
+    def findall(
+        self,
+        tree: Union[cst.MaybeSentinel, cst.RemovalSentinel, cst.CSTNode],
+        matcher: Union[
+            BaseMatcherNode,
+            MatchIfTrue[Callable[..., bool]],
+            MatchMetadata,
+            InverseOf[
+                Union[BaseMatcherNode, MatchIfTrue[Callable[..., bool]], MatchMetadata]
+            ],
+        ],
+    ) -> Sequence[cst.CSTNode]:
+        """
+        A convenience method to call :func:`~libcst.matchers.findall` without requiring
+        an explicit parameter for metadata. Since our instance is an instance of
+        :class:`libcst.MetadataDependent`, we work as a metadata resolver. Please see
+        documentation for :func:`~libcst.matchers.findall` as it is identical to this
+        function.
+        """
+        return findall(tree, matcher, metadata_resolver=self)
+
     def _transform_module_impl(self, tree: cst.Module) -> cst.Module:
         return tree.visit(self)
 
@@ -658,3 +682,24 @@ class MatcherDecoratableVisitor(CSTVisitor):
         function.
         """
         return matches(node, matcher, metadata_resolver=self)
+
+    def findall(
+        self,
+        tree: Union[cst.MaybeSentinel, cst.RemovalSentinel, cst.CSTNode],
+        matcher: Union[
+            BaseMatcherNode,
+            MatchIfTrue[Callable[..., bool]],
+            MatchMetadata,
+            InverseOf[
+                Union[BaseMatcherNode, MatchIfTrue[Callable[..., bool]], MatchMetadata]
+            ],
+        ],
+    ) -> Sequence[cst.CSTNode]:
+        """
+        A convenience method to call :func:`~libcst.matchers.findall` without requiring
+        an explicit parameter for metadata. Since our instance is an instance of
+        :class:`libcst.MetadataDependent`, we work as a metadata resolver. Please see
+        documentation for :func:`~libcst.matchers.findall` as it is identical to this
+        function.
+        """
+        return findall(tree, matcher, metadata_resolver=self)

--- a/libcst/matchers/tests/test_findall.py
+++ b/libcst/matchers/tests/test_findall.py
@@ -1,0 +1,164 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# pyre-strict
+
+from textwrap import dedent
+from typing import Optional, Sequence
+
+import libcst as cst
+import libcst.matchers as m
+import libcst.metadata as meta
+from libcst.matchers import findall
+from libcst.testing.utils import UnitTest
+
+
+class MatchersFindAllTest(UnitTest):
+    def assertNodeSequenceEqual(
+        self,
+        seq1: Sequence[cst.CSTNode],
+        seq2: Sequence[cst.CSTNode],
+        msg: Optional[str] = None,
+    ) -> None:
+        suffix = "" if msg is None else f"\n{msg}"
+        if len(seq1) != len(seq2):
+            raise AssertionError(
+                f"\n{seq1!r}\nis not deeply equal to \n{seq2!r}{suffix}"
+            )
+
+        for node1, node2 in zip(seq1, seq2):
+            if not node1.deep_equals(node2):
+                raise AssertionError(
+                    f"\n{seq1!r}\nis not deeply equal to \n{seq2!r}{suffix}"
+                )
+
+    def test_findall_with_sentinels(self) -> None:
+        # Verify behavior when provided a sentinel
+        nothing = findall(cst.RemovalSentinel.REMOVE, m.Name("True") | m.Name("False"))
+        self.assertNodeSequenceEqual(nothing, [])
+        nothing = findall(cst.MaybeSentinel.DEFAULT, m.Name("True") | m.Name("False"))
+        self.assertNodeSequenceEqual(nothing, [])
+
+    def test_simple_findall(self) -> None:
+        # Find all booleans in a tree
+        code = """
+            a = 1
+            b = True
+
+            def foo(bar: int) -> bool:
+                return False
+        """
+
+        module = cst.parse_module(dedent(code))
+        booleans = findall(module, m.Name("True") | m.Name("False"))
+        self.assertNodeSequenceEqual(booleans, [cst.Name("True"), cst.Name("False")])
+
+    def test_findall_with_metadata_wrapper(self) -> None:
+        # Find all assignments in a tree
+        code = """
+            a = 1
+            b = True
+
+            def foo(bar: int) -> bool:
+                return False
+        """
+
+        module = cst.parse_module(dedent(code))
+        wrapper = meta.MetadataWrapper(module)
+
+        # Test that when we find over a wrapper, we implicitly use it for
+        # metadata as well as traversal.
+        booleans = findall(
+            wrapper,
+            m.MatchMetadata(
+                meta.ExpressionContextProvider, meta.ExpressionContext.STORE
+            ),
+        )
+        self.assertNodeSequenceEqual(booleans, [cst.Name("a"), cst.Name("b")])
+
+        # Test that we can provide an explicit resolver and tree
+        booleans = findall(
+            wrapper.module,
+            m.MatchMetadata(
+                meta.ExpressionContextProvider, meta.ExpressionContext.STORE
+            ),
+            metadata_resolver=wrapper,
+        )
+        self.assertNodeSequenceEqual(booleans, [cst.Name("a"), cst.Name("b")])
+
+        # Test that failing to provide metadata leads to no match
+        booleans = findall(
+            wrapper.module,
+            m.MatchMetadata(
+                meta.ExpressionContextProvider, meta.ExpressionContext.STORE
+            ),
+        )
+        self.assertNodeSequenceEqual(booleans, [])
+
+    def test_findall_with_visitors(self) -> None:
+        # Find all assignments in a tree
+        class TestVisitor(m.MatcherDecoratableVisitor):
+            METADATA_DEPENDENCIES: Sequence[meta.ProviderT] = (
+                meta.ExpressionContextProvider,
+            )
+
+            def __init__(self) -> None:
+                super().__init__()
+                self.results: Sequence[cst.CSTNode] = ()
+
+            def visit_Module(self, node: cst.Module) -> None:
+                self.results = self.findall(
+                    node,
+                    m.MatchMetadata(
+                        meta.ExpressionContextProvider, meta.ExpressionContext.STORE
+                    ),
+                )
+
+        code = """
+            a = 1
+            b = True
+
+            def foo(bar: int) -> bool:
+                return False
+        """
+
+        module = cst.parse_module(dedent(code))
+        wrapper = meta.MetadataWrapper(module)
+        visitor = TestVisitor()
+        wrapper.visit(visitor)
+        self.assertNodeSequenceEqual(visitor.results, [cst.Name("a"), cst.Name("b")])
+
+    def test_findall_with_transformers(self) -> None:
+        # Find all assignments in a tree
+        class TestTransformer(m.MatcherDecoratableTransformer):
+            METADATA_DEPENDENCIES: Sequence[meta.ProviderT] = (
+                meta.ExpressionContextProvider,
+            )
+
+            def __init__(self) -> None:
+                super().__init__()
+                self.results: Sequence[cst.CSTNode] = ()
+
+            def visit_Module(self, node: cst.Module) -> None:
+                self.results = self.findall(
+                    node,
+                    m.MatchMetadata(
+                        meta.ExpressionContextProvider, meta.ExpressionContext.STORE
+                    ),
+                )
+
+        code = """
+            a = 1
+            b = True
+
+            def foo(bar: int) -> bool:
+                return False
+        """
+
+        module = cst.parse_module(dedent(code))
+        wrapper = meta.MetadataWrapper(module)
+        visitor = TestTransformer()
+        wrapper.visit(visitor)
+        self.assertNodeSequenceEqual(visitor.results, [cst.Name("a"), cst.Name("b")])


### PR DESCRIPTION
## Summary

Findall does what you expect given a matcher and a tree: It returns all nodes
that exist in that tree which match the given matcher. For convenience, findall
works with regular LibCST trees as well as MetadataWrappers. It is also provided
as a helper method on the matcher transforms.

Note that this does not return an iterator. I based this decision on the fact that we
don't currently have a way to use visitors under the hood to create an iterator. If I
were to implement this myself, I would effectively be reinventing traversal of trees.
I don't think this is that big of a deal. If we need an efficient way to find the first
occurance of a match in a tree, I can implement `find` which bails early and document
it as such. For now, I don't want to overcomplicate the API, so I will wait until this
is needed to implement it.

## Test Plan

tox