### PR TITLE
Version override in libcst.tool

### DIFF
--- a/libcst/codemod/_runner.py
+++ b/libcst/codemod/_runner.py
@@ -12,9 +12,9 @@ Provides everything needed to run a CodemodCommand.
 import traceback
 from dataclasses import dataclass
 from enum import Enum
-from typing import Sequence, Union
+from typing import Optional, Sequence, Union
 
-from libcst import parse_module
+from libcst import PartialParserConfig, parse_module
 from libcst.codemod._codemod import Codemod
 
 
@@ -115,7 +115,9 @@ TransformResult = Union[
 ]
 
 
-def transform_module(transformer: Codemod, code: str) -> TransformResult:
+def transform_module(
+    transformer: Codemod, code: str, *, python_version: Optional[str] = None
+) -> TransformResult:
     """
     Given a module as represented by a string and a :class:`~libcst.codemod.Codemod`
     that we wish to run, execute the codemod on the code and return a
@@ -132,7 +134,14 @@ def transform_module(transformer: Codemod, code: str) -> TransformResult:
     codemod crashed.
     """
     try:
-        input_tree = parse_module(code)
+        input_tree = parse_module(
+            code,
+            config=(
+                PartialParserConfig(python_version=python_version)
+                if python_version is not None
+                else PartialParserConfig()
+            ),
+        )
         output_tree = transformer.transform_module(input_tree)
         return TransformSuccess(
             code=output_tree.code, warning_messages=transformer.context.warnings

--- a/libcst/codemod/_testing.py
+++ b/libcst/codemod/_testing.py
@@ -70,7 +70,7 @@ class _CodemodTest:
         after: str,
         *args: object,
         context_override: Optional[CodemodContext] = None,
-        python_version: str = "3.7",
+        python_version: Optional[str] = None,
         expected_warnings: Optional[Sequence[str]] = None,
         expected_skip: bool = False,
         **kwargs: object,
@@ -85,7 +85,11 @@ class _CodemodTest:
         transform_instance = self.TRANSFORM(context, *args, **kwargs)
         input_tree = parse_module(
             CodemodTest.make_fixture_data(before),
-            config=PartialParserConfig(python_version=python_version),
+            config=(
+                PartialParserConfig(python_version=python_version)
+                if python_version is not None
+                else PartialParserConfig()
+            ),
         )
         try:
             output_tree = transform_instance.transform_module(input_tree)

--- a/libcst/codemod/commands/tests/test_convert_format_to_fstring.py
+++ b/libcst/codemod/commands/tests/test_convert_format_to_fstring.py
@@ -138,6 +138,8 @@ class ConvertFormatStringCommandTest(CodemodTest):
                 "Unsupported backslash in format expression",
                 "Unsupported await in format() call",
             ],
+            # await isn't supported inside functions in 3.6
+            python_version="3.7",
         )
 
     def test_unsupported_formatspec(self) -> None:

--- a/libcst/tool.py
+++ b/libcst/tool.py
@@ -407,6 +407,17 @@ def _codemod_impl(proc_name: str, command_args: List[str]) -> int:  # noqa: C901
         default=None,
     )
     parser.add_argument(
+        "-p",
+        "--python-version",
+        metavar="VERSION",
+        help=(
+            "Override the version string used for parsing Python source files. Defaults "
+            + "to the version of python used to run this tool."
+        ),
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
         "-u",
         "--unified-diff",
         metavar="CONTEXT",
@@ -459,6 +470,7 @@ def _codemod_impl(proc_name: str, command_args: List[str]) -> int:  # noqa: C901
             "path",
             "unified_diff",
             "jobs",
+            "python_version",
             "include_generated",
             "include_stubs",
             "no_format",
@@ -484,6 +496,7 @@ def _codemod_impl(proc_name: str, command_args: List[str]) -> int:  # noqa: C901
             generated_code_marker=config["generated_code_marker"],
             format_code=not args.no_format,
             formatter_args=config["formatter"],
+            python_version=args.python_version,
         )
         if not newcode:
             print("Failed to codemod from stdin", file=sys.stderr)
@@ -513,6 +526,7 @@ def _codemod_impl(proc_name: str, command_args: List[str]) -> int:  # noqa: C901
             hide_blacklisted=args.hide_blacklisted_warnings,
             hide_progress=args.hide_progress,
             blacklist_patterns=config["blacklist_patterns"],
+            python_version=args.python_version,
         )
     except KeyboardInterrupt:
         print("Interrupted!", file=sys.stderr)


### PR DESCRIPTION
## Summary

Allow python version overrides for various libcst.codemod transformation utilities and plumb that out to the command-line. As a bonus, this gets rid of a render/parse loop for multi-pass codemods since we are 100% sure now that metadata calculation results in a unique tree.

## Test Plan

tox, pyre