### PR TITLE
Deprecate "default_params" on Parameters

### DIFF
--- a/libcst/_nodes/tests/test_funcdef.py
+++ b/libcst/_nodes/tests/test_funcdef.py
@@ -88,7 +88,7 @@ class FunctionDefCreationTest(CSTNodeTest):
                 "node": cst.FunctionDef(
                     cst.Name("foo"),
                     cst.Parameters(
-                        default_params=(
+                        params=(
                             cst.Param(
                                 cst.Name("bar"), default=cst.SimpleString('"one"')
                             ),
@@ -104,7 +104,7 @@ class FunctionDefCreationTest(CSTNodeTest):
                 "node": cst.FunctionDef(
                     cst.Name("foo"),
                     cst.Parameters(
-                        default_params=(
+                        params=(
                             cst.Param(
                                 cst.Name("bar"),
                                 cst.Annotation(cst.Name("str")),
@@ -128,8 +128,6 @@ class FunctionDefCreationTest(CSTNodeTest):
                     cst.Parameters(
                         params=(
                             cst.Param(cst.Name("bar"), cst.Annotation(cst.Name("str"))),
-                        ),
-                        default_params=(
                             cst.Param(
                                 cst.Name("baz"),
                                 cst.Annotation(cst.Name("int")),
@@ -207,12 +205,12 @@ class FunctionDefCreationTest(CSTNodeTest):
                 ),
                 "code": 'def foo(first, second, *, bar: str = "one", baz: int, biz: str = "two"): pass\n',
             },
-            # Mixed default_params and kwonly_params
+            # Mixed params and kwonly_params
             {
                 "node": cst.FunctionDef(
                     cst.Name("foo"),
                     cst.Parameters(
-                        default_params=(
+                        params=(
                             cst.Param(cst.Name("first"), default=cst.Float("1.0")),
                             cst.Param(cst.Name("second"), default=cst.Float("1.5")),
                         ),
@@ -234,7 +232,7 @@ class FunctionDefCreationTest(CSTNodeTest):
                 ),
                 "code": 'def foo(first = 1.0, second = 1.5, *, bar: str = "one", baz: int, biz: str = "two"): pass\n',
             },
-            # Mixed params, default_params, and kwonly_params
+            # Mixed params and kwonly_params
             {
                 "node": cst.FunctionDef(
                     cst.Name("foo"),
@@ -242,8 +240,6 @@ class FunctionDefCreationTest(CSTNodeTest):
                         params=(
                             cst.Param(cst.Name("first")),
                             cst.Param(cst.Name("second")),
-                        ),
-                        default_params=(
                             cst.Param(cst.Name("third"), default=cst.Float("1.0")),
                             cst.Param(cst.Name("fourth"), default=cst.Float("1.5")),
                         ),
@@ -300,7 +296,7 @@ class FunctionDefCreationTest(CSTNodeTest):
                 ),
                 "code": 'def foo(*params: str, bar: str = "one", baz: int, biz: str = "two"): pass\n',
             },
-            # Mixed params default_params, star_arg and kwonly_params
+            # Mixed params star_arg and kwonly_params
             {
                 "node": cst.FunctionDef(
                     cst.Name("foo"),
@@ -308,8 +304,6 @@ class FunctionDefCreationTest(CSTNodeTest):
                         params=(
                             cst.Param(cst.Name("first")),
                             cst.Param(cst.Name("second")),
-                        ),
-                        default_params=(
                             cst.Param(cst.Name("third"), default=cst.Float("1.0")),
                             cst.Param(cst.Name("fourth"), default=cst.Float("1.5")),
                         ),
@@ -521,8 +515,6 @@ class FunctionDefCreationTest(CSTNodeTest):
                     params=(
                         cst.Param(cst.Name("first")),
                         cst.Param(cst.Name("second")),
-                    ),
-                    default_params=(
                         cst.Param(cst.Name("third"), default=cst.Float("1.0")),
                         cst.Param(cst.Name("fourth"), default=cst.Float("1.5")),
                     ),
@@ -621,19 +613,12 @@ class FunctionDefCreationTest(CSTNodeTest):
                             cst.Param(
                                 cst.Name("bar"), default=cst.SimpleString('"one"')
                             ),
+                            cst.Param(cst.Name("bar")),
                         )
                     ),
                     cst.SimpleStatementSuite((cst.Pass(),)),
                 ),
-                "Cannot have defaults for params",
-            ),
-            (
-                lambda: cst.FunctionDef(
-                    cst.Name("foo"),
-                    cst.Parameters(default_params=(cst.Param(cst.Name("bar")),)),
-                    cst.SimpleStatementSuite((cst.Pass(),)),
-                ),
-                "Must have defaults for default_params",
+                "Cannot have param without defaults following a param with defaults.",
             ),
             (
                 lambda: cst.FunctionDef(
@@ -655,7 +640,7 @@ class FunctionDefCreationTest(CSTNodeTest):
                 lambda: cst.FunctionDef(
                     cst.Name("foo"),
                     cst.Parameters(
-                        default_params=(
+                        params=(
                             cst.Param(
                                 cst.Name("bar"),
                                 default=cst.SimpleString('"one"'),
@@ -826,7 +811,7 @@ class FunctionDefParserTest(CSTNodeTest):
                 cst.FunctionDef(
                     cst.Name("foo"),
                     cst.Parameters(
-                        default_params=(
+                        params=(
                             cst.Param(
                                 cst.Name("bar"),
                                 equal=cst.AssignEqual(),
@@ -853,7 +838,7 @@ class FunctionDefParserTest(CSTNodeTest):
                 cst.FunctionDef(
                     cst.Name("foo"),
                     cst.Parameters(
-                        default_params=(
+                        params=(
                             cst.Param(
                                 cst.Name("bar"),
                                 cst.Annotation(
@@ -907,8 +892,6 @@ class FunctionDefParserTest(CSTNodeTest):
                                     whitespace_after=cst.SimpleWhitespace(" ")
                                 ),
                             ),
-                        ),
-                        default_params=(
                             cst.Param(
                                 cst.Name("baz"),
                                 cst.Annotation(
@@ -1078,12 +1061,12 @@ class FunctionDefParserTest(CSTNodeTest):
                 ),
                 'def foo(first, second, *, bar: str = "one", baz: int, biz: str = "two"): pass\n',
             ),
-            # Mixed default_params and kwonly_params
+            # Mixed params and kwonly_params
             (
                 cst.FunctionDef(
                     cst.Name("foo"),
                     cst.Parameters(
-                        default_params=(
+                        params=(
                             cst.Param(
                                 cst.Name("first"),
                                 annotation=None,
@@ -1154,7 +1137,7 @@ class FunctionDefParserTest(CSTNodeTest):
                 ),
                 'def foo(first = 1.0, second = 1.5, *, bar: str = "one", baz: int, biz: str = "two"): pass\n',
             ),
-            # Mixed params, default_params, and kwonly_params
+            # Mixed params, and kwonly_params
             (
                 cst.FunctionDef(
                     cst.Name("foo"),
@@ -1178,8 +1161,6 @@ class FunctionDefParserTest(CSTNodeTest):
                                     whitespace_after=cst.SimpleWhitespace(" ")
                                 ),
                             ),
-                        ),
-                        default_params=(
                             cst.Param(
                                 cst.Name("third"),
                                 annotation=None,
@@ -1326,7 +1307,7 @@ class FunctionDefParserTest(CSTNodeTest):
                 ),
                 'def foo(*params: str, bar: str = "one", baz: int, biz: str = "two"): pass\n',
             ),
-            # Mixed params default_params, star_arg and kwonly_params
+            # Mixed params star_arg and kwonly_params
             (
                 cst.FunctionDef(
                     cst.Name("foo"),
@@ -1350,8 +1331,6 @@ class FunctionDefParserTest(CSTNodeTest):
                                     whitespace_after=cst.SimpleWhitespace(" ")
                                 ),
                             ),
-                        ),
-                        default_params=(
                             cst.Param(
                                 cst.Name("third"),
                                 annotation=None,

--- a/libcst/_nodes/tests/test_lambda.py
+++ b/libcst/_nodes/tests/test_lambda.py
@@ -32,7 +32,7 @@ class LambdaCreationTest(CSTNodeTest):
             (
                 cst.Lambda(
                     cst.Parameters(
-                        default_params=(
+                        params=(
                             cst.Param(
                                 cst.Name("bar"), default=cst.SimpleString('"one"')
                             ),
@@ -47,8 +47,8 @@ class LambdaCreationTest(CSTNodeTest):
             (
                 cst.Lambda(
                     cst.Parameters(
-                        params=(cst.Param(cst.Name("bar")),),
-                        default_params=(
+                        params=(
+                            cst.Param(cst.Name("bar")),
                             cst.Param(cst.Name("baz"), default=cst.Integer("5")),
                         ),
                     ),
@@ -93,11 +93,11 @@ class LambdaCreationTest(CSTNodeTest):
                 ),
                 'lambda first, second, *, bar = "one", baz, biz = "two": 5',
             ),
-            # Mixed default_params and kwonly_params
+            # Mixed params and kwonly_params
             (
                 cst.Lambda(
                     cst.Parameters(
-                        default_params=(
+                        params=(
                             cst.Param(cst.Name("first"), default=cst.Float("1.0")),
                             cst.Param(cst.Name("second"), default=cst.Float("1.5")),
                         ),
@@ -115,15 +115,13 @@ class LambdaCreationTest(CSTNodeTest):
                 ),
                 'lambda first = 1.0, second = 1.5, *, bar = "one", baz, biz = "two": 5',
             ),
-            # Mixed params, default_params, and kwonly_params
+            # Mixed params and kwonly_params
             (
                 cst.Lambda(
                     cst.Parameters(
                         params=(
                             cst.Param(cst.Name("first")),
                             cst.Param(cst.Name("second")),
-                        ),
-                        default_params=(
                             cst.Param(cst.Name("third"), default=cst.Float("1.0")),
                             cst.Param(cst.Name("fourth"), default=cst.Float("1.5")),
                         ),
@@ -169,15 +167,13 @@ class LambdaCreationTest(CSTNodeTest):
                 ),
                 'lambda *params, bar = "one", baz, biz = "two": 5',
             ),
-            # Mixed params default_params, star_arg and kwonly_params
+            # Mixed params, star_arg and kwonly_params
             (
                 cst.Lambda(
                     cst.Parameters(
                         params=(
                             cst.Param(cst.Name("first")),
                             cst.Param(cst.Name("second")),
-                        ),
-                        default_params=(
                             cst.Param(cst.Name("third"), default=cst.Float("1.0")),
                             cst.Param(cst.Name("fourth"), default=cst.Float("1.5")),
                         ),
@@ -264,9 +260,7 @@ class LambdaCreationTest(CSTNodeTest):
             (
                 lambda: cst.Lambda(
                     cst.Parameters(
-                        default_params=(
-                            cst.Param(cst.Name("arg"), default=cst.Integer("5")),
-                        )
+                        params=(cst.Param(cst.Name("arg"), default=cst.Integer("5")),)
                     ),
                     cst.Integer("5"),
                     whitespace_after_lambda=cst.SimpleWhitespace(""),
@@ -320,18 +314,12 @@ class LambdaCreationTest(CSTNodeTest):
                             cst.Param(
                                 cst.Name("bar"), default=cst.SimpleString('"one"')
                             ),
+                            cst.Param(cst.Name("bar")),
                         )
                     ),
                     cst.Integer("5"),
                 ),
-                "Cannot have defaults for params",
-            ),
-            (
-                lambda: cst.Lambda(
-                    cst.Parameters(default_params=(cst.Param(cst.Name("bar")),)),
-                    cst.Integer("5"),
-                ),
-                "Must have defaults for default_params",
+                "Cannot have param without defaults following a param with defaults.",
             ),
             (
                 lambda: cst.Lambda(
@@ -349,7 +337,7 @@ class LambdaCreationTest(CSTNodeTest):
             (
                 lambda: cst.Lambda(
                     cst.Parameters(
-                        default_params=(
+                        params=(
                             cst.Param(
                                 cst.Name("bar"),
                                 default=cst.SimpleString('"one"'),
@@ -402,7 +390,7 @@ class LambdaCreationTest(CSTNodeTest):
             (
                 lambda: cst.Lambda(
                     cst.Parameters(
-                        default_params=(
+                        params=(
                             cst.Param(
                                 cst.Name("arg"),
                                 default=cst.Integer("5"),
@@ -491,7 +479,7 @@ class LambdaParserTest(CSTNodeTest):
             (
                 cst.Lambda(
                     cst.Parameters(
-                        default_params=(
+                        params=(
                             cst.Param(
                                 cst.Name("bar"),
                                 default=cst.SimpleString('"one"'),
@@ -526,8 +514,6 @@ class LambdaParserTest(CSTNodeTest):
                                     whitespace_after=cst.SimpleWhitespace(" ")
                                 ),
                             ),
-                        ),
-                        default_params=(
                             cst.Param(
                                 cst.Name("baz"),
                                 default=cst.Integer("5"),
@@ -615,11 +601,11 @@ class LambdaParserTest(CSTNodeTest):
                 ),
                 'lambda first, second, *, bar = "one", baz, biz = "two": 5',
             ),
-            # Mixed default_params and kwonly_params
+            # Mixed params and kwonly_params
             (
                 cst.Lambda(
                     cst.Parameters(
-                        default_params=(
+                        params=(
                             cst.Param(
                                 cst.Name("first"),
                                 default=cst.Float("1.0"),
@@ -670,7 +656,7 @@ class LambdaParserTest(CSTNodeTest):
                 ),
                 'lambda first = 1.0, second = 1.5, *, bar = "one", baz, biz = "two": 5',
             ),
-            # Mixed params, default_params, and kwonly_params
+            # Mixed params and kwonly_params
             (
                 cst.Lambda(
                     cst.Parameters(
@@ -689,8 +675,6 @@ class LambdaParserTest(CSTNodeTest):
                                     whitespace_after=cst.SimpleWhitespace(" ")
                                 ),
                             ),
-                        ),
-                        default_params=(
                             cst.Param(
                                 cst.Name("third"),
                                 default=cst.Float("1.0"),
@@ -789,7 +773,7 @@ class LambdaParserTest(CSTNodeTest):
                 ),
                 'lambda *params, bar = "one", baz, biz = "two": 5',
             ),
-            # Mixed params default_params, star_arg and kwonly_params
+            # Mixed params, star_arg and kwonly_params
             (
                 cst.Lambda(
                     cst.Parameters(
@@ -808,8 +792,6 @@ class LambdaParserTest(CSTNodeTest):
                                     whitespace_after=cst.SimpleWhitespace(" ")
                                 ),
                             ),
-                        ),
-                        default_params=(
                             cst.Param(
                                 cst.Name("third"),
                                 default=cst.Float("1.0"),

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -471,7 +471,7 @@ class ScopeProviderTest(UnitTest):
         self.assertIsInstance(scope_of_f, FunctionScope)
 
         decorator = f.decorators[0]
-        x = f.params.default_params[0]
+        x = f.params.params[0]
         xT = ensure_type(x.annotation, cst.Annotation)
         one = ensure_type(x.default, cst.BaseExpression)
         vararg = ensure_type(f.params.star_arg, cst.Param)
@@ -529,7 +529,7 @@ class ScopeProviderTest(UnitTest):
         scope_of_f = scopes[f.body]
         self.assertIsInstance(scope_of_f, FunctionScope)
 
-        x = f.params.default_params[0]
+        x = f.params.params[0]
         one = ensure_type(x.default, cst.BaseExpression)
         vararg = ensure_type(f.params.star_arg, cst.Param)
         y = f.params.kwonly_params[0]


### PR DESCRIPTION
## Summary

Deprecate "default_params". All uses of this outside of the this repo inside Instagram just combine "params" and "default_params" which says that the distinction was not necessary. This also stops us from supporting `/` for positional only parameters in 3.8. This diff deprecates this by allowing "default_params" in construction, but never parses to them. Given that complete removal of "default_params" is a breaking change, we must wait until at least 0.3.0 to remove it and add support for `/`. At that point, we can bump 3.8 support to official.

This is necessary but not sufficient for #122 

## Test Plan

Updated existing tests, pyre.