### PR TITLE
Fix mark_no_op decorator type preservation on mypy

### DIFF
--- a/libcst/_typed_visitor_base.py
+++ b/libcst/_typed_visitor_base.py
@@ -10,8 +10,7 @@ from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
 if TYPE_CHECKING:
     from libcst._typed_visitor import CSTTypedBaseFunctions  # noqa: F401
 
-T = TypeVar("T")
-FuncType = Callable[["CSTTypedBaseFunctions", T], None]
+FuncType = Callable[["CSTTypedBaseFunctions", Any], None]
 F = TypeVar("F", bound=FuncType)
 
 

--- a/libcst/_typed_visitor_base.py
+++ b/libcst/_typed_visitor_base.py
@@ -10,8 +10,7 @@ from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
 if TYPE_CHECKING:
     from libcst._typed_visitor import CSTTypedBaseFunctions  # noqa: F401
 
-FuncType = Callable
-F = TypeVar("F", bound=FuncType)
+F = TypeVar("F", bound=Callable)
 
 
 def mark_no_op(f: F) -> F:

--- a/libcst/_typed_visitor_base.py
+++ b/libcst/_typed_visitor_base.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
 if TYPE_CHECKING:
     from libcst._typed_visitor import CSTTypedBaseFunctions  # noqa: F401
 
-FuncType = Callable[["CSTTypedBaseFunctions", Any], None]
+FuncType = Callable[["CSTTypedBaseFunctions", ...], None]
 F = TypeVar("F", bound=FuncType)
 
 

--- a/libcst/_typed_visitor_base.py
+++ b/libcst/_typed_visitor_base.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
 if TYPE_CHECKING:
     from libcst._typed_visitor import CSTTypedBaseFunctions  # noqa: F401
 
-FuncType = Callable[["CSTTypedBaseFunctions", ...], None]
+FuncType = Callable
 F = TypeVar("F", bound=FuncType)
 
 

--- a/libcst/_typed_visitor_base.py
+++ b/libcst/_typed_visitor_base.py
@@ -11,11 +11,11 @@ if TYPE_CHECKING:
     from libcst._typed_visitor import CSTTypedBaseFunctions  # noqa: F401
 
 T = TypeVar("T")
