### PR TITLE
Use qualified name scope in string replacement codemod

### DIFF
--- a/libcst/codemod/commands/tests/test_strip_strings_from_types.py
+++ b/libcst/codemod/commands/tests/test_strip_strings_from_types.py
@@ -142,3 +142,90 @@ class TestStripStringsCodemod(CodemodTest):
         """
 
         self.assertCodemod(before, after)
+
+    def test_literal_alias(self) -> None:
+        before = """
+            from typing_extensions import Literal as Lit
+
+            class Class:
+                pass
+
+            def foo(a: Lit["one", "two", "three"]):
+                pass
+
+            def bar(a: Union["Class", Lit["one", "two", "three"]]):
+                pass
+        """
+        after = """
+            from __future__ import annotations
+            from typing_extensions import Literal as Lit
+
+            class Class:
+                pass
+
+            def foo(a: Lit["one", "two", "three"]):
+                pass
+
+            def bar(a: Union[Class, Lit["one", "two", "three"]]):
+                pass
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_literal_object(self) -> None:
+        before = """
+            import typing_extensions
+
+            class Class:
+                pass
+
+            def foo(a: typing_extensions.Literal["one", "two", "three"]):
+                pass
+
+            def bar(a: Union["Class", typing_extensions.Literal["one", "two", "three"]]):
+                pass
+        """
+        after = """
+            from __future__ import annotations
+            import typing_extensions
+
+            class Class:
+                pass
+
+            def foo(a: typing_extensions.Literal["one", "two", "three"]):
+                pass
+
+            def bar(a: Union[Class, typing_extensions.Literal["one", "two", "three"]]):
+                pass
+        """
+
+        self.assertCodemod(before, after)
+
+    def test_literal_object_alias(self) -> None:
+        before = """
+            import typing_extensions as typext
+
+            class Class:
+                pass
+
+            def foo(a: typext.Literal["one", "two", "three"]):
+                pass
+
+            def bar(a: Union["Class", typext.Literal["one", "two", "three"]]):
+                pass
+        """
+        after = """
+            from __future__ import annotations
+            import typing_extensions as typext
+
+            class Class:
+                pass
+
+            def foo(a: typext.Literal["one", "two", "three"]):
+                pass
+
+            def bar(a: Union[Class, typext.Literal["one", "two", "three"]]):
+                pass
+        """
+
+        self.assertCodemod(before, after)


### PR DESCRIPTION
## Summary

As it says on the tin. We don't have a good example of this in open-source codemods. Also, the codemod itself is more incorrect without than with, so lets fix that by adding this!

## Test Plan

Existing tests (which include literal support tests) and a few new ones to show off that this does indeed capture what we want it to.