### PR TITLE
Codemod Utilities and Example Codemods

### DIFF
--- a/libcst/codemod/__init__.py
+++ b/libcst/codemod/__init__.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 from libcst.codemod._cli import (
     ParallelTransformResult,

--- a/libcst/codemod/__init__.py
+++ b/libcst/codemod/__init__.py
@@ -1,3 +1,4 @@
+# pyre-strict
 from libcst.codemod._cli import (
     ParallelTransformResult,
     diff_code,

--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 """
 Provides helpers for CLI interaction.

--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -1,3 +1,4 @@
+# pyre-strict
 """
 Provides helpers for CLI interaction.
 """

--- a/libcst/codemod/_codemod.py
+++ b/libcst/codemod/_codemod.py
@@ -1,3 +1,4 @@
+# pyre-strict
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from dataclasses import replace

--- a/libcst/codemod/_codemod.py
+++ b/libcst/codemod/_codemod.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 from abc import ABC, abstractmethod
 from contextlib import contextmanager

--- a/libcst/codemod/_command.py
+++ b/libcst/codemod/_command.py
@@ -1,7 +1,8 @@
+# pyre-strict
 import argparse
 import inspect
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Generator, List, Type, TypeVar
+from typing import Dict, Generator, List, Type, TypeVar
 
 from libcst import Module
 from libcst.codemod._codemod import Codemod
@@ -95,7 +96,7 @@ class MagicArgsCodemodCommand(CodemodCommand, ABC):
     transforms.
     """
 
-    def __init__(self, context: CodemodContext, **kwargs: Dict[str, Any]) -> None:
+    def __init__(self, context: CodemodContext, **kwargs: Dict[str, object]) -> None:
         super().__init__(context)
         self.context.scratch.update(kwargs)
 
@@ -106,8 +107,8 @@ class MagicArgsCodemodCommand(CodemodCommand, ABC):
     def _instantiate(self, transform: Type[Codemod]) -> Codemod:
         # Grab the expected arguments
         argspec = inspect.getfullargspec(transform.__init__)
-        args: List[Any] = []
-        kwargs: Dict[str, Any] = {}
+        args: List[object] = []
+        kwargs: Dict[str, object] = {}
         # pyre-fixme[6]: Expected `Sized` for 1st param but got `Union[Tuple[],
         #  Tuple[Any, ...]]`.
         last_default_arg = len(argspec.args) - len(argspec.defaults or ())

--- a/libcst/codemod/_command.py
+++ b/libcst/codemod/_command.py
@@ -27,6 +27,10 @@ class CodemodCommand(Codemod, ABC):
 
     """
 
+    # An overrideable description attribute so that codemods can provide
+    # a short summary of what they do.
+    DESCRIPTION: str = "No description."
+
     @staticmethod
     def add_args(arg_parser: argparse.ArgumentParser) -> None:
         """

--- a/libcst/codemod/_command.py
+++ b/libcst/codemod/_command.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 import argparse
 import inspect

--- a/libcst/codemod/_context.py
+++ b/libcst/codemod/_context.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional

--- a/libcst/codemod/_context.py
+++ b/libcst/codemod/_context.py
@@ -1,3 +1,4 @@
+# pyre-strict
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 

--- a/libcst/codemod/_runner.py
+++ b/libcst/codemod/_runner.py
@@ -1,4 +1,10 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
+
 """
 Provides everything needed to run a CodemodCommand.
 """

--- a/libcst/codemod/_runner.py
+++ b/libcst/codemod/_runner.py
@@ -1,3 +1,4 @@
+# pyre-strict
 """
 Provides everything needed to run a CodemodCommand.
 """

--- a/libcst/codemod/_testing.py
+++ b/libcst/codemod/_testing.py
@@ -1,3 +1,4 @@
+# pyre-strict
 from textwrap import dedent
 from typing import Optional, Sequence, Type
 

--- a/libcst/codemod/_testing.py
+++ b/libcst/codemod/_testing.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 from textwrap import dedent
 from typing import Optional, Sequence, Type

--- a/libcst/codemod/_visitor.py
+++ b/libcst/codemod/_visitor.py
@@ -1,8 +1,12 @@
+# pyre-strict
+from typing import Mapping
+
 import libcst as cst
 from libcst import MetadataDependent
 from libcst.codemod._codemod import Codemod
 from libcst.codemod._context import CodemodContext
 from libcst.matchers import MatcherDecoratableTransformer, MatcherDecoratableVisitor
+from libcst.metadata import ProviderT
 
 
 class ContextAwareTransformer(Codemod, MatcherDecoratableTransformer):
@@ -52,7 +56,9 @@ class ContextAwareVisitor(MatcherDecoratableVisitor, MetadataDependent):
                         + f"parent transforms of {self.__class__.__name__} declare "
                         + f"{dep.__name__} as a metadata dependency."
                     )
-            self.metadata = {dep: wrapper._metadata[dep] for dep in dependencies}
+            self.metadata: Mapping[ProviderT, Mapping[cst.CSTNode, object]] = {
+                dep: wrapper._metadata[dep] for dep in dependencies
+            }
 
     @property
     def module(self) -> cst.Module:

--- a/libcst/codemod/_visitor.py
+++ b/libcst/codemod/_visitor.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 from typing import Mapping
 

--- a/libcst/codemod/commands/__init__.py
+++ b/libcst/codemod/commands/__init__.py
@@ -1,0 +1,1 @@
+# pyre-strict

--- a/libcst/codemod/commands/__init__.py
+++ b/libcst/codemod/commands/__init__.py
@@ -1,1 +1,6 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict

--- a/libcst/codemod/commands/add_pyre_directive.py
+++ b/libcst/codemod/commands/add_pyre_directive.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 import re
 from abc import ABC

--- a/libcst/codemod/commands/add_pyre_directive.py
+++ b/libcst/codemod/commands/add_pyre_directive.py
@@ -1,0 +1,53 @@
+import re
+from abc import ABC
+from typing import Pattern
+
+import libcst
+from libcst.codemod import CodemodContext, VisitorBasedCodemodCommand
+from libcst.helpers.module import insert_header_comments
+
+
+class AddPyreDirectiveCommand(VisitorBasedCodemodCommand, ABC):
+    PYRE_TAG: str
+
+    def __init__(self, context: CodemodContext) -> None:
+        super().__init__(context)
+        self._regex_pattern: Pattern[str] = re.compile(
+            rf"^#\s+pyre-{self.PYRE_TAG}\s*$"
+        )
+        self.needs_add = True
+
+    def visit_Comment(self, node: libcst.Comment) -> None:
+        if self._regex_pattern.search(node.value):
+            self.needs_add = False
+
+    def leave_Module(
+        self, original_node: libcst.Module, updated_node: libcst.Module
+    ) -> libcst.Module:
+        # If the tag already exists, don't modify the file.
+        if not self.needs_add:
+            return updated_node
+
+        return insert_header_comments(updated_node, [f"# pyre-{self.PYRE_TAG}"])
+
+
+class AddPyreStrictCommand(AddPyreDirectiveCommand):
+    """
+    Given a source file, we'll add the strict tag if the file doesn't already
+    contain it.
+    """
+
+    PYRE_TAG: str = "strict"
+
+    DESCRIPTION: str = "Add the 'pyre-strict' tag to a module."
+
+
+class AddPyreUnsafeCommand(AddPyreDirectiveCommand):
+    """
+    Given a source file, we'll add the unsafe tag if the file doesn't already
+    contain it.
+    """
+
+    PYRE_TAG: str = "unsafe"
+
+    DESCRIPTION: str = "Add the 'pyre-unsafe' tag to a module."

--- a/libcst/codemod/commands/add_pyre_directive.py
+++ b/libcst/codemod/commands/add_pyre_directive.py
@@ -1,3 +1,4 @@
+# pyre-strict
 import re
 from abc import ABC
 from typing import Pattern

--- a/libcst/codemod/commands/convert_format_to_fstring.py
+++ b/libcst/codemod/commands/convert_format_to_fstring.py
@@ -1,0 +1,367 @@
+import ast
+from typing import Generator, List, Optional, Sequence, Set, Tuple
+
+import libcst as cst
+import libcst.matchers as m
+from libcst.codemod import (
+    CodemodContext,
+    ContextAwareTransformer,
+    ContextAwareVisitor,
+    VisitorBasedCodemodCommand,
+)
+
+
+def _get_lhs(field: cst.BaseExpression) -> cst.BaseExpression:
+    if isinstance(field, (cst.Name, cst.Integer)):
+        return field
+    elif isinstance(field, (cst.Attribute, cst.Subscript)):
+        return _get_lhs(field.value)
+    else:
+        raise Exception("Unsupported node type!")
+
+
+def _find_expr_from_field_name(
+    fieldname: str, args: Sequence[cst.Arg]
+) -> Optional[cst.BaseExpression]:
+    # Things like "0.name" are invalid expressions in python since
+    # we can't tell if name is supposed to be the fraction or a name.
+    # So we do a trick to parse here where we wrap the LHS in parens
+    # and assume LibCST will handle it.
+    if "." in fieldname:
+        ind, exp = fieldname.split(".", 1)
+        fieldname = f"({ind}).{exp}"
+    field_expr = cst.parse_expression(fieldname)
+    lhs = _get_lhs(field_expr)
+
+    # Verify we don't have any *args or **kwargs attributes.
+    if any(arg.star != "" for arg in args):
+        return None
+
+    # Get the index into the arg
+    index: Optional[int] = None
+    if isinstance(lhs, cst.Integer):
+        index = int(lhs.value)
+        if index < 0 or index >= len(args):
+            raise Exception(f"Logic error, arg sequence {index} out of bounds!")
+    elif isinstance(lhs, cst.Name):
+        for i, arg in enumerate(args):
+            kw = arg.keyword
+            if kw is None:
+                continue
+            if kw.value == lhs.value:
+                index = i
+                break
+        if index is None:
+            raise Exception(f"Logic error, arg name {lhs.value} out of bounds!")
+
+    if index is None:
+        raise Exception(f"Logic error, unsupported fieldname expression {fieldname}!")
+
+    # Format it!
+    return field_expr.deep_replace(lhs, args[index].value)
+
+
+def _string_prefix_and_quotes(string: str) -> Tuple[str, str, str]:
+    prefix: str = ""
+    quote: str = ""
+    pos: int = 0
+
+    for i in range(0, len(string)):
+        if string[i] in {"'", '"'}:
+            pos = i
+            break
+        prefix += string[i]
+
+    for i in range(pos, len(string)):
+        if string[i] not in {"'", '"'}:
+            break
+        if quote and string[i] != quote[0]:
+            # This is no longer the same string quote
+            break
+        quote += string[i]
+
+    if len(quote) == 2:
+        # Lets assume this is an empty string.
+        quote = quote[:1]
+    elif len(quote) == 6:
+        # Lets assume this is an empty string.
+        quote = quote[:3]
+    if len(quote) not in {1, 3}:
+        raise Exception(f"Invalid string {string}")
+
+    innards = string[(len(prefix) + len(quote)) : (-len(quote))]
+
+    return prefix, quote, innards
+
+
+def _get_field(formatstr: str) -> Tuple[str, Optional[str], Optional[str]]:
+    in_index: int = 0
+    format_spec: Optional[str] = None
+    conversion: Optional[str] = None
+
+    # Grab any format spec as long as its not an array slice
+    for pos, char in enumerate(formatstr):
+        if char == "[":
+            in_index += 1
+        elif char == "]":
+            in_index -= 1
+        elif char == ":":
+            if in_index == 0:
+                formatstr, format_spec = (formatstr[:pos], formatstr[pos + 1 :])
+                break
+
+    # Grab any conversion
+    if "!" in formatstr:
+        formatstr, conversion = formatstr.split("!", 1)
+
+    # Return it
+    return formatstr, format_spec, conversion
+
+
+def _get_tokens(  # noqa: C901
+    string: str,
+) -> Generator[Tuple[str, Optional[str], Optional[str], Optional[str]], None, None]:
+    length = len(string)
+    prefix: str = ""
+    format_accum: str = ""
+    in_brackets: int = 0
+    seen_escape: bool = False
+
+    for pos, char in enumerate(string):
+        if seen_escape:
+            # The last character was an escape character, so consume
+            # this one as well, and then pop out of the escape.
+            if in_brackets == 0:
+                prefix += char
+            else:
+                format_accum += char
+            seen_escape = False
+            continue
+
+        # We can't escape inside a f-string/format specifier.
+        if in_brackets == 0:
+            # Grab the next character to see if we are an escape sequence.
+            next_char: Optional[str] = None
+            if pos < length - 1:
+                next_char = string[pos + 1]
+
+            # If this current character is an escape, we want to
+            # not react to it, append it to the current accumulator and
+            # then do the same for the next character.
+            if char == "{" and next_char == "{":
+                seen_escape = True
+            if char == "}" and next_char == "}":
+                seen_escape = True
+
+        # Only if we are not an escape sequence do we consider these
+        # brackets.
+        if not seen_escape:
+            if char == "{":
+                in_brackets += 1
+
+                # We want to add brackets to the format accumulator as
+                # long as they aren't the outermost, because format
+                # specs allow {} expansion.
+                if in_brackets == 1:
+                    continue
+            if char == "}":
+                in_brackets -= 1
+
+                if in_brackets < 0:
+                    raise Exception("Stray } in format string!")
+
+                if in_brackets == 0:
+                    field_name, format_spec, conversion = _get_field(format_accum)
+                    yield (prefix, field_name, format_spec, conversion)
+
+                    prefix = ""
+                    format_accum = ""
+                    continue
+
+        # Place in the correct accumulator
+        if in_brackets == 0:
+            prefix += char
+        else:
+            format_accum += char
+
+    if in_brackets > 0:
+        raise Exception("Stray { in format string!")
+    if format_accum:
+        raise Exception("Logic error!")
+
+    # Yield the last bit of information
+    yield (prefix, None, None, None)
+
+
+class StringQuoteGatherer(ContextAwareVisitor):
+    def __init__(self, context: CodemodContext) -> None:
+        super().__init__(context)
+        self.stringends: Set[str] = set()
+
+    def visit_SimpleString(self, node: cst.SimpleString) -> None:
+        self.stringends.add(node.value[-1])
+
+
+class StripNewlinesTransformer(ContextAwareTransformer):
+    def leave_ParenthesizedWhitespace(
+        self,
+        original_node: cst.ParenthesizedWhitespace,
+        updated_node: cst.ParenthesizedWhitespace,
+    ) -> cst.SimpleWhitespace:
+        return cst.SimpleWhitespace(" ")
+
+
+class SwitchStringQuotesTransformer(ContextAwareTransformer):
+    def __init__(self, context: CodemodContext, avoid_quote: str) -> None:
+        super().__init__(context)
+        if avoid_quote not in {'"', "'"}:
+            raise Exception("Must specify either ' or \" single quote to avoid.")
+        self.avoid_quote: str = avoid_quote
+        self.replace_quote: str = '"' if avoid_quote == "'" else "'"
+
+    def leave_SimpleString(
+        self, original_node: cst.SimpleString, updated_node: cst.SimpleString
+    ) -> cst.SimpleString:
+        prefix, quote, innards = _string_prefix_and_quotes(updated_node.value)
+        if self.avoid_quote in quote:
+            # Attempt to swap the value out, verify that the string is still identical
+            # before and after transformation.
+            new_quote = quote.replace(self.avoid_quote, self.replace_quote)
+            new_value = f"{prefix}{new_quote}{innards}{new_quote}"
+
+            try:
+                old_str = ast.literal_eval(updated_node.value)
+                new_str = ast.literal_eval(new_value)
+
+                if old_str != new_str:
+                    # This isn't the same!
+                    return updated_node
+
+                return updated_node.with_changes(value=new_value)
+            except Exception:
+                # Failed to parse string, changing the quoting screwed us up.
+                pass
+
+        # Either failed to parse the new string, or don't need to make changes.
+        return updated_node
+
+
+class ConvertFormatStringCommand(VisitorBasedCodemodCommand):
+
+    DESCRIPTION: str = "Converts instances of str.format() to f-string."
+
+    def leave_Call(  # noqa: C901
+        self, original_node: cst.Call, updated_node: cst.Call
+    ) -> cst.BaseExpression:
+        # Lets figure out if this is a "".format() call
+        if self.matches(
+            updated_node,
+            m.Call(func=m.Attribute(value=m.SimpleString(), attr=m.Name("format"))),
+        ):
+            fstring: List[cst.BaseFormattedStringContent] = []
+            inserted_sequence: int = 0
+
+            # TODO: Use `extract` when it becomes available.
+            stringvalue = cst.ensure_type(
+                cst.ensure_type(updated_node.func, cst.Attribute).value,
+                cst.SimpleString,
+            ).value
+            prefix, quote, innards = _string_prefix_and_quotes(stringvalue)
+            tokens = _get_tokens(innards)
+            for (literal_text, field_name, format_spec, conversion) in tokens:
+                if literal_text:
+                    fstring.append(cst.FormattedStringText(literal_text))
+                if field_name is None:
+                    # This is not a format-specification
+                    continue
+                if format_spec is not None and len(format_spec) > 0:
+                    # TODO: This is supportable since format specs are compatible
+                    # with f-string format specs, but it would require matching
+                    # format specifier expansions.
+                    self.warn(f"Unsupported format_spec {format_spec} in format() call")
+                    return updated_node
+
+                # Auto-insert field sequence if it is empty
+                if field_name == "":
+                    field_name = str(inserted_sequence)
+                    inserted_sequence += 1
+                expr = _find_expr_from_field_name(field_name, updated_node.args)
+                if expr is None:
+                    # Most likely they used * expansion in a format.
+                    self.warn(f"Unsupported field_name {field_name} in format() call")
+                    return updated_node
+
+                # Verify that we don't have any comments or newlines. Comments aren't
+                # allowed in f-strings, and newlines need parenthesization. We can
+                # have formattedstrings inside other formattedstrings, but I chose not
+                # to doeal with that for now.
+                if self.findall(expr, m.Comment()):
+                    # We could strip comments, but this is a formatting change so
+                    # we choose not to for now.
+                    self.warn(f"Unsupported comment in format() call")
+                    return updated_node
+                if self.findall(expr, m.FormattedString()):
+                    self.warn(f"Unsupported f-string in format() call")
+                    return updated_node
+                if self.findall(expr, m.Await()):
+                    # This is fixed in 3.7 but we don't currently have a flag
+                    # to enable/disable it.
+                    self.warn(f"Unsupported await in format() call")
+                    return updated_node
+
+                # Stripping newlines is effectively a format-only change.
+                expr = cst.ensure_type(
+                    expr.visit(StripNewlinesTransformer(self.context)),
+                    cst.BaseExpression,
+                )
+
+                # Try our best to swap quotes on any strings that won't fit
+                expr = cst.ensure_type(
+                    expr.visit(SwitchStringQuotesTransformer(self.context, quote[0])),
+                    cst.BaseExpression,
+                )
+
+                # Verify that the resulting expression doesn't have a backslash
+                # in it.
+                raw_expr_string = self.module.code_for_node(expr)
+                if "\\" in raw_expr_string:
+                    self.warn(f"Unsupported backslash in format expression")
+                    return updated_node
+
+                # For safety sake, if this is a dict/set or dict/set comprehension,
+                # wrap it in parens so that it doesn't accidentally create an
+                # escape.
+                if (
+                    raw_expr_string.startswith("{") or raw_expr_string.endswith("}")
+                ) and (not expr.lpar or not expr.rpar):
+                    expr = expr.with_changes(
+                        lpar=[cst.LeftParen()], rpar=[cst.RightParen()]
+                    )
+
+                # Verify that any strings we insert don't have the same quote
+                quote_gatherer = StringQuoteGatherer(self.context)
+                expr.visit(quote_gatherer)
+                for stringend in quote_gatherer.stringends:
+                    if stringend in quote:
+                        self.warn(
+                            f"Cannot embed string with same quote from format() call"
+                        )
+                        return updated_node
+
+                fstring.append(
+                    cst.FormattedStringExpression(
+                        expression=expr, conversion=conversion
+                    )
+                )
+            if quote not in ['"', '"""', "'", "'''"]:
+                raise Exception(f"Invalid f-string quote {quote}")
+            return cst.FormattedString(
+                parts=fstring,
+                start=f"f{prefix}{quote}",
+                # pyre-ignore I know what I'm doing with end, so no Literal[str]
+                # here. We get the string start/end from the original SimpleString
+                # so we know its correct.
+                end=quote,
+            )
+
+        return updated_node

--- a/libcst/codemod/commands/convert_format_to_fstring.py
+++ b/libcst/codemod/commands/convert_format_to_fstring.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 import ast
 from typing import Generator, List, Optional, Sequence, Set, Tuple

--- a/libcst/codemod/commands/convert_format_to_fstring.py
+++ b/libcst/codemod/commands/convert_format_to_fstring.py
@@ -1,3 +1,4 @@
+# pyre-strict
 import ast
 from typing import Generator, List, Optional, Sequence, Set, Tuple
 

--- a/libcst/codemod/commands/ensure_import_present.py
+++ b/libcst/codemod/commands/ensure_import_present.py
@@ -1,0 +1,41 @@
+import argparse
+from typing import Generator, Type
+
+from libcst.codemod import Codemod, MagicArgsCodemodCommand
+from libcst.codemod.visitors import AddImportsVisitor
+
+
+class EnsureImportPresentCommand(MagicArgsCodemodCommand):
+
+    DESCRIPTION: str = (
+        "Given a module and possibly an entity in that module, add an import "
+        + "as long as one does not already exist."
+    )
+
+    @staticmethod
+    def add_args(parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "--module",
+            dest="module",
+            metavar="MODULE",
+            help="Module that should be imported.",
+            type=str,
+            required=True,
+        )
+        parser.add_argument(
+            "--entity",
+            dest="entity",
+            metavar="ENTITY",
+            help=(
+                "Entity that should be imported from module. If left empty, entire "
+                + " module will be imported."
+            ),
+            type=str,
+            default=None,
+        )
+
+    def get_transforms(self) -> Generator[Type[Codemod], None, None]:
+        AddImportsVisitor.add_needed_import(
+            self.context, self.context.scratch["module"], self.context.scratch["entity"]
+        )
+        yield AddImportsVisitor

--- a/libcst/codemod/commands/ensure_import_present.py
+++ b/libcst/codemod/commands/ensure_import_present.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 import argparse
 from typing import Generator, Type

--- a/libcst/codemod/commands/ensure_import_present.py
+++ b/libcst/codemod/commands/ensure_import_present.py
@@ -1,3 +1,4 @@
+# pyre-strict
 import argparse
 from typing import Generator, Type
 

--- a/libcst/codemod/commands/fix_pyre_directives.py
+++ b/libcst/codemod/commands/fix_pyre_directives.py
@@ -1,0 +1,83 @@
+from typing import Dict, Sequence, Union
+
+import libcst
+import libcst.matchers as m
+from libcst.codemod import CodemodContext, VisitorBasedCodemodCommand
+from libcst.helpers.module import insert_header_comments
+
+
+class FixPyreDirectivesCommand(VisitorBasedCodemodCommand):
+    """
+    Given a source file, we'll move the any strict or unsafe tag to the top of the
+    file if it contains one. Also tries to fix typo'd directives.
+    """
+
+    DESCRIPTION: str = "Fixes common misspelling and location errors with pyre tags."
+
+    PYRE_TAGS: Sequence[str] = ["strict", "unsafe"]
+
+    def __init__(self, context: CodemodContext) -> None:
+        super().__init__(context)
+        self.move_strict: Dict[str, bool] = {tag: False for tag in self.PYRE_TAGS}
+        self.module_header_tags: Dict[str, int] = {tag: 0 for tag in self.PYRE_TAGS}
+        self.in_module_header: bool = False
+
+    def visit_Module_header(self, node: libcst.Module) -> None:
+        if self.in_module_header:
+            raise Exception("Logic error!")
+        self.in_module_header = True
+
+    def leave_Module_header(self, node: libcst.Module) -> None:
+        if not self.in_module_header:
+            raise Exception("Logic error!")
+        self.in_module_header = False
+
+    def leave_EmptyLine(
+        self, original_node: libcst.EmptyLine, updated_node: libcst.EmptyLine
+    ) -> Union[libcst.EmptyLine, libcst.RemovalSentinel]:
+        # First, find misplaced lines.
+        for tag in self.PYRE_TAGS:
+            if m.matches(updated_node, m.EmptyLine(comment=m.Comment(f"# pyre-{tag}"))):
+                if self.in_module_header:
+                    # We only want to remove this if we've already found another
+                    # pyre-strict in the header (that means its duplicated). We
+                    # also don't want to move the pyre-strict since its already in
+                    # the header, so don't mark that we need to move.
+                    self.module_header_tags[tag] += 1
+                    if self.module_header_tags[tag] > 1:
+                        return libcst.RemoveFromParent()
+                    else:
+                        return updated_node
+                else:
+                    # This showed up outside the module header, so move it inside
+                    if self.module_header_tags[tag] < 1:
+                        self.move_strict[tag] = True
+                    return libcst.RemoveFromParent()
+            # Now, find misnamed lines
+            if m.matches(updated_node, m.EmptyLine(comment=m.Comment(f"# pyre {tag}"))):
+                if self.in_module_header:
+                    # We only want to remove this if we've already found another
+                    # pyre-strict in the header (that means its duplicated). We
+                    # also don't want to move the pyre-strict since its already in
+                    # the header, so don't mark that we need to move.
+                    self.module_header_tags[tag] += 1
+                    if self.module_header_tags[tag] > 1:
+                        return libcst.RemoveFromParent()
+                    else:
+                        return updated_node.with_changes(
+                            comment=libcst.Comment(f"# pyre-{tag}")
+                        )
+                else:
+                    # We found an intended pyre-strict, but its spelled wrong. So, remove it
+                    # and re-add a new one in leave_Module.
+                    if self.module_header_tags[tag] < 1:
+                        self.move_strict[tag] = True
+                    return libcst.RemoveFromParent()
+        # We found a regular comment, don't care about this.
+        return updated_node
+
+    def leave_Module(
+        self, original_node: libcst.Module, updated_node: libcst.Module
+    ) -> libcst.Module:
+        comments = [f"# pyre-{tag}" for tag in self.PYRE_TAGS if self.move_strict[tag]]
+        return insert_header_comments(updated_node, comments)

--- a/libcst/codemod/commands/fix_pyre_directives.py
+++ b/libcst/codemod/commands/fix_pyre_directives.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 from typing import Dict, Sequence, Union
 

--- a/libcst/codemod/commands/fix_pyre_directives.py
+++ b/libcst/codemod/commands/fix_pyre_directives.py
@@ -1,3 +1,4 @@
+# pyre-strict
 from typing import Dict, Sequence, Union
 
 import libcst

--- a/libcst/codemod/commands/noop.py
+++ b/libcst/codemod/commands/noop.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 from libcst import Module
 from libcst.codemod import CodemodCommand

--- a/libcst/codemod/commands/noop.py
+++ b/libcst/codemod/commands/noop.py
@@ -3,6 +3,8 @@ from libcst.codemod import CodemodCommand
 
 
 class NOOPCommand(CodemodCommand):
+    DESCRIPTION: str = "Does absolutely nothing."
+
     def transform_module_impl(self, tree: Module) -> Module:
         # Return the tree as-is, with absolutely no modification
         return tree

--- a/libcst/codemod/commands/noop.py
+++ b/libcst/codemod/commands/noop.py
@@ -1,3 +1,4 @@
+# pyre-strict
 from libcst import Module
 from libcst.codemod import CodemodCommand
 

--- a/libcst/codemod/commands/remove_pyre_directive.py
+++ b/libcst/codemod/commands/remove_pyre_directive.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 import re
 from abc import ABC

--- a/libcst/codemod/commands/remove_pyre_directive.py
+++ b/libcst/codemod/commands/remove_pyre_directive.py
@@ -1,0 +1,51 @@
+import re
+from abc import ABC
+from typing import Pattern, Union
+
+import libcst
+from libcst.codemod import CodemodContext, VisitorBasedCodemodCommand
+
+
+class RemovePyreDirectiveCommand(VisitorBasedCodemodCommand, ABC):
+    PYRE_TAG: str
+
+    def __init__(self, context: CodemodContext) -> None:
+        super().__init__(context)
+        self._regex_pattern: Pattern[str] = re.compile(
+            rf"^#\s+pyre-{self.PYRE_TAG}\s*$"
+        )
+
+    def leave_EmptyLine(
+        self, original_node: libcst.EmptyLine, updated_node: libcst.EmptyLine
+    ) -> Union[libcst.EmptyLine, libcst.RemovalSentinel]:
+        if updated_node.comment is None or not bool(
+            self._regex_pattern.search(
+                libcst.ensure_type(updated_node.comment, libcst.Comment).value
+            )
+        ):
+            # This is a normal comment
+            return updated_node
+        # This is a directive comment matching our tag, so remove it.
+        return libcst.RemoveFromParent()
+
+
+class RemovePyreStrictCommand(RemovePyreDirectiveCommand):
+    """
+    Given a source file, we'll remove the any strict tag if the file already
+    contains it.
+    """
+
+    DESCRIPTION: str = "Removes the 'pyre-strict' tag from a module."
+
+    PYRE_TAG: str = "strict"
+
+
+class RemovePyreUnsafeCommand(RemovePyreDirectiveCommand):
+    """
+    Given a source file, we'll remove the any unsafe tag if the file already
+    contains it.
+    """
+
+    DESCRIPTION: str = "Removes the 'pyre-unsafe' tag from a module."
+
+    PYRE_TAG: str = "unsafe"

--- a/libcst/codemod/commands/remove_pyre_directive.py
+++ b/libcst/codemod/commands/remove_pyre_directive.py
@@ -1,3 +1,4 @@
+# pyre-strict
 import re
 from abc import ABC
 from typing import Pattern, Union

--- a/libcst/codemod/commands/strip_strings_from_types.py
+++ b/libcst/codemod/commands/strip_strings_from_types.py
@@ -1,3 +1,4 @@
+# pyre-strict
 from ast import literal_eval
 from typing import Union
 

--- a/libcst/codemod/commands/strip_strings_from_types.py
+++ b/libcst/codemod/commands/strip_strings_from_types.py
@@ -1,0 +1,23 @@
+from ast import literal_eval
+from typing import Union
+
+import libcst
+import libcst.matchers as m
+from libcst import parse_expression
+from libcst.codemod import VisitorBasedCodemodCommand
+from libcst.codemod.visitors import AddImportsVisitor
+
+
+class StripStringsCommand(VisitorBasedCodemodCommand):
+
+    DESCRIPTION: str = "Converts string type annotations to 3.7-compatible forward references."
+
+    @m.call_if_inside(m.Annotation())
+    @m.call_if_not_inside(m.Subscript(m.Name("Literal")))
+    def leave_SimpleString(
+        self, original_node: libcst.SimpleString, updated_node: libcst.SimpleString
+    ) -> Union[libcst.SimpleString, libcst.BaseExpression]:
+        AddImportsVisitor.add_needed_import(self.context, "__future__", "annotations")
+        return parse_expression(
+            literal_eval(updated_node.value), config=self.module.config_for_parsing
+        )

--- a/libcst/codemod/commands/strip_strings_from_types.py
+++ b/libcst/codemod/commands/strip_strings_from_types.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 from ast import literal_eval
 from typing import Union

--- a/libcst/codemod/commands/tests/__init__.py
+++ b/libcst/codemod/commands/tests/__init__.py
@@ -1,0 +1,1 @@
+# pyre-strict

--- a/libcst/codemod/commands/tests/__init__.py
+++ b/libcst/codemod/commands/tests/__init__.py
@@ -1,1 +1,6 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict

--- a/libcst/codemod/commands/tests/test_add_pyre_directive.py
+++ b/libcst/codemod/commands/tests/test_add_pyre_directive.py
@@ -1,3 +1,4 @@
+# pyre-strict
 from libcst.codemod import CodemodTest
 from libcst.codemod.commands.add_pyre_directive import AddPyreUnsafeCommand
 

--- a/libcst/codemod/commands/tests/test_add_pyre_directive.py
+++ b/libcst/codemod/commands/tests/test_add_pyre_directive.py
@@ -1,0 +1,119 @@
+from libcst.codemod import CodemodTest
+from libcst.codemod.commands.add_pyre_directive import AddPyreUnsafeCommand
+
+
+class TestAddPyreUnsafeCommand(CodemodTest):
+
+    TRANSFORM = AddPyreUnsafeCommand
+
+    def test_add_to_file(self) -> None:
+        before = """
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            # pyre-unsafe
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_add_to_file_with_pyre_unsafe(self) -> None:
+        """
+        We shouldn't be adding pyre-unsafe to a file that already has it.
+        """
+        before = """
+            # pyre-unsafe
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            # pyre-unsafe
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_add_to_file_with_pyre_unsafe_after(self) -> None:
+        """
+        We shouldn't be adding pyre-unsafe to a file that already has it.
+        """
+        before = """
+            # THIS IS A COMMENT!
+            # pyre-unsafe
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            # THIS IS A COMMENT!
+            # pyre-unsafe
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_add_to_file_with_pyre_unsafe_before(self) -> None:
+        """
+        We shouldn't be adding pyre-unsafe to a file that already has it.
+        """
+        before = """
+            # pyre-unsafe
+            # THIS IS A COMMENT!
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            # pyre-unsafe
+            # THIS IS A COMMENT!
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_empty_file(self) -> None:
+        """
+        If a file is empty, we should still add it.
+        """
+        before = ""
+        after = "# pyre-unsafe"
+        self.assertCodemod(before, after)
+
+    def test_add_to_file_with_comment(self) -> None:
+        """
+        We should add pyre-unsafe after the last comment at the top of a file.
+        """
+        before = """
+            # YO I'M A COMMENT
+
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            # YO I'M A COMMENT
+            # pyre-unsafe
+
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_add_to_file_with_import(self) -> None:
+        """
+        Tests that adding to a file with an import works properly.
+        """
+        before = """
+            from typing import List
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            # pyre-unsafe
+            from typing import List
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)

