### PR TITLE
run pyre codegen in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,8 @@ jobs:
             pip install --upgrade pip
             pip install -r requirements.txt -r requirements-dev.txt
             pyre check
+            PYTHONPATH=`pwd` python libcst/tests/test_pyre_integration.py
+            git diff --exit-code  # verify no generated changes
       - save_cache:
           key: pyre-v1-{{ checksum "tox.ini" }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "setup.py" }}-{{ checksum ".circleci/config.yml" }}
           paths:

--- a/libcst/tests/test_pyre_integration.py
+++ b/libcst/tests/test_pyre_integration.py
@@ -130,7 +130,7 @@ if __name__ == "__main__":
     stdout: str
     stderr: str
     return_code: int
-    stdout, stderr, return_code = run_command("pyre")
+    stdout, stderr, return_code = run_command("pyre start")
     if return_code != 0:
         print(stdout)
         print(stderr)
@@ -144,7 +144,7 @@ if __name__ == "__main__":
             print(stderr)
         data = json.loads(stdout)
         data = data["response"][0]
-        _process_pyre_data(data)
+        data = _process_pyre_data(data)
         output_path = path.with_suffix(".json")
         print(f"write output to {output_path}")
         output_path.write_text(json.dumps(data, indent=2))


### PR DESCRIPTION
## Summary
Run pyre codegen in CI to make sure Pyre codegen changes are always reviewed and committed proactively.

Pyre query depends on Pyre server. We start Pyre server in the codegen script before querying.

## Test Plan
CI job run.
When no changes are generated. Pyre job passed. https://app.circleci.com/jobs/github/Instagram/LibCST/4887/parallel-runs/0/steps/0-103

When changes are generated. Pyre job failed.
https://app.circleci.com/jobs/github/Instagram/LibCST/4900/parallel-runs/0/steps/0-103