### PR TITLE
Add documentation for libcst.codemod and friends.

### DIFF
--- a/docs/source/codemods.rst
+++ b/docs/source/codemods.rst
@@ -1,0 +1,142 @@
+========
+Codemods
+========
+
+LibCST defines a codemod as an automated refactor that can be applied to a codebase
+of arbitrary size. Codemods are provided as a framework for writing higher-order
+transforms that consist of other, simpler transforms. It includes provisions for
+quickly creating a command-line interface to execute a codemod.
+
+.. _libcst-codemod-base:
+
+------------
+Codemod Base
+------------
+
+All codemods derive from a common base, :class:`~libcst.codemod.Codemod`. This class
+includes a context, automatic metadata resolution and multi-pass transform support.
+Codemods are intended to be executed using the :func:`~libcst.codemod.transform_module`
+interface.
+
+.. autoclass:: libcst.codemod.Codemod
+.. autoclass:: libcst.codemod.CodemodContext
+
+As a convenience, LibCST-compatible visitors are provided which extend the feature-set
+of :class:`~libcst.codemod.Codemod` to LibCST visitors and transforms. Remember that
+:class:`~libcst.codemod.ContextAwareTransformer` is still a
+:class:`~libcst.codemod.Codemod`, so you should still execute it using
+:func:`~libcst.codemod.transform_module`.
+
+.. autoclass:: libcst.codemod.ContextAwareTransformer
+  :exclude-members: transform_module_impl
+.. autoclass:: libcst.codemod.ContextAwareVisitor
+
+It is often necessary to bail out of a codemod mid-operation when you realize that
+you do not want to operate on a module. This can be for any reason such as realizing
+the module includes some operation that you do not support. If you wish to skip a
+module, you can raise the :class:`~libcst.codemod.SkipFile` exception. For codemods
+executed using the :func:`~libcst.codemod.transform_module` interface, all warnings
+emitted up to the exception being thrown will be preserved in the result.
+
+.. autoclass:: libcst.codemod.SkipFile
+
+-------------------
+Execution Interface
+-------------------
+
+As documented in the Codemod Base section above, codemods are meant to be
+programmatically executed using :func:`~libcst.codemod.transform_module`. Executing
+in this manner handles all of the featureset of codemods, including metadata calculation
+and exception handling.
+
+.. autofunction:: libcst.codemod.transform_module
+.. autoclass:: libcst.codemod.TransformResult
+.. autoclass:: libcst.codemod.TransformSuccess
+.. autoclass:: libcst.codemod.TransformFailure
+.. autoclass:: libcst.codemod.TransformSkip
+.. autoclass:: libcst.codemod.SkipReason
+.. autoclass:: libcst.codemod.TransformExit
+
+--------------------
+Command-Line Support
+--------------------
+
+LibCST includes additional support to facilitate faster development of codemods which
+are to be run at the command-line. This is achieved through the
+:class:`~libcst.codemod.CodemodCommand` class and the ``codemod`` utility which lives
+inside ``libcst.tool``. The :class:`~libcst.codemod.CodemodCommand` class provides a
+codemod description and an interface to add arguments to the command-line. This is
+translated to a custom help message and command-line options that a user can provide
+when running a codemod at the command-line.
+
+For a brief overview of supported universal options, run the ``codemod`` utility like so::
+
+    python3 -m libcst.tool codemod --help
+
+The utility provides support for gathering up and parallelizing codemods across a
+series of files or directories, auto-formatting changed code according to a configured
+formatter, generating a unified diff of changes instead of applying them to files,
+taking code from stdin and codemodding it before returning to stdout, and printing
+progress and warnings to stderr during execution of a codemod.
+
+Help is auto-customized if a codemod class is provided, including any added options
+and the codemod description. For an example, run the ``codemod`` utility like so::
+
+    python3 -m libcst.tool codemod noop.NOOPCommand --help
+
+A second utility, ``list``, can list all available codemods given your configuration.
+Run it like so::
+
+    python3 -m libcst.tool list
+
+Finally, to set up a directory for codemodding using these tools, including additional
+directories where codemods can be found, use the ``initialize`` utility. To see help
+for how to use this, run the ``initialize`` utility like so::
+
+    python3 -m libcst.tool initialize --help
+
+The above tools operate against any codemod which subclasses from
+:class:`~libcst.codemod.CodemodCommand`. Remember that :class:`~libcst.codemod.CodemodCommand`
+is a subclass of :class:`~libcst.codemod.Codemod`, so all of the features documented
+in the :ref:`libcst-codemod-base` section are available in addition to command-line
+support. Any command-line enabled codemod can also be programmatically instantiated
+and invoked using the above-documented :func:`~libcst.codemod.transform_module`
+interface.
+
+.. autoclass:: libcst.codemod.CodemodCommand
+  :exclude-members: transform_module
+
+Additionally, a few convenience classes have been provided which take the boilerplate
+out of common types of codemods:
+
+.. autoclass:: libcst.codemod.VisitorBasedCodemodCommand
+.. autoclass:: libcst.codemod.MagicArgsCodemodCommand
+  :exclude-members: transform_module_impl
+
+--------------------
+Command-Line Toolkit
+--------------------
+
+Several helpers for constructing a command-line interface are provided. These are used
+in the ``codemod`` utility to provide LibCST's de-facto command-line interface but they
+are also available to be used directly in the case that circumstances demand a custom
+command-line tool.
+
+.. autofunction:: libcst.codemod.gather_files
+.. autofunction:: libcst.codemod.exec_transform_with_prettyprint
+.. autofunction:: libcst.codemod.parallel_exec_transform_with_prettyprint
+.. autoclass:: libcst.codemod.ParallelTransformResult
+.. autofunction:: libcst.codemod.diff_code
+
+---------------------
+Library of Transforms
+---------------------
+
+LibCST additionally includes a library of transforms to reduce the need for boilerplate
+inside codemods. As of now, the list includes the following helpers.
+
+.. autoclass:: libcst.codemod.visitors.GatherImportsVisitor
+  :exclude-members: visit_Import, visit_ImportFrom
+.. autoclass:: libcst.codemod.visitors.AddImportsVisitor
+  :exclude-members: CONTEXT_KEY, visit_Module, leave_ImportFrom, leave_Module
+.. autofunction:: libcst.helpers.module.insert_header_comments