--- a/libcst/codemod/commands/tests/test_add_pyre_directive.py
+++ b/libcst/codemod/commands/tests/test_add_pyre_directive.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 from libcst.codemod import CodemodTest
 from libcst.codemod.commands.add_pyre_directive import AddPyreUnsafeCommand

--- a/libcst/codemod/commands/tests/test_convert_format_to_fstring.py
+++ b/libcst/codemod/commands/tests/test_convert_format_to_fstring.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 from libcst.codemod import CodemodTest
 from libcst.codemod.commands.convert_format_to_fstring import ConvertFormatStringCommand

--- a/libcst/codemod/commands/tests/test_convert_format_to_fstring.py
+++ b/libcst/codemod/commands/tests/test_convert_format_to_fstring.py
@@ -1,0 +1,327 @@
+from libcst.codemod import CodemodTest
+from libcst.codemod.commands.convert_format_to_fstring import ConvertFormatStringCommand
+
+
+class ConvertFormatStringCommandTest(CodemodTest):
+
+    TRANSFORM = ConvertFormatStringCommand
+
+    def test_noop(self) -> None:
+        """
+        Should do nothing, since there's nothing to do.
+        """
+
+        before = """
+            def foo() -> str:
+                return "foo"
+
+            def bar(baz: str) -> str:
+                return baz.format(bla, baz)
+        """
+        after = """
+            def foo() -> str:
+                return "foo"
+
+            def bar(baz: str) -> str:
+                return baz.format(bla, baz)
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_unsupported_expansion(self) -> None:
+        """
+        Should do nothing, since we can't safely expand at compile-time.
+        """
+
+        before = """
+            def baz() -> str:
+                return "{}: {}".format(*baz)
+
+            def foobar() -> str:
+                return "{x}: {y}".format(**baz)
+        """
+        after = """
+            def baz() -> str:
+                return "{}: {}".format(*baz)
+
+            def foobar() -> str:
+                return "{x}: {y}".format(**baz)
+        """
+
+        self.assertCodemod(
+            before,
+            after,
+            expected_warnings=[
+                "Unsupported field_name 0 in format() call",
+                "Unsupported field_name x in format() call",
+            ],
+        )
+
+    def test_unsupported_expression(self) -> None:
+        """
+        Should do nothing, since we can't safely expand these expressions.
+        """
+
+        before = """
+            def foo() -> str:
+                return "{}".format(f'bla')
+
+            def bar() -> str:
+                return "{}".format("'bla'")
+
+            def baz() -> str:
+                return "{}".format(1 +\\
+                    2)
+
+            def foobar() -> str:
+                return "{}".format((
+                    1 +
+                    # Woah, comment
+                    2
+                ))
+
+            def foobarbaz() -> str:
+                return "{}".format('\\n')
+        """
+        after = """
+            def foo() -> str:
+                return "{}".format(f'bla')
+
+            def bar() -> str:
+                return "{}".format("'bla'")
+
+            def baz() -> str:
+                return "{}".format(1 +\\
+                    2)
+
+            def foobar() -> str:
+                return "{}".format((
+                    1 +
+                    # Woah, comment
+                    2
+                ))
+
+            def foobarbaz() -> str:
+                return "{}".format('\\n')
+        """
+
+        self.assertCodemod(
+            before,
+            after,
+            expected_warnings=[
+                "Unsupported f-string in format() call",
+                "Cannot embed string with same quote from format() call",
+                "Unsupported backslash in format expression",
+                "Unsupported comment in format() call",
+                "Unsupported backslash in format expression",
+            ],
+        )
+
+    def test_position_replacement(self) -> None:
+        """
+        Should convert a format with positional-only paramaters.
+        """
+
+        before = """
+            def foo() -> str:
+                return "{}".format(baz)
+
+            def bar() -> str:
+                return "{} {} {}".format(foo(), baz, foobar)
+
+            def baz() -> str:
+                return "foo: {}, baz: {}, foobar: {}!".format(foo(), baz, foobar)
+
+            def foobar() -> str:
+                return "foo: {2}, baz: {1}, foobar: {0}!".format(foobar, baz, foo())
+        """
+        after = """
+            def foo() -> str:
+                return f"{baz}"
+
+            def bar() -> str:
+                return f"{foo()} {baz} {foobar}"
+
+            def baz() -> str:
+                return f"foo: {foo()}, baz: {baz}, foobar: {foobar}!"
+
+            def foobar() -> str:
+                return f"foo: {foo()}, baz: {baz}, foobar: {foobar}!"
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_name_replacement(self) -> None:
+        """
+        Should convert a format with name-only paramaters.
+        """
+
+        before = """
+            def foo() -> str:
+                return "{baz}".format(baz=baz)
+
+            def bar() -> str:
+                return "{a} {b} {c}".format(a=foo(), b=baz, c=foobar)
+        """
+        after = """
+            def foo() -> str:
+                return f"{baz}"
+
+            def bar() -> str:
+                return f"{foo()} {baz} {foobar}"
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_replacement_with_escapes(self) -> None:
+        """
+        Should convert a format while not dropping escape sequences
+        """
+
+        before = r"""
+            def foo() -> str:
+                return '"bla": {}\n'.format(baz)
+
+            def foobar() -> str:
+                return "{{bla}}: {}".format(baz)
+
+            def bar() -> str:
+                return r"'bla': {}\n".format(baz)
+
+            def barbaz() -> str:
+                return r"{{bla}}: {}\n".format(baz)
+
+            def foobarbaz() -> str:
+                return "{{min={}, max={}}}".format(minval, maxval)
+        """
+        after = r"""
+            def foo() -> str:
+                return f'"bla": {baz}\n'
+
+            def foobar() -> str:
+                return f"{{bla}}: {baz}"
+
+            def bar() -> str:
+                return fr"'bla': {baz}\n"
+
+            def barbaz() -> str:
+                return fr"{{bla}}: {baz}\n"
+
+            def foobarbaz() -> str:
+                return f"{{min={minval}, max={maxval}}}"
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_replacement_with_expression(self) -> None:
+        """
+        Should convert a format with attr/subscript expression.
+        """
+
+        before = """
+            def foo() -> str:
+                return "{baz.name}".format(baz=baz)
+
+            def bar() -> str:
+                return "{baz[0]}".format(baz=baz)
+
+            def foobar() -> str:
+                return "{0.name}".format(baz)
+
+            def baz() -> str:
+                return "{0[0]}".format(baz)
+        """
+        after = """
+            def foo() -> str:
+                return f"{baz.name}"
+
+            def bar() -> str:
+                return f"{baz[0]}"
+
+            def foobar() -> str:
+                return f"{baz.name}"
+
+            def baz() -> str:
+                return f"{baz[0]}"
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_replacement_with_conversion(self) -> None:
+        """
+        Should convert a format which uses a conversion
+        """
+
+        before = r"""
+            def foo() -> str:
+                return "bla: {0!r}\n".format(baz)
+        """
+        after = r"""
+            def foo() -> str:
+                return f"bla: {baz!r}\n"
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_replacement_with_newline(self) -> None:
+        """
+        Should convert a format which uses a conversion
+        """
+
+        before = r"""
+            def foo() -> str:
+                return "bla: {}\n".format(
+                    baz +
+                    bar
+                )
+        """
+        after = r"""
+            def foo() -> str:
+                return f"bla: {baz + bar}\n"
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_replacement_with_string(self) -> None:
+        """
+        Should convert a format which uses string
+        """
+
+        before = r"""
+            def foo() -> str:
+                return "bla: {}".format('baz')
+
+            def bar() -> str:
+                return 'bla: {}'.format("baz")
+
+            def baz() -> str:
+                return "bla: {}".format("baz")
+        """
+        after = r"""
+            def foo() -> str:
+                return f"bla: {'baz'}"
+
+            def bar() -> str:
+                return f'bla: {"baz"}'
+
+            def baz() -> str:
+                return f"bla: {'baz'}"
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_replacement_with_dict(self) -> None:
+        """
+        Should convert a format which uses dict
+        """
+
+        before = r"""
+            def foo() -> str:
+                return "bla: {}".format({'foo': 'bar'})
+        """
+        after = r"""
+            def foo() -> str:
+                return f"bla: {({'foo': 'bar'})}"
+        """
+
+        self.assertCodemod(before, after)

