### PR TITLE
Remove unused parentheses and fix broken usage link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,7 @@ BinaryOperation(
 )
 
 For a more detailed usage example, `see our documentation 
-<https://libcst.readthedocs.io/en/latest/usage.html>`__.
+<https://libcst.readthedocs.io/en/latest/tutorial.html>`__.
 
 Installation
 ------------

--- a/libcst/tests/test_pyre_integration.py
+++ b/libcst/tests/test_pyre_integration.py
@@ -167,7 +167,7 @@ if __name__ == "__main__":
         print(stdout)
         print(stderr)
 
-    for path in (TEST_SUITE_PATH).glob("*.py"):
+    for path in TEST_SUITE_PATH.glob("*.py"):
         cmd = f'''pyre query "types(path='{path}')"'''
         print(cmd)
         stdout, stderr, return_code = _run_command(cmd)


### PR DESCRIPTION
as title.
https://libcst.readthedocs.io/en/latest/usage.html is renamed and it's 404 now.