### PR TITLE
Fix typo in "scope_tutorial.ipynb" file.

### DIFF
--- a/docs/source/scope_tutorial.ipynb
+++ b/docs/source/scope_tutorial.ipynb
@@ -134,7 +134,7 @@
     "Automatically Remove Unused Import\n",
     "==================================\n",
     "Unused import is a commmon code suggestion provided by lint tool like `flake8 F401 <https://lintlyci.github.io/Flake8Rules/rules/F401.html>`_ ``imported but unused``.\n",
-    "Even though reporing unused import is already useful, with LibCST we can provide automatic fix to remove unused import. That can make the suggestion more actionable and save developer's time.\n",
+    "Even though reporting unused import is already useful, with LibCST we can provide automatic fix to remove unused import. That can make the suggestion more actionable and save developer's time.\n",
     "\n",
     "An import statement may import multiple names, we want to remove those unused names from the import statement. If all the names in the import statement are not used, we remove the entire import.\n",
     "To remove the unused name, we implement ``RemoveUnusedImportTransformer`` by subclassing :class:`~libcst.CSTTransformer`. We overwrite ``leave_Import`` and ``leave_ImportFrom`` to modify the import statements.\n",


### PR DESCRIPTION
## Summary

This PR fixes a typo in the `docs/source/scope_tutorial.ipynb` file.

## Test Plan