--- a/libcst/codemod/commands/tests/test_convert_format_to_fstring.py
+++ b/libcst/codemod/commands/tests/test_convert_format_to_fstring.py
@@ -1,3 +1,4 @@
+# pyre-strict
 from libcst.codemod import CodemodTest
 from libcst.codemod.commands.convert_format_to_fstring import ConvertFormatStringCommand
 

--- a/libcst/codemod/commands/tests/test_ensure_import_present.py
+++ b/libcst/codemod/commands/tests/test_ensure_import_present.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 from libcst.codemod import CodemodTest
 from libcst.codemod.commands.ensure_import_present import EnsureImportPresentCommand

--- a/libcst/codemod/commands/tests/test_ensure_import_present.py
+++ b/libcst/codemod/commands/tests/test_ensure_import_present.py
@@ -1,0 +1,21 @@
+from libcst.codemod import CodemodTest
+from libcst.codemod.commands.ensure_import_present import EnsureImportPresentCommand
+
+
+class EnsureImportPresentCommandTest(CodemodTest):
+    TRANSFORM = EnsureImportPresentCommand
+
+    def test_import_module(self) -> None:
+        before = ""
+        after = "import a"
+        self.assertCodemod(before, after, module="a", entity=None)
+
+    def test_import_entity(self) -> None:
+        before = ""
+        after = "from a import b"
+        self.assertCodemod(before, after, module="a", entity="b")
+
+    def test_import_wildcard(self) -> None:
+        before = "from a import *"
+        after = "from a import *"
+        self.assertCodemod(before, after, module="a", entity="b")