--- a/docs/source/codemods_tutorial.rst
+++ b/docs/source/codemods_tutorial.rst
@@ -1,0 +1,197 @@
+=====================
+Working With Codemods
+=====================
+
+Codemods are an abstraction on top of LibCST for performing large-scale changes
+to an entire codebase. See :doc:`Codemods <codemods>` for the complete
+documentation.
+
+-------------------------------
+Setting up and Running Codemods
+-------------------------------
+
+Let's say you were interested in converting legacy ``.format()`` calls to shiny new
+Python 3.6 f-strings. LibCST ships with a command-line interface known as
+``libcst.tool``. This includes a few provisions for working with codemods at the
+command-line. It also includes a library of pre-defined codemods, one of which is
+a transform that can convert most ``.format()`` calls to f-strings. So, let's use this
+to give Python 3.6 f-strings a try.
+
+
+You might be lucky enough that the defaults for LibCST perfectly match your coding
+style, but chances are you want to customize LibCST to your repository. Initialize
+your repository by running the following command in the root of your repository and
+then edit the produced ``.libcst.codemod.yaml`` file::
+
+    python3 -m libcst.tool initialize .
+
+The file includes provisions for customizing any generated code marker, calling an
+external code formatter such as `black <https://pypi.org/project/black/>`_, blackisting
+patterns of files you never wish to touch and a list of modules that contain valid
+codemods that can be executed. If you want to write and run codemods specific to your
+repository or organization, you can add an in-repo module location to the list of
+modules and LibCST will discover codemods in all locations.
+
+Now that your repository is initialized, let's have a quick look at what's currently
+available for running. Run the following command from the root of your repository::
+
+    python3 -m libcst.tool list
+
+You'll see several codemods available to you, one of which is
+``convert_format_to_fstring.ConvertFormatStringCommand``. The description to the right
+of this codemod indicates that it converts ``.format()`` calls to f-strings, so let's
+give it a whirl! Execute the codemod from the root of your repository like so::
+
+    python3 -m libcst.tool codemod convert_format_to_fstring.ConvertFormatStringCommand .
+
+If you want to try it out on only one file or a specific subdirectory, you can replace
+the ``.`` in the above command with a relative directory, file, list of directories or
+list of files. While LibCST is walking through your repository and codemodding files
+you will see a progress indicator. If there's anything the codemod can't do or any
+unexpected syntax errors, you will also see them on your console as it progresses.
+
+If everything works out, you'll notice that your ``.format()`` calls have been
+converted to f-strings!
+
+-----------------
+Writing a Codemod
+-----------------
+
+Codemods use the same principles as the rest of LibCST. They take LibCST's core,
+metadata and matchers and package them up as a simple command-line interface. So,
+anything you can do with LibCST in isolation you can also do with a codemod.
+
+Let's say you need to clean up some legacy code which used magic values instead
+of constants. You've already got a constants module called ``utils.constants``
+and you want to assume that every reference to a raw string matching a particular
+constant should be converted to that constant. For the simplest version of this
+codemod, you'll need a command-line tool that takes as arguments the string to
+replace and the constant to replace it with. You'll also need to ensure that
+modified modules import the constant itself.
+
+So, you can write something similar to the following::
+
+    import argparse
+    from ast import literal_eval
+    from typing import Union
+
+    import libcst as cst
+    from libcst.codemod import CodemodContext, VisitorBasedCodemodCommand
+    from libcst.codemod.visitors import AddImportsVisitor
+
+
+    class ConvertConstantCommand(VisitorBasedCodemodCommand):
+
+        # Add a description so that future codemodders can see what this does.
+        DESCRIPTION: str = "Converts raw strings to constant accesses."
+
+        @staticmethod
+        def add_args(arg_parser: argparse.ArgumentParser) -> None:
+            # Add command-line args that a codemodd user can specify for running this
+            # codemod.
+            arg_parser.add_argument(
+                "--string",
+                dest="string",
+                metavar="STRING",
+                help="String contents that we should look for.",
+                type=str,
+                required=True,
+            )
+            arg_parser.add_argument(
+                "--constant",
+                dest="constant",
+                metavar="CONSTANT",
+                help="Constant identifier we should replace strings with.",
+                type=str,
+                required=True,
+            )
+
+        def __init__(self, context: CodemodContext, string: str, constant: str) -> None:
+            # Initialize the base class with context, and save our args. Remember, the
+            # "dest" for each argument we added above must match a parameter name in
+            # this init.
+            super().__init__(context)
+            self.string = string
+            self.constant = constant
+
+        def leave_SimpleString(
+            self, original_node: cst.SimpleString, updated_node: cst.SimpleString
+        ) -> Union[cst.SimpleString, cst.Name]:
+            if literal_eval(updated_node.value) == self.string:
+                # Check to see if the string matches what we want to replace. If so,
+                # then we do the replacement. We also know at this point that we need
+                # to import the constant itself.
+                AddImportsVisitor.add_needed_import(
+                    self.context, "utils.constants", self.constant,
+                )
+                return cst.Name(self.constant)
+            # This isn't a string we're concerned with, so leave it unchanged.
+            return updated_node
+
+This codemod is pretty simple. It defines a command-line description, sets up to parse
+a few required command-line args, initializes its own member variables with the
+command-line args that were parsed for it by ``libcst.tool codemod`` and finally
+replaces any string which matches our string command-line argument with a constant.
+It also takes care of adding the import required for the constant to be defined properly.
+
+Cool! Let's look at the command-line help for this codemod. Let's assume you saved it
+as ``constant_folding.py`` inside ``libcst.codemod.commands``. You can get help for the
+codemod by running the following command::
+
+    python3 -m libcst.tool codemod constant_folding.ConvertConstantCommand --help
+
+Notice that along with the default arguments, the ``--string`` and ``--constant``
+arguments are present in the help, and the command-line description has been updated
+with the codemod's description string. You'' notice that the codemod also shows up
+on ``libcst.tool list``.
+
+----------------
+Testing Codemods
+----------------
+
+Instead of iterating on a codemod by running it repeatedly on a codebase and seeing
+what happens, we can write a series of unit tests that assert on desired
+transformations. Given the above constant folding codemod that we wrote, we can test
+it with some code similar to the following::
+
+    from libcst.codemod import CodemodTest
+    from libcst.codemod.commands.constant_folding import ConvertConstantCommand
+
+
+    class TestConvertConstantCommand(CodemodTest):
+
+        # The codemod that will be instantiated for us in assertCodemod.
+        TRANSFORM = ConvertConstantCommand
+
+        def test_noop(self) -> None:
+            before = """
+                foo = "bar"
+            """
+            after = """
+                foo = "bar"
+            """
+
+            # Verify that if we don't have a valid string match, we don't make
+            # any substitutions.
+            self.assertCodemod(before, after, string="baz", constant="BAZ")
+
+        def test_substitution(self) -> None:
+            before = """
+                foo = "bar"
+            """
+            after = """
+                from utils.constants import BAR
+
+                foo = BAR
+            """
+
+            # Verify that if we do have a valid string match, we make a substitution
+            # as well as import the constant.
+            self.assertCodemod(before, after, string="bar", constant="BAR")
+
+If we save this as ``test_constant_folding.py`` inside ``libcst.codemod.commands.tests``
+then we can execute the tests with the following line::
+
+    python3 -m unittest libcst.codemod.commands.tests.test_constant_folding
+
+That's all there is to it!

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,6 +27,7 @@ LibCST
    Metadata <metadata_tutorial>
    Scope Analysis <scope_tutorial>
    Matchers <matchers_tutorial>
