### PR TITLE
Bump LibCST to 0.2.5.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 0.2.5 - 2018-12-05
+
+## Added
+
+ - Added `extract`, `extractall` and `replace` functions to Matchers API.
+
+## Fixed
+
+ - Fixed length restrictions for `AllOf` and `OneOf` so that they can be used with sequence expansion operators.
+ - Fixed batchable visitors not calling attribute visit functions.
+ - Fixed typos in docstrings.
+ - Fixed matcher type exception not being pickleable.
+
+## Deprecated
+
+ - Deprecated parsing function parameters with defaults into `default_params` attribute. They can be found in the `params` attribute instead.
+
 # 0.2.4 - 2019-11-13
 
 ## Fixed

--- a/README.rst
+++ b/README.rst
@@ -183,7 +183,6 @@ Future
 ======
 
 - Python 3.8 support, both in running on Python 3.8 and parsing 3.8 code.
-- Addition to Matchers API which allows for operations such as extract/find/replaceall, similar to the RE module.
 - Additional layer providing command-line frontend for executing refactors.
 - More metadata providers from deep static analysis including variable type annotation, etc.
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     description="A concrete syntax tree with AST-like properties for Python 3.5, 3.6 and 3.7 programs.",
     long_description=long_description,
     long_description_content_type="text/x-rst",
-    version="0.2.4",
+    version="0.2.5",
     url="https://github.com/Instagram/LibCST",
     license="MIT",
     packages=setuptools.find_packages(),


### PR DESCRIPTION
## Summary

As it says on the tin. We have a lot of bugfixes to get out.

## Test Plan

tox, pyre