--- a/libcst/codemod/commands/tests/test_ensure_import_present.py
+++ b/libcst/codemod/commands/tests/test_ensure_import_present.py
@@ -1,3 +1,4 @@
+# pyre-strict
 from libcst.codemod import CodemodTest
 from libcst.codemod.commands.ensure_import_present import EnsureImportPresentCommand
 

--- a/libcst/codemod/commands/tests/test_fix_pyre_directives.py
+++ b/libcst/codemod/commands/tests/test_fix_pyre_directives.py
@@ -1,3 +1,4 @@
+# pyre-strict
 from libcst.codemod import CodemodTest
 from libcst.codemod.commands.fix_pyre_directives import FixPyreDirectivesCommand
 

--- a/libcst/codemod/commands/tests/test_fix_pyre_directives.py
+++ b/libcst/codemod/commands/tests/test_fix_pyre_directives.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 from libcst.codemod import CodemodTest
 from libcst.codemod.commands.fix_pyre_directives import FixPyreDirectivesCommand

--- a/libcst/codemod/commands/tests/test_fix_pyre_directives.py
+++ b/libcst/codemod/commands/tests/test_fix_pyre_directives.py
@@ -1,0 +1,225 @@
+from libcst.codemod import CodemodTest
+from libcst.codemod.commands.fix_pyre_directives import FixPyreDirectivesCommand
+
+
+class TestFixPyreDirectivesCommand(CodemodTest):
+
+    TRANSFORM = FixPyreDirectivesCommand
+
+    def test_no_need_to_fix_simple(self) -> None:
+        """
+        Tests that a pyre-strict inside the module header doesn't get touched.
+        """
+        before = """
+            # pyre-strict
+            from typing import List
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            # pyre-strict
+            from typing import List
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_no_need_to_fix_complex_bottom(self) -> None:
+        """
+        Tests that a pyre-strict inside the module header doesn't get touched.
+        """
+        before = """
+            # This is some header comment.
+            #
+            # pyre-strict
+            from typing import List
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            # This is some header comment.
+            #
+            # pyre-strict
+            from typing import List
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_no_need_to_fix_complex_top(self) -> None:
+        """
+        Tests that a pyre-strict inside the module header doesn't get touched.
+        """
+        before = """
+            # pyre-strict
+            #
+            # This is some header comment.
+
+            from typing import List
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            # pyre-strict
+            #
+            # This is some header comment.
+
+            from typing import List
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_fix_misspelled_header(self) -> None:
+        """
+        Tests that we correctly address poor spelling of a comment.
+        """
+        before = """
+            # pyre strict
+            from typing import List
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            # pyre-strict
+            from typing import List
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_fix_misspelled_body(self) -> None:
+        """
+        Tests that we correctly address poor spelling of a comment.
+        """
+        before = """
+            from typing import List
+            # pyre strict
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            # pyre-strict
+            from typing import List
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_fix_header_duplicate(self) -> None:
+        """
+        Tests that we correctly remove a duplicate, even with a mistake.
+        """
+        before = """
+            # pyre-strict
+            # pyre-strict
+            from typing import List
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            # pyre-strict
+            from typing import List
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_fix_body_duplicate(self) -> None:
+        """
+        Tests that we correctly remove a duplicate, even with a mistake.
+        """
+        before = """
+            # This is a comment.
+            #
+            # pyre-strict
+            from typing import List
+
+            # pyre-strict
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            # This is a comment.
+            #
+            # pyre-strict
+            from typing import List
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_fix_misspelled_header_duplicate(self) -> None:
+        """
+        Tests that we correctly remove a duplicate, even with a mistake.
+        """
+        before = """
+            # pyre-strict
+            # pyre strict
+            from typing import List
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            # pyre-strict
+            from typing import List
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_fix_misspelled_header_duplicate_body(self) -> None:
+        """
+        Tests that we correctly remove a duplicate, even with a mistake.
+        """
+        before = """
+            # pyre-strict
+            from typing import List
+            # pyre strict
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            # pyre-strict
+            from typing import List
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_fix_wrong_location(self) -> None:
+        """
+        Tests that we correctly move a badly-located pyre-strict.
+        """
+        before = """
+            from typing import List
+
+            # pyre-strict
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            # pyre-strict
+            from typing import List
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)