+   Codemodding <codemods_tutorial>
    Best Practices <best_practices>
 
 
@@ -39,6 +40,7 @@ LibCST
    visitors
    metadata
    matchers
+   codemods
    experimental
 
 

--- a/docs/source/scope_tutorial.ipynb
+++ b/docs/source/scope_tutorial.ipynb
@@ -6,6 +6,8 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
+    " .. _libcst-scope-tutorial:\n",
+    "\n",
     "==============\n",
     "Scope Analysis\n",
     "==============\n",

--- a/docs/source/tutorial.ipynb
+++ b/docs/source/tutorial.ipynb
@@ -6,9 +6,9 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "========\n",
-    "Tutorial\n",
-    "========\n",
+    "====================\n",
+    "Parsing and Visiting\n",
+    "====================\n",
     "\n",
     "LibCST provides helpers to parse source code string as concrete syntax tree. In order to perform static analysis to identify patterns in the tree or modify the tree programmatically, we can use visitor pattern to traverse the tree. In this tutorial, we demonstrate a common three-step-workflow to build an automated refactoring (codemod) application:\n",
     "\n",

--- a/libcst/codemod/_codemod.py
+++ b/libcst/codemod/_codemod.py
@@ -16,9 +16,16 @@ from libcst.codemod._context import CodemodContext
 class Codemod(MetadataDependent, ABC):
     """
     Abstract base class that all codemods must subclass from. Classes wishing
-    to perform arbitrary mutations on a tree should subclass from this. Classes
-    wishing to perform visitor-based mutation should instead subclass from
-    ContextAwareTransformer.
+    to perform arbitrary, non-visitor-based mutations on a tree should subclass
+    from this class directly. Classes wishing to perform visitor-based mutation
+    should instead subclass from :class:`~libcst.codemod.ContextAwareTransformer`.
+
+    Note that a :class:`~libcst.codemod.Codemod` is a subclass of
+    :class:`~libcst.MetadataDependent`, meaning that you can declare metadata
+    dependencies with the :attr:`~libcst.MetadataDependent.METADATA_DEPENDENCIES`
+    class property and while you are executing a transform you can call
+    :meth:`~libcst.MetadataDependent.get_metadata` to retrieve
+    the resolved metadata.
     """
 
     def __init__(self, context: CodemodContext) -> None:
@@ -27,20 +34,26 @@ class Codemod(MetadataDependent, ABC):
 
     def should_allow_multiple_passes(self) -> bool:
         """
-        Override this and return True to allow your transform to be called
+        Override this and return ``True`` to allow your transform to be called
         repeatedly until the tree doesn't change between passes. By default,
         this is off, and should suffice for most transforms.
         """
         return False
 
     def warn(self, warning: str) -> None:
+        """
+        Emit a warning that is displayed to the user who has invoked this codemod.
+        """
         self.context.warnings.append(warning)
 
     @property
     def module(self) -> Module:
         """
         Reference to the currently-traversed module. Note that this is only available
-        during a transform itself.
+        during the execution of a codemod. The module reference is particularly
+        handy if you want to use :meth:`libcst.Module.code_for_node` or
+        :attr:`libcst.Module.config_for_parsing` and don't wish to track a reference
+        to the top-level module manually.
         """
         module = self.context.module
         if module is None:
@@ -53,8 +66,9 @@ class Codemod(MetadataDependent, ABC):
     @abstractmethod
     def transform_module_impl(self, tree: Module) -> Module:
         """
-        Override this with your transform. You should take in the tree,
-        optionally mutate it and then return it.
+        Override this with your transform. You should take in the tree, optionally
+        mutate it and then return the mutated version. The module reference and all
+        calculated metadata are available for the lifetime of this function.
         """
         ...
 
