### PR TITLE
Upgrade pyre-check version

### DIFF
--- a/libcst/_parser/conversions/expression.py
+++ b/libcst/_parser/conversions/expression.py
@@ -787,10 +787,15 @@ def convert_subscript(
             lower=lower.value if lower is not None else None,
             first_colon=Colon(
                 whitespace_before=parse_parenthesizable_whitespace(
-                    config, first_colon.whitespace_before
+                    config,
+                    # pyre-fixme[16]: Optional type has no attribute
+                    #  `whitespace_before`.
+                    first_colon.whitespace_before,
                 ),
                 whitespace_after=parse_parenthesizable_whitespace(
-                    config, first_colon.whitespace_after
+                    config,
+                    # pyre-fixme[16]: Optional type has no attribute `whitespace_after`.
+                    first_colon.whitespace_after,
                 ),
             ),
             upper=upper.value if upper is not None else None,
@@ -1195,7 +1200,9 @@ def _convert_sequencelike(
 
     # lpar/rpar are the responsibility of our parent
     return WithLeadingWhitespace(
-        sequence_type(elements, lpar=(), rpar=()), children[0].whitespace_before
+        # pyre-ignore[29]: `Union[Type[List], Type[Set], Type[Tuple]]` is not a function.
+        sequence_type(elements, lpar=(), rpar=()),
+        children[0].whitespace_before,
     )
 
 

--- a/libcst/_position.py
+++ b/libcst/_position.py
@@ -47,6 +47,8 @@ class CodeRange:
     def __init__(self, start: Tuple[int, int], end: Tuple[int, int]) -> None:
         ...
 
+    # pyre-ignore[13]: Attribute `end` is never initialized.
+    # pyre-ignore[13]: Attribute `start` is never initialized.
     def __init__(self, start: _CodePositionT, end: _CodePositionT) -> None:
         if isinstance(start, tuple) and isinstance(end, tuple):
             object.__setattr__(self, "start", CodePosition(start[0], start[1]))

--- a/libcst/_type_enforce.py
+++ b/libcst/_type_enforce.py
@@ -72,7 +72,6 @@ def is_value_of_type(  # noqa: C901 "too complex"
             literal_values = get_args(expected_type, evaluate=True)
         return any(value == literal for literal in literal_values)
 
-    # pyre-fixme[16]: Module `typing` has no attribute `ForwardRef`.
     elif isinstance(expected_origin_type, ForwardRef):
         # not much we can do here for now, lets just return :(
         return True

--- a/libcst/codegen/gather.py
+++ b/libcst/codegen/gather.py
@@ -119,7 +119,6 @@ def _get_args(typeobj: object) -> List[object]:
 
 def _is_sequence(typeobj: object) -> bool:
     origin = _get_origin(typeobj)
-    # pyre-ignore Pyre doesn't know about collections.abc.Sequence
     return origin is Sequence or origin is ABCSequence
 
 

--- a/libcst/codemod/commands/tests/test_convert_format_to_fstring.py
+++ b/libcst/codemod/commands/tests/test_convert_format_to_fstring.py
@@ -155,7 +155,7 @@ class ConvertFormatStringCommandTest(CodemodTest):
         self.assertCodemod(
             before,
             after,
-            expected_warnings=["Unsupported format_spec #0{1}x in format() call",],
+            expected_warnings=["Unsupported format_spec #0{1}x in format() call"],
         )
 
     def test_position_replacement(self) -> None:

--- a/libcst/tool.py
+++ b/libcst/tool.py
@@ -601,7 +601,7 @@ def _initialize_impl(proc_name: str, command_args: List[str]) -> int:
             + "filenames to determine if the module should be touched."
         ),
         "modules": _ListSerializer(
-            "List of modules that contain codemods inside of them.", newlines=True,
+            "List of modules that contain codemods inside of them.", newlines=True
         ),
     }
 
@@ -627,7 +627,7 @@ def _list_impl(proc_name: str, command_args: List[str]) -> int:  # noqa: C901
     config = _find_and_load_config()
 
     parser = argparse.ArgumentParser(
-        description="List all codemods available to run.", prog=f"{proc_name} list",
+        description="List all codemods available to run.", prog=f"{proc_name} list"
     )
     _ = parser.parse_args(command_args)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,6 @@ git+https://github.com/jimmylai/sphinx.git@slots_type_annotation
 isort==4.3.20
 jupyter==1.0.0
 nbsphinx==0.4.2
-pyre-check==0.0.32
+pyre-check==0.0.33
 sphinx-rtd-theme==0.4.3
 prompt-toolkit==2.0.9


### PR DESCRIPTION
## Summary
Upgrade pyre-check version. Pyre has new version 0.0.33, upgrading to it to test type checking.
CC @shannonzhu
We expect pyre-check to have a newer version later today. Will bump the version to 0.0.34 when the new version is available.

## Test Plan
Existing type checking.