--- a/libcst/codemod/commands/tests/test_noop.py
+++ b/libcst/codemod/commands/tests/test_noop.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 from libcst.codemod import CodemodTest
 from libcst.codemod.commands.noop import NOOPCommand

--- a/libcst/codemod/commands/tests/test_remove_pyre_directive.py
+++ b/libcst/codemod/commands/tests/test_remove_pyre_directive.py
@@ -1,3 +1,4 @@
+# pyre-strict
 from libcst.codemod import CodemodTest
 from libcst.codemod.commands.remove_pyre_directive import (
     RemovePyreStrictCommand,

--- a/libcst/codemod/commands/tests/test_remove_pyre_directive.py
+++ b/libcst/codemod/commands/tests/test_remove_pyre_directive.py
@@ -1,0 +1,177 @@
+from libcst.codemod import CodemodTest
+from libcst.codemod.commands.remove_pyre_directive import (
+    RemovePyreStrictCommand,
+    RemovePyreUnsafeCommand,
+)
+
+
+class TestRemovePyreStrictCommand(CodemodTest):
+
+    TRANSFORM = RemovePyreStrictCommand
+
+    def test_remove_from_file(self) -> None:
+        before = """
+            # pyre-strict
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_remove_from_file_without_pyre_strict(self) -> None:
+        """
+        We shouldn't be removing pyre-strict to a file that doesn't have it.
+        """
+        before = """
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_remove_from_file_with_pyre_strict_after(self) -> None:
+        """
+        Test removal if pyre-strict is after comments.
+        """
+        before = """
+            # THIS IS A COMMENT!
+            # pyre-strict
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            # THIS IS A COMMENT!
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_remove_from_file_with_pyre_strict_before(self) -> None:
+        """
+        Test removal if pyre-strict is before comments.
+        """
+        before = """
+            # pyre-strict
+            # THIS IS A COMMENT!
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            # THIS IS A COMMENT!
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_remove_from_file_with_comment(self) -> None:
+        """
+        We should preserve comments and spacing when removing.
+        """
+        before = """
+            # YO I'M A COMMENT
+            # pyre-strict
+
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            # YO I'M A COMMENT
+
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+
+class TestRemovePyreUnsafeCommand(CodemodTest):
+
+    TRANSFORM = RemovePyreUnsafeCommand
+
+    def test_remove_from_file(self) -> None:
+        before = """
+            # pyre-unsafe
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_remove_from_file_without_pyre_unsafe(self) -> None:
+        """
+        We shouldn't be removing pyre-unsafe to a file that doesn't have it.
+        """
+        before = """
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_remove_from_file_with_pyre_unsafe_after(self) -> None:
+        """
+        Test removal if pyre-unsafe is after comments.
+        """
+        before = """
+            # THIS IS A COMMENT!
+            # pyre-unsafe
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            # THIS IS A COMMENT!
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_remove_from_file_with_pyre_unsafe_before(self) -> None:
+        """
+        Test removal if pyre-unsafe is before comments.
+        """
+        before = """
+            # pyre-unsafe
+            # THIS IS A COMMENT!
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            # THIS IS A COMMENT!
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_remove_from_file_with_comment(self) -> None:
+        """
+        We should preserve comments and spacing when removing.
+        """
+        before = """
+            # YO I'M A COMMENT
+            # pyre-unsafe
+
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        after = """
+            # YO I'M A COMMENT
+
+
+            def baz() -> List[Foo]:
+                pass
+        """
+        self.assertCodemod(before, after)

--- a/libcst/codemod/commands/tests/test_remove_pyre_directive.py
+++ b/libcst/codemod/commands/tests/test_remove_pyre_directive.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 from libcst.codemod import CodemodTest
 from libcst.codemod.commands.remove_pyre_directive import (

--- a/libcst/codemod/commands/tests/test_strip_strings_from_types.py
+++ b/libcst/codemod/commands/tests/test_strip_strings_from_types.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 from libcst.codemod import CodemodTest
 from libcst.codemod.commands.strip_strings_from_types import StripStringsCommand

--- a/libcst/codemod/commands/tests/test_strip_strings_from_types.py
+++ b/libcst/codemod/commands/tests/test_strip_strings_from_types.py
@@ -1,0 +1,138 @@
+from libcst.codemod import CodemodTest
+from libcst.codemod.commands.strip_strings_from_types import StripStringsCommand
+
+
+class TestStripStringsCodemod(CodemodTest):
+
+    TRANSFORM = StripStringsCommand
+
+    def test_noop(self) -> None:
+        before = """
+            foo: str = ""
+
+            class Class:
+                pass
+
+            def foo(a: Class, **kwargs: str) -> Class:
+                t: Class = Class()  # This is a comment
+                bar = ""
+                return t
+        """
+        after = """
+            foo: str = ""
+
+            class Class:
+                pass
+
+            def foo(a: Class, **kwargs: str) -> Class:
+                t: Class = Class()  # This is a comment
+                bar = ""
+                return t
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_non_async(self) -> None:
+        before = """
+            class Class:
+                pass
+
+            def foo(a: "Class", **kwargs: "str") -> "Class":
+                t: "Class" = Class()  # This is a comment
+                return t
+        """
+        after = """
+            from __future__ import annotations
+
+            class Class:
+                pass
+
+            def foo(a: Class, **kwargs: str) -> Class:
+                t: Class = Class()  # This is a comment
+                return t
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_async(self) -> None:
+        before = """
+            class Class:
+                pass
+
+            async def foo(a: "Class", **kwargs: "str") -> "Class":
+                t: "Class" = Class()  # This is a comment
+                return t
+        """
+        after = """
+            from __future__ import annotations
+
+            class Class:
+                pass
+
+            async def foo(a: Class, **kwargs: str) -> Class:
+                t: Class = Class()  # This is a comment
+                return t
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_recursive(self) -> None:
+        before = """
+            class Class:
+                pass
+
+            def foo(a: List["Class"]):
+                pass
+
+            def bar(a: List[Optional["Class"]]):
+                pass
+
+            def baz(a: "List[Class]"):
+                pass
+        """
+        after = """
+            from __future__ import annotations
+
+            class Class:
+                pass
+
+            def foo(a: List[Class]):
+                pass
+
+            def bar(a: List[Optional[Class]]):
+                pass
+
+            def baz(a: List[Class]):
+                pass
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_literal(self) -> None:
+        before = """
+            from typing_extensions import Literal
+
+            class Class:
+                pass
+
+            def foo(a: Literal["one", "two", "three"]):
+                pass
+
+            def bar(a: Union["Class", Literal["one", "two", "three"]]):
+                pass
+        """
+        after = """
+            from __future__ import annotations
+            from typing_extensions import Literal
+
+            class Class:
+                pass
+
+            def foo(a: Literal["one", "two", "three"]):
+                pass
+
+            def bar(a: Union[Class, Literal["one", "two", "three"]]):
+                pass
+        """
+
+        self.assertCodemod(before, after)

--- a/libcst/codemod/commands/tests/test_strip_strings_from_types.py
+++ b/libcst/codemod/commands/tests/test_strip_strings_from_types.py
@@ -1,3 +1,4 @@
+# pyre-strict
 from libcst.codemod import CodemodTest
 from libcst.codemod.commands.strip_strings_from_types import StripStringsCommand
 

--- a/libcst/codemod/commands/tests/test_unnecessary_format_string.py
+++ b/libcst/codemod/commands/tests/test_unnecessary_format_string.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 from typing import Type
 

--- a/libcst/codemod/commands/tests/test_unnecessary_format_string.py
+++ b/libcst/codemod/commands/tests/test_unnecessary_format_string.py
@@ -1,3 +1,4 @@
+# pyre-strict
 from typing import Type
 
 from libcst.codemod import Codemod, CodemodTest

--- a/libcst/codemod/commands/tests/test_unnecessary_format_string.py
+++ b/libcst/codemod/commands/tests/test_unnecessary_format_string.py
@@ -1,0 +1,39 @@
+from typing import Type
+
+from libcst.codemod import Codemod, CodemodTest
+from libcst.codemod.commands.unnecessary_format_string import UnnecessaryFormatString
+
+
+class TestUnnecessaryFormatString(CodemodTest):
+    TRANSFORM: Type[Codemod] = UnnecessaryFormatString
+
+    def test_replace(self) -> None:
+        before = r"""
+            good: str = "good"
+            good: str = f"with_arg{arg}"
+            good = "good{arg1}".format(1234)
+            good = "good".format()
+            good = "good" % {}
+            good = "good" % ()
+            good = rf"good\d+{bar}"
+            good = f"wow i dont have args but dont mess my braces {{ up }}"
+
+            bad: str = f"bad" + "bad"
+            bad: str = f'bad'
+            bad: str = rf'bad\d+'
+        """
+        after = r"""
+            good: str = "good"
+            good: str = f"with_arg{arg}"
+            good = "good{arg1}".format(1234)
+            good = "good".format()
+            good = "good" % {}
+            good = "good" % ()
+            good = rf"good\d+{bar}"
+            good = f"wow i dont have args but dont mess my braces {{ up }}"
+
+            bad: str = "bad" + "bad"
+            bad: str = 'bad'
+            bad: str = r'bad\d+'
+        """
+        self.assertCodemod(before, after)

--- a/libcst/codemod/commands/unnecessary_format_string.py
+++ b/libcst/codemod/commands/unnecessary_format_string.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 import libcst
 import libcst.matchers as m

--- a/libcst/codemod/commands/unnecessary_format_string.py
+++ b/libcst/codemod/commands/unnecessary_format_string.py
@@ -1,3 +1,4 @@
+# pyre-strict
 import libcst
 import libcst.matchers as m
 from libcst.codemod import VisitorBasedCodemodCommand

--- a/libcst/codemod/commands/unnecessary_format_string.py
+++ b/libcst/codemod/commands/unnecessary_format_string.py
@@ -1,0 +1,41 @@
+import libcst
+import libcst.matchers as m
+from libcst.codemod import VisitorBasedCodemodCommand
+
+
+class UnnecessaryFormatString(VisitorBasedCodemodCommand):
+
+    DESCRIPTION: str = "Converts f-strings which perform no formatting to regular strings."
+
+    @m.leave(m.FormattedString(parts=(m.FormattedStringText(),)))
+    def _check_formatted_string(
+        self,
+        _original_node: libcst.FormattedString,
+        updated_node: libcst.FormattedString,
+    ) -> libcst.BaseExpression:
+        old_string_inner = libcst.ensure_type(
+            updated_node.parts[0], libcst.FormattedStringText
+        ).value
+        if "{{" in old_string_inner or "}}" in old_string_inner:
+            # there are only two characters we need to worry about escaping.
+            return updated_node
+
+        old_string_literal = updated_node.start + old_string_inner + updated_node.end
+        new_string_literal = (
+            updated_node.start.replace("f", "").replace("F", "")
+            + old_string_inner
+            + updated_node.end
+        )
+
+        old_string_evaled = eval(old_string_literal)  # noqa
+        new_string_evaled = eval(new_string_literal)  # noqa
+        if old_string_evaled != new_string_evaled:
+            warn_message = (
+                f"Attempted to codemod |{old_string_literal}| to "
+                + f"|{new_string_literal}| but dont eval to the same! First is |{old_string_evaled}| and "
+                + f"second is |{new_string_evaled}|"
+            )
+            self.warn(warn_message)
+            return updated_node
+
+        return libcst.SimpleString(new_string_literal)

--- a/libcst/codemod/tests/__init__.py
+++ b/libcst/codemod/tests/__init__.py
@@ -1,0 +1,1 @@
+# pyre-strict

--- a/libcst/codemod/tests/__init__.py
+++ b/libcst/codemod/tests/__init__.py
@@ -1,1 +1,6 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict

--- a/libcst/codemod/tests/test_codemod.py
+++ b/libcst/codemod/tests/test_codemod.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 from unittest import expectedFailure
 

--- a/libcst/codemod/tests/test_metadata.py
+++ b/libcst/codemod/tests/test_metadata.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 from textwrap import dedent
 

--- a/libcst/codemod/tests/test_metadata.py
+++ b/libcst/codemod/tests/test_metadata.py
@@ -1,3 +1,4 @@
+# pyre-strict
 from textwrap import dedent
 
 import libcst as cst

--- a/libcst/codemod/tests/test_runner.py
+++ b/libcst/codemod/tests/test_runner.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 from textwrap import dedent
 from typing import Dict

--- a/libcst/codemod/visitors/__init__.py
+++ b/libcst/codemod/visitors/__init__.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 from libcst.codemod.visitors._add_imports import AddImportsVisitor
 from libcst.codemod.visitors._gather_imports import GatherImportsVisitor

--- a/libcst/codemod/visitors/__init__.py
+++ b/libcst/codemod/visitors/__init__.py
@@ -1,3 +1,4 @@
+# pyre-strict
 from libcst.codemod.visitors._add_imports import AddImportsVisitor
 from libcst.codemod.visitors._gather_imports import GatherImportsVisitor
 

--- a/libcst/codemod/visitors/_add_imports.py
+++ b/libcst/codemod/visitors/_add_imports.py
@@ -47,6 +47,11 @@ class AddImportsVisitor(ContextAwareTransformer):
             *imports,
         ]
 
+        # Verify that the imports are valid
+        for module, obj in imports:
+            if module == "__future__" and obj is None:
+                raise Exception("Cannot import __future__ directly!")
+
         # List of modules we need to ensure are imported
         self.module_imports: Set[str] = {
             module for (module, obj) in imports if obj is None

--- a/libcst/codemod/visitors/_add_imports.py
+++ b/libcst/codemod/visitors/_add_imports.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 from typing import Dict, List, Optional, Sequence, Set, Tuple, Union
 

--- a/libcst/codemod/visitors/_add_imports.py
+++ b/libcst/codemod/visitors/_add_imports.py
@@ -1,3 +1,4 @@
+# pyre-strict
 from typing import Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import libcst

--- a/libcst/codemod/visitors/_gather_imports.py
+++ b/libcst/codemod/visitors/_gather_imports.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 from typing import Dict, List, Optional, Sequence, Set, Tuple, Union
 

--- a/libcst/codemod/visitors/_gather_imports.py
+++ b/libcst/codemod/visitors/_gather_imports.py
@@ -1,3 +1,4 @@
+# pyre-strict
 from typing import Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import libcst

--- a/libcst/codemod/visitors/tests/__init__.py
+++ b/libcst/codemod/visitors/tests/__init__.py
@@ -1,0 +1,1 @@
+# pyre-strict

--- a/libcst/codemod/visitors/tests/__init__.py
+++ b/libcst/codemod/visitors/tests/__init__.py
@@ -1,1 +1,6 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict

--- a/libcst/codemod/visitors/tests/test_add_imports.py
+++ b/libcst/codemod/visitors/tests/test_add_imports.py
@@ -370,7 +370,9 @@ class TestAddImportsCodemod(CodemodTest):
         self.assertCodemod(before, after, [("a.b.c", "D"), ("argparse", None)])
 
     def test_strict_module_no_imports(self) -> None:
-        """First added import in strict module should go after __strict__ flag."""
+        """
+        First added import in strict module should go after __strict__ flag.
+        """
         before = """
             __strict__ = True
 
@@ -379,6 +381,30 @@ class TestAddImportsCodemod(CodemodTest):
         """
         after = """
             __strict__ = True
+            import argparse
+
+            class Foo:
+                pass
+        """
+
+        self.assertCodemod(before, after, [("argparse", None)])
+
+    def test_strict_module_with_imports(self) -> None:
+        """
+        First added import in strict module should go after __strict__ flag.
+        """
+        before = """
+            __strict__ = True
+
+            import unittest
+
+            class Foo:
+                pass
+        """
+        after = """
+            __strict__ = True
+
+            import unittest
             import argparse
 
             class Foo:

--- a/libcst/codemod/visitors/tests/test_add_imports.py
+++ b/libcst/codemod/visitors/tests/test_add_imports.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 from libcst.codemod import CodemodTest
 from libcst.codemod.visitors import AddImportsVisitor

--- a/libcst/codemod/visitors/tests/test_add_imports.py
+++ b/libcst/codemod/visitors/tests/test_add_imports.py
@@ -1,3 +1,4 @@
+# pyre-strict
 from libcst.codemod import CodemodTest
 from libcst.codemod.visitors import AddImportsVisitor
 

--- a/libcst/codemod/visitors/tests/test_gather_imports.py
+++ b/libcst/codemod/visitors/tests/test_gather_imports.py
@@ -1,3 +1,4 @@
+# pyre-strict
 from libcst import parse_module
 from libcst.codemod import CodemodContext, CodemodTest
 from libcst.codemod.visitors import GatherImportsVisitor

--- a/libcst/codemod/visitors/tests/test_gather_imports.py
+++ b/libcst/codemod/visitors/tests/test_gather_imports.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
 from libcst import parse_module
 from libcst.codemod import CodemodContext, CodemodTest

--- a/libcst/helpers/__init__.py
+++ b/libcst/helpers/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# pyre-strict

--- a/libcst/helpers/module.py
+++ b/libcst/helpers/module.py
@@ -1,3 +1,9 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# pyre-strict
 from itertools import islice
 from typing import List
 

--- a/libcst/helpers/module.py
+++ b/libcst/helpers/module.py
@@ -1,0 +1,21 @@
+from itertools import islice
+from typing import List
+
+import libcst
+
+
+def insert_header_comments(node: libcst.Module, comments: List[str]) -> libcst.Module:
+    """Insert comments after last non-empty line in header."""
+    # Split the lines up into a contiguous comment-containing section and
+    # the empty whitespace section that follows
+    last_comment_index = -1
+    for i, line in enumerate(node.header):
+        if line.comment is not None:
+            last_comment_index = i
+
+    comment_lines = islice(node.header, last_comment_index + 1)
+    empty_lines = islice(node.header, last_comment_index + 1, None)
+    inserted_lines = [
+        libcst.EmptyLine(comment=libcst.Comment(value=comment)) for comment in comments
+    ]
+    return node.with_changes(header=(*comment_lines, *inserted_lines, *empty_lines))

--- a/libcst/helpers/tests/test_module.py
+++ b/libcst/helpers/tests/test_module.py
@@ -1,3 +1,9 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# pyre-strict
 import libcst
 from libcst.helpers.module import insert_header_comments
 from libcst.testing.utils import UnitTest

--- a/libcst/helpers/tests/test_module.py
+++ b/libcst/helpers/tests/test_module.py
@@ -1,0 +1,54 @@
+import libcst
+from libcst.helpers.module import insert_header_comments
+from libcst.testing.utils import UnitTest
+
+
+class ModuleTest(UnitTest):
+    def test_insert_header_comments(self) -> None:
+        inserted_comments = ["# INSERT ME", "# AND ME"]
+        comment_lines = ["# First comment", "# Another one", "# comment 3"]
+        empty_lines = [" ", ""]
+        non_header_line = ["SOME_VARIABLE = 0"]
+        original_code = "\n".join(comment_lines + empty_lines + non_header_line)
+        expected_code = "\n".join(
+            comment_lines + inserted_comments + empty_lines + non_header_line
+        )
+        node = libcst.parse_module(original_code)
+        self.assertEqual(
+            insert_header_comments(node, inserted_comments).code, expected_code
+        )
+
+        # No comment case
+        original_code = "\n".join(empty_lines + non_header_line)
+        expected_code = "\n".join(inserted_comments + empty_lines + non_header_line)
+        node = libcst.parse_module(original_code)
+        self.assertEqual(
+            insert_header_comments(node, inserted_comments).code, expected_code
+        )
+
+        # No empty lines case
+        original_code = "\n".join(comment_lines + non_header_line)
+        expected_code = "\n".join(comment_lines + inserted_comments + non_header_line)
+        node = libcst.parse_module(original_code)
+        self.assertEqual(
+            insert_header_comments(node, inserted_comments).code, expected_code
+        )
+
+        # Empty line between comments
+        comment_lines.insert(1, " ")
+        original_code = "\n".join(comment_lines + empty_lines + non_header_line)
+        expected_code = "\n".join(
+            comment_lines + inserted_comments + empty_lines + non_header_line
+        )
+        node = libcst.parse_module(original_code)
+        self.assertEqual(
+            insert_header_comments(node, inserted_comments).code, expected_code
+        )
+
+        # No header case
+        original_code = "\n".join(non_header_line)
+        expected_code = "\n".join(inserted_comments + non_header_line)
+        node = libcst.parse_module(original_code)
+        self.assertEqual(
+            insert_header_comments(node, inserted_comments).code, expected_code
+        )

--- a/libcst/tool.py
+++ b/libcst/tool.py
@@ -712,4 +712,6 @@ def main(proc_name: str, cli_args: List[str]) -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main("libcst.tool", sys.argv[1:]))
+    sys.exit(
+        main(os.environ.get("LIBCST_TOOL_COMMAND_NAME", "libcst.tool"), sys.argv[1:])
+    )

--- a/libcst/tool.py
+++ b/libcst/tool.py
@@ -621,6 +621,7 @@ def _list_impl(proc_name: str, command_args: List[str]) -> int:  # noqa: C901
     _ = parser.parse_args(command_args)
 
     # Now, import each of the modules to determine their paths.
+    codemods: List[str] = []
     for module in config["modules"]:
         try:
             imported_module = importlib.import_module(module)
@@ -660,10 +661,13 @@ def _list_impl(proc_name: str, command_args: List[str]) -> int:  # noqa: C901
                     # check for that here.
                     if any(cls[0] is ABC for cls in inspect.getclasstree([obj])):
                         continue
-                    print(f"{filename[:-3]}.{obj.__name__} - {obj.DESCRIPTION}")
+                    codemods.append(
+                        f"{filename[:-3]}.{obj.__name__} - {obj.DESCRIPTION}"
+                    )
                 except TypeError:
                     continue
 
+    print("\n".join(sorted(codemods)))
     return 0
 
 

--- a/libcst/tool.py
+++ b/libcst/tool.py
@@ -366,7 +366,11 @@ def _codemod_impl(proc_name: str, command_args: List[str]) -> int:  # noqa: C901
 
     # Now, construct the full parser, parse the args and run the class.
     parser = argparse.ArgumentParser(
-        description="Execute a codemod against a series of files.",
+        description=(
+            "Execute a codemod against a series of files."
+            if command_class is CodemodCommand
+            else command_class.DESCRIPTION
+        ),
         prog=f"{proc_name} codemod",
     )
     parser.add_argument(

--- a/libcst/tool.py
+++ b/libcst/tool.py
@@ -11,6 +11,7 @@
 # pyre-strict
 import argparse
 import dataclasses
+import distutils.spawn
 import importlib
 import inspect
 import os
@@ -316,6 +317,14 @@ def _find_and_load_config() -> Dict[str, Any]:
         previous_dir = current_dir
         current_dir = os.path.abspath(os.path.join(current_dir, os.pardir))
 
+    # Make sure that the formatter is findable.
+    if config["formatter"]:
+        exe = (
+            distutils.spawn.find_executable(config["formatter"][0])
+            or config["formatter"][0]
+        )
+        config["formatter"] = [os.path.abspath(exe), *config["formatter"][1:]]
+
     return config
 
 
@@ -418,7 +427,7 @@ def _codemod_impl(proc_name: str, command_args: List[str]) -> int:  # noqa: C901
     parser.add_argument(
         "--no-format",
         action="store_true",
-        help="Don't format resulting codemod with black.",
+        help="Don't format resulting codemod with configured formatter.",
     )
     parser.add_argument(
         "--show-successes",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 dataclasses==0.6.0; python_version < '3.7'
 typing_extensions==3.7.2
 typing_inspect==0.4.0
+pyyaml==5.2


### PR DESCRIPTION
## Summary

This PR brings the missing feature-set that I alluded to in PR #164. This adds a config file format to override defaults, a utility for initializing the config file, a utility for listing out known codemods given an existing config file, and a series of universally-applicable codemods that were previously developed inside Instagram. In the spirit of continuing to use `libcst.tool` for command-line operations related to LibCST, all of these utilities were added to `libcst.tool` and it was refactored a bit to allow for this.

Note that this is still missing documentation, which I am working on in yet another PR. However, it is complete and therefore worth releasing.

## Test Plan

pyre, tox, run `libcst.tool` locally and verify that its behavior is correct. I also used `libcst.tool codemod` to fix pyre-strict issues in the codemod directory, since Instagram internally uses `pyre-unsafe` and is strict by default.