@@ -74,8 +88,9 @@ class Codemod(MetadataDependent, ABC):
     def transform_module(self, tree: Module) -> Module:
         """
         Transform entrypoint which handles multi-pass logic and metadata calculation
-        for you. This is the method that you should call if you wish to
-        invoke a codemod directly.
+        for you. This is the method that you should call if you wish to invoke a
+        codemod directly. This is the method that is called by
+        :func:`~libcst.codemod.transform_module`.
         """
 
         if not self.should_allow_multiple_passes():

--- a/libcst/codemod/_context.py
+++ b/libcst/codemod/_context.py
@@ -14,32 +14,43 @@ import libcst as cst
 class CodemodContext:
     """
     A context holding all information that is shared amongst all transforms
-    in a single codemod invocation. When chaining multiple transforms together,
-    the context holds the state that needs to be passed between transforms.
-    The context is responsible for keeping track of metadata wrappers and the
-    filename of the file that is being modified (if available).
+    and visitors in a single codemod invocation. When chaining multiple
+    transforms together, the context holds the state that needs to be passed
+    between transforms. The context is responsible for keeping track of
+    metadata wrappers and the filename of the file that is being modified
+    (if available).
     """
 
-    # List of warnings gathered up while running a codemod. Add to this list
-    # by calling the `warn()` method on a transform.
+    #: List of warnings gathered while running a codemod. Add to this list
+    #: by calling :meth:`~libcst.codemod.Codemod.warn` method from a class
+    #: that subclasses from :class:`~libcst.codemod.Codemod`,
+    #: :class:`~libcst.codemod.ContextAwareTransformer` or
+    #: :class:`~libcst.codemod.ContextAwareVisitor`.
     warnings: List[str] = field(default_factory=list)
-    # Scratch dictionary available for codemods which spread across multiple
-    # transforms. Codemods are free to add to this at will.
+
+    #: Scratch dictionary available for codemods which are spread across multiple
+    #: transforms. Codemods are free to add to this at will.
     scratch: Dict[str, Any] = field(default_factory=dict)
-    # The current filename if a codemod is being executed against a file that
-    # lives on disk.
+
+    #: The current filename if a codemod is being executed against a file that
+    #: lives on disk. Populated by
+    #: :func:`libcst.codemod.parallel_exec_transform_with_prettyprint` when
+    #: running codemods from the command line.
     filename: Optional[str] = None