+FuncType = Callable[["CSTTypedBaseFunctions", T], None]
+F = TypeVar("F", bound=FuncType)
 
 
-def mark_no_op(
-    f: Callable[["CSTTypedBaseFunctions", T], None]
-) -> Callable[["CSTTypedBaseFunctions", T], None]:
+def mark_no_op(f: F) -> F:
     """
     Annotates stubs with a field to indicate they should not be collected
     by BatchableCSTVisitor.get_visitors() to reduce function call

--- a/libcst/matchers/tests/test_decorators.py
+++ b/libcst/matchers/tests/test_decorators.py
@@ -113,8 +113,8 @@ class MatchersGatingDecoratorsTest(UnitTest):
                 self.visits.append(node.value)
 
             @call_if_inside(m.FunctionDef())
-            def leave_SimpleString(self, node: cst.SimpleString) -> None:
-                self.leaves.append(node.value)
+            def leave_SimpleString(self, original_node: cst.SimpleString) -> None:
+                self.leaves.append(original_node.value)
 
         # Parse a module and verify we visited correctly.
         module = fixture(
@@ -316,8 +316,8 @@ class MatchersGatingDecoratorsTest(UnitTest):
                 self.visits.append(node.value)
 
             @call_if_not_inside(m.FunctionDef())
-            def leave_SimpleString(self, node: cst.SimpleString) -> None:
-                self.leaves.append(node.value)
+            def leave_SimpleString(self, original_node: cst.SimpleString) -> None:
+                self.leaves.append(original_node.value)
 
         # Parse a module and verify we visited correctly.
         module = fixture(
@@ -832,8 +832,8 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
                 self.visits.append(node.value)
 
             @call_if_inside(m.FunctionDef())
-            def leave_SimpleString_lpar(self, original_node: cst.SimpleString) -> None:
-                self.leaves.append(original_node.value)
+            def leave_SimpleString_lpar(self, node: cst.SimpleString) -> None:
+                self.leaves.append(node.value)
 
         # Parse a module and verify we visited correctly.
         module = fixture(
@@ -868,8 +868,8 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
                 self.visits.append(node.value)
 
             @call_if_inside(m.FunctionDef())
-            def leave_SimpleString_lpar(self, original_node: cst.SimpleString) -> None:
-                self.leaves.append(original_node.value)
+            def leave_SimpleString_lpar(self, node: cst.SimpleString) -> None:
+                self.leaves.append(node.value)
 
         # Parse a module and verify we visited correctly.
         module = fixture(
@@ -904,8 +904,8 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
                 self.visits.append(node.value)
 
             @call_if_not_inside(m.FunctionDef())
-            def leave_SimpleString_lpar(self, original_node: cst.SimpleString) -> None:
-                self.leaves.append(original_node.value)
+            def leave_SimpleString_lpar(self, node: cst.SimpleString) -> None:
+                self.leaves.append(node.value)
 
         # Parse a module and verify we visited correctly.
         module = fixture(
@@ -940,8 +940,8 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
                 self.visits.append(node.value)
 
             @call_if_not_inside(m.FunctionDef())
-            def leave_SimpleString_lpar(self, original_node: cst.SimpleString) -> None:
-                self.leaves.append(original_node.value)
+            def leave_SimpleString_lpar(self, node: cst.SimpleString) -> None:
+                self.leaves.append(node.value)
 
         # Parse a module and verify we visited correctly.
         module = fixture(

--- a/libcst/tests/test_batched_visitor.py
+++ b/libcst/tests/test_batched_visitor.py
@@ -49,9 +49,9 @@ class BatchedVisitorTest(UnitTest):
                 mock.visit_Pass_semicolon()
                 object.__setattr__(node, "visit_Pass_semicolon", True)
 
-            def leave_Pass_semicolon(self, original_node: cst.Pass) -> None:
+            def leave_Pass_semicolon(self, node: cst.Pass) -> None:
                 mock.leave_Pass_semicolon()
-                object.__setattr__(original_node, "leave_Pass_semicolon", True)
+                object.__setattr__(node, "leave_Pass_semicolon", True)
 
             def leave_Pass(self, original_node: cst.Pass) -> None:
                 mock.leave_Pass()

--- a/libcst/tests/test_deprecate_extslice.py
+++ b/libcst/tests/test_deprecate_extslice.py
@@ -107,11 +107,11 @@ class ExtSliceDeprecatedUseTest(UnitTest):
                     ).value
                 )
 
-            def leave_ExtSlice_slice(self, original_node: cst.ExtSlice) -> None:
+            def leave_ExtSlice_slice(self, node: cst.ExtSlice) -> None:
                 self.leaves.add(
                     "attr "
                     + cst.ensure_type(
-                        cst.ensure_type(original_node.slice, cst.Index).value,
+                        cst.ensure_type(node.slice, cst.Index).value,
                         cst.Integer,
                     ).value
                 )

--- a/libcst/tests/test_deprecate_extslice.py
+++ b/libcst/tests/test_deprecate_extslice.py
@@ -111,8 +111,7 @@ class ExtSliceDeprecatedUseTest(UnitTest):
                 self.leaves.add(
                     "attr "
                     + cst.ensure_type(
-                        cst.ensure_type(node.slice, cst.Index).value,
-                        cst.Integer,
+                        cst.ensure_type(node.slice, cst.Index).value, cst.Integer
                     ).value
                 )
 

--- a/libcst/tests/test_visitor.py
+++ b/libcst/tests/test_visitor.py
@@ -20,7 +20,7 @@ class VisitorTest(UnitTest):
             def visit_If(self, node: cst.If) -> None:
                 self.visit_order.append("visit_If")
 
-            def leave_If(self, node: cst.If) -> None:
+            def leave_If(self, original_node: cst.If) -> None:
                 self.visit_order.append("leave_If")
 
             def visit_If_test(self, node: cst.If) -> None:
@@ -32,7 +32,7 @@ class VisitorTest(UnitTest):
             def visit_Name(self, node: cst.Name) -> None:
                 self.visit_order.append("visit_Name")
 
-            def leave_Name(self, node: cst.Name) -> None:
+            def leave_Name(self, original_node: cst.Name) -> None:
                 self.visit_order.append("leave_Name")
 
         # Create and visit a simple module.
@@ -68,7 +68,7 @@ class VisitorTest(UnitTest):
             def visit_If_test(self, node: cst.If) -> None:
                 self.visit_order.append("visit_If_test")
 
-            def leave_If_test(self, updated_node: cst.If) -> None:
+            def leave_If_test(self, node: cst.If) -> None:
                 self.visit_order.append("leave_If_test")
 
             def visit_Name(self, node: cst.Name) -> None:


### PR DESCRIPTION
## Summary
fix #161 by following decorator type preservation example code in mypy docs: https://mypy.readthedocs.io/en/latest/generics.html#declaring-decorators

## Test Plan
will consult with libcst folks on type tests

