### PR TITLE
Implement an `extractall` function

### DIFF
--- a/docs/source/matchers.rst
+++ b/docs/source/matchers.rst
@@ -32,6 +32,7 @@ selectively control when LibCST calls visitor functions.
 .. autofunction:: libcst.matchers.matches
 .. autofunction:: libcst.matchers.findall
 .. autofunction:: libcst.matchers.extract
+.. autofunction:: libcst.matchers.extractall
 
 .. _libcst-matcher-decorators:
 

--- a/libcst/codegen/gen_matcher_classes.py
+++ b/libcst/codegen/gen_matcher_classes.py
@@ -482,7 +482,7 @@ generated_code.append("from typing_extensions import Literal")
 generated_code.append("import libcst as cst")
 generated_code.append("")
 generated_code.append(
-    "from libcst.matchers._matcher_base import BaseMatcherNode, DoNotCareSentinel, DoNotCare, OneOf, AllOf, DoesNotMatch, MatchIfTrue, MatchRegex, MatchMetadata, MatchMetadataIfTrue, ZeroOrMore, AtLeastN, ZeroOrOne, AtMostN, SaveMatchedNode, extract, findall, matches"
+    "from libcst.matchers._matcher_base import BaseMatcherNode, DoNotCareSentinel, DoNotCare, OneOf, AllOf, DoesNotMatch, MatchIfTrue, MatchRegex, MatchMetadata, MatchMetadataIfTrue, ZeroOrMore, AtLeastN, ZeroOrOne, AtMostN, SaveMatchedNode, extract, extractall, findall, matches"
 )
 all_exports.update(
     [
@@ -502,6 +502,7 @@ all_exports.update(
         "AtMostN",
         "SaveMatchedNode",
         "extract",
+        "extractall",
         "findall",
         "matches",
     ]

--- a/libcst/matchers/__init__.py
+++ b/libcst/matchers/__init__.py
@@ -31,6 +31,7 @@ from libcst.matchers._matcher_base import (
     ZeroOrMore,
     ZeroOrOne,
     extract,
+    extractall,
     findall,
     matches,
 )
@@ -13466,6 +13467,7 @@ __all__ = [
     "call_if_inside",
     "call_if_not_inside",
     "extract",
+    "extractall",
     "findall",
     "leave",
     "matches",

--- a/libcst/matchers/_visitors.py
+++ b/libcst/matchers/_visitors.py
@@ -36,9 +36,10 @@ from libcst.matchers._matcher_base import (
     BaseMatcherNode,
     MatchIfTrue,
     MatchMetadata,
+    MatchMetadataIfTrue,
     OneOf,
-    _InverseOf,
     extract,
+    extractall,
     findall,
     matches,
 )
@@ -565,9 +566,7 @@ class MatcherDecoratableTransformer(CSTTransformer):
             BaseMatcherNode,
             MatchIfTrue[Callable[..., bool]],
             MatchMetadata,
-            _InverseOf[
-                Union[BaseMatcherNode, MatchIfTrue[Callable[..., bool]], MatchMetadata]
-            ],
+            MatchMetadataIfTrue,
         ],
     ) -> Sequence[cst.CSTNode]:
         """
@@ -592,6 +591,25 @@ class MatcherDecoratableTransformer(CSTTransformer):
         function.
         """
         return extract(node, matcher, metadata_resolver=self)
+
+    def extractall(
+        self,
+        tree: Union[cst.MaybeSentinel, cst.RemovalSentinel, cst.CSTNode],
+        matcher: Union[
+            BaseMatcherNode,
+            MatchIfTrue[Callable[..., bool]],
+            MatchMetadata,
+            MatchMetadataIfTrue,
+        ],
+    ) -> Sequence[Dict[str, Union[cst.CSTNode, Sequence[cst.CSTNode]]]]:
+        """
+        A convenience method to call :func:`~libcst.matchers.extractall` without requiring
+        an explicit parameter for metadata. Since our instance is an instance of
+        :class:`libcst.MetadataDependent`, we work as a metadata resolver. Please see
+        documentation for :func:`~libcst.matchers.extractall` as it is identical to this
+        function.
+        """
+        return extractall(tree, matcher, metadata_resolver=self)
 
     def _transform_module_impl(self, tree: cst.Module) -> cst.Module:
         return tree.visit(self)
@@ -718,9 +736,7 @@ class MatcherDecoratableVisitor(CSTVisitor):
             BaseMatcherNode,
             MatchIfTrue[Callable[..., bool]],
             MatchMetadata,
-            _InverseOf[
-                Union[BaseMatcherNode, MatchIfTrue[Callable[..., bool]], MatchMetadata]
-            ],
+            MatchMetadataIfTrue,
         ],
     ) -> Sequence[cst.CSTNode]:
         """
@@ -745,3 +761,22 @@ class MatcherDecoratableVisitor(CSTVisitor):
         function.
         """
         return extract(node, matcher, metadata_resolver=self)
+
+    def extractall(
+        self,
+        tree: Union[cst.MaybeSentinel, cst.RemovalSentinel, cst.CSTNode],
+        matcher: Union[
+            BaseMatcherNode,
+            MatchIfTrue[Callable[..., bool]],
+            MatchMetadata,
+            MatchMetadataIfTrue,
+        ],
+    ) -> Sequence[Dict[str, Union[cst.CSTNode, Sequence[cst.CSTNode]]]]:
+        """
+        A convenience method to call :func:`~libcst.matchers.extractall` without requiring
+        an explicit parameter for metadata. Since our instance is an instance of
+        :class:`libcst.MetadataDependent`, we work as a metadata resolver. Please see
+        documentation for :func:`~libcst.matchers.extractall` as it is identical to this
+        function.
+        """
+        return extractall(tree, matcher, metadata_resolver=self)


### PR DESCRIPTION
## Summary

This is equivalent to calling `findall` on a node, and then calling `extract` with the same
matcher on each of the returned nodes from `findall`.

## Test Plan

tox, added tests. This is a refactor of `findall` so I expect most edge cases to be covered already. I only tested the basic cases as a result.