### PR TITLE
Bump LibCST to 0.2.3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+# 0.2.3 - 2019-11-11
+
+## Added
+
+ - Preliminary support for 3.8 walrus operator.
+ - CI config and fuzz tests for 3.8.
+ - Experimental re-entrant codegen API.
+ - Added `unsafe_skip_copy` optimization to `MetadataWrapper`.
+ - Matchers API now includes a `findall` function.
+ - Matchers now have a `MatchMetadataIfTrue` special matcher.
+
+## Updated
+
+ - Updated to latest Black release.
+ - Better type documentation for generated matchers.
+
+## Fixed
+
+ - Clarified matchers documentation in several confusing areas.
+ - Drastically sped up codegen and tests.
+ - `QualifiedName` now supports imported attributtes.
+ - `ExpressionContext` properly marks loop variables as `STORE`.
+ - Various typos in documentation are fixed.
+
+## Deprecated
+
+ - Deprecated `BasicPositionProvider` and `SyntacticPositionProvider` in favor of `WhitespaceInclusivePositionProvider` and `PositionProvider`.
+
 # 0.2.2 - 2019-10-24
 
 ## Added
@@ -22,7 +50,6 @@
 
  - Deprecated `ExtSlice` in favor of `SubscriptElement`.
  - Deprecated parsing `Subscript` slices directly into `Index` or `Slice` nodes.
- - Deprecated `BasicPositionProvider` and `SyntacticPositionProvider`. Replaced with new name `WhitespaceInclusivePositionProvider` and `PositionProvider`.
 
 # 0.2.1 - 2019-10-14
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     description="A concrete syntax tree with AST-like properties for Python 3.5, 3.6 and 3.7 programs.",
     long_description=long_description,
     long_description_content_type="text/x-rst",
-    version="0.2.2",
+    version="0.2.3",
     url="https://github.com/Instagram/LibCST",
     license="MIT",
     packages=setuptools.find_packages(),


### PR DESCRIPTION
## Summary

Its time for a new release. Update the version and changelog.

## Test Plan

Ran tox.