-    # The current top level metadata wrapper for the module being modified.
-    # To access computed metadata, use `self.get_metadata` to retrieve values
-    # when inside an actively running transform.
+
+    #: The current top level metadata wrapper for the module being modified.
+    #: To access computed metadata when inside an actively running codemod, use
+    #: the :meth:`~libcst.MetadataDependent.get_metadata` method on
+    #: :class:`~libcst.codemod.Codemod`.
     wrapper: Optional[cst.MetadataWrapper] = None
 
     @property
     def module(self) -> Optional[cst.Module]:
         """
         The current top level module being modified. As a convenience, you can
-        use `self.module` to refer to this when inside an actively running
-        transform.
+        use the :attr:`~libcst.codemod.Codemod.module` property on
+        :class:`~libcst.codemod.Codemod` to refer to this when inside an actively
+        running codemod.
         """
 
         wrapper = self.wrapper

--- a/libcst/codemod/visitors/_gather_imports.py
+++ b/libcst/codemod/visitors/_gather_imports.py
@@ -12,6 +12,44 @@ from libcst.codemod._visitor import ContextAwareVisitor
 
 
 class GatherImportsVisitor(ContextAwareVisitor):
+    """
+    Gathers all imports in a module and stores them as attributes on the instance.
+    Intended to be instantiated and passed to a :class:`~libcst.Module`
+    :meth:`~libcst.CSTNode.visit` method in order to gather up information about
+    imports on a module. Note that this is not a substitute for scope analysis or
+    qualified name support. Please see :ref:`libcst-scope-tutorial` for a more
+    robust way of determining the qualified name and definition for an arbitrary
+    node.
+
+    After visiting a module the following attributes will be populated:
+
+     module_imports
+      A sequence of strings representing modules that were imported directly, such as
+      in the case of ``import typing``. Each module directly imported but not aliased
+      will be included here.
+     object_mapping
+      A mapping of strings to sequences of strings representing modules where we
+      imported objects from, such as in the case of ``from typing import Optional``.
+      Each from import that was not aliased will be included here, where the keys of
+      the mapping are the module we are importing from, and the value is a
+      sequence of objects we are importing from the module.
+     module_aliases
+      A mapping of strings representing modules that were imported and aliased,
+      such as in the case of ``import typing as t``. Each module imported this
+      way will be represented as a key in this mapping, and the value will be
+      the local alias of the module.
+     alias_mapping
+      A mapping of strings to sequences of tuples representing modules where we
+      imported objects from and aliased using ``as`` syntax, such as in the case
+      of ``from typing import Optional as opt``. Each from import that was aliased
+      will be included here, where the keys of the mapping are the module we are
+      importing from, and the value is a tuple representing the original object
+      name and the alias.
+     all_imports
+      A collection of all :class:`~libcst.Import` and :class:`~libcst.ImportFrom`
+      statements that were encountered in the module.
+    """
+
     def __init__(self, context: CodemodContext) -> None:
         super().__init__(context)
         # Track the available imports in this transform

--- a/libcst/helpers/module.py
+++ b/libcst/helpers/module.py
@@ -11,7 +11,12 @@ import libcst
 
 
 def insert_header_comments(node: libcst.Module, comments: List[str]) -> libcst.Module:
-    """Insert comments after last non-empty line in header."""
+    """
+    Insert comments after last non-empty line in header. Use this to insert one or more
+    comments after any copyright preamble in a :class:`~libcst.Module`. Each comment in
+    the list of ``comments`` must start with a ``#`` and will be placed on its own line
+    in the appropriate location.
+    """
     # Split the lines up into a contiguous comment-containing section and
     # the empty whitespace section that follows
     last_comment_index = -1


### PR DESCRIPTION
## Summary

Add documentation for ``libcst.tool``, and ``libcst.codemod`` directory. This includes full documentation for Codemods, CodemodCommands, the CLI, helper functions and the current set of transforms in our transform library and helpers.

## Test Plan

`tox -e docs`, this is far too much documentation to screenshot so please look at the generated docs in the CI artifacts.