### PR TITLE
Bump LibCST to 0.2.4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.4 - 2019-11-13
+
+## Fixed
+
+ - Fixed broken types for sequence matchers.
+
 # 0.2.3 - 2019-11-11
 
 ## Added

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     description="A concrete syntax tree with AST-like properties for Python 3.5, 3.6 and 3.7 programs.",
     long_description=long_description,
     long_description_content_type="text/x-rst",
-    version="0.2.3",
+    version="0.2.4",
     url="https://github.com/Instagram/LibCST",
     license="MIT",
     packages=setuptools.find_packages(),


### PR DESCRIPTION
## Summary

As it says on the tin! Types are fixed so its time to release again.

## Test Plan

tox