### PR TITLE
Use Pyre strict mode in Pyre test suite

### DIFF
--- a/libcst/metadata/tests/test_type_inference_provider.py
+++ b/libcst/metadata/tests/test_type_inference_provider.py
@@ -26,13 +26,15 @@ def _test_simple_class_helper(test: UnitTest, wrapper: MetadataWrapper) -> None:
             ).body.body[0],
             cst.SimpleStatementLine,
         ).body[0],
-        cst.Assign,
+        cst.AnnAssign,
     )
-    self_number_attr = cst.ensure_type(assign.targets[0].target, cst.Attribute,)
+    self_number_attr = cst.ensure_type(assign.target, cst.Attribute)
     # TODO: uncomment when typing issue is fixed
     # self.assertEqual(types[self_number_attr], "int")
 
-    test.assertEqual(types[assign.value], "int")
+    value = assign.value
+    if value:
+        test.assertEqual(types[value], "int")
 
     # self
     test.assertEqual(
@@ -44,9 +46,9 @@ def _test_simple_class_helper(test: UnitTest, wrapper: MetadataWrapper) -> None:
     collector = collector_assign.targets[0].target
     test.assertEqual(types[collector], "libcst.tests.pyre.simple_class.ItemCollector")
     items_assign = cst.ensure_type(
-        cst.ensure_type(m.body[4], cst.SimpleStatementLine).body[0], cst.Assign
+        cst.ensure_type(m.body[4], cst.SimpleStatementLine).body[0], cst.AnnAssign
     )
-    items = items_assign.targets[0].target
+    items = items_assign.target
     test.assertEqual(
         types[items], "typing.Sequence[libcst.tests.pyre.simple_class.Item]"
     )

--- a/libcst/tests/pyre/simple_class.json
+++ b/libcst/tests/pyre/simple_class.json
@@ -4,11 +4,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 7,
+          "line": 8,
           "column": 19
         },
         "stop": {
-          "line": 7,
+          "line": 8,
           "column": 27
         }
       },
@@ -18,11 +18,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 10,
+          "line": 11,
           "column": 6
         },
         "stop": {
-          "line": 10,
+          "line": 11,
           "column": 10
         }
       },
@@ -32,11 +32,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 11,
+          "line": 12,
           "column": 8
         },
         "stop": {
-          "line": 11,
+          "line": 12,
           "column": 16
         }
       },
@@ -46,11 +46,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 11,
+          "line": 12,
           "column": 17
         },
         "stop": {
-          "line": 11,
+          "line": 12,
           "column": 21
         }
       },
@@ -60,11 +60,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 11,
+          "line": 12,
           "column": 23
         },
         "stop": {
-          "line": 11,
+          "line": 12,
           "column": 24
         }
       },
@@ -74,11 +74,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 11,
+          "line": 12,
           "column": 26
         },
         "stop": {
-          "line": 11,
+          "line": 12,
           "column": 29
         }
       },
@@ -88,11 +88,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 11,
+          "line": 12,
           "column": 34
         },
         "stop": {
-          "line": 11,
+          "line": 12,
           "column": 38
         }
       },
@@ -102,11 +102,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 12,
+          "line": 13,
           "column": 8
         },
         "stop": {
-          "line": 12,
+          "line": 13,
           "column": 12
         }
       },
@@ -116,12 +116,12 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 12,
-          "column": 22
+          "line": 13,
+          "column": 8
         },
         "stop": {
-          "line": 12,
-          "column": 23
+          "line": 13,
+          "column": 19
         }
       },
       "annotation": "int"
@@ -130,11 +130,39 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 15,
+          "line": 13,
+          "column": 21
+        },
+        "stop": {
+          "line": 13,
+          "column": 24
+        }
+      },
+      "annotation": "typing.Type[int]"
+    },
+    {
+      "location": {
+        "path": "libcst/tests/pyre/simple_class.py",
+        "start": {
+          "line": 13,
+          "column": 27
+        },
+        "stop": {
+          "line": 13,
+          "column": 28
+        }
+      },
+      "annotation": "int"
+    },
+    {
+      "location": {
+        "path": "libcst/tests/pyre/simple_class.py",
+        "start": {
+          "line": 16,
           "column": 6
         },
         "stop": {
-          "line": 15,
+          "line": 16,
           "column": 19
         }
       },
@@ -144,11 +172,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 16,
+          "line": 17,
           "column": 8
         },
         "stop": {
-          "line": 16,
+          "line": 17,
           "column": 17
         }
       },
@@ -158,11 +186,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 16,
+          "line": 17,
           "column": 18
         },
         "stop": {
-          "line": 16,
+          "line": 17,
           "column": 22
         }
       },
@@ -172,11 +200,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 16,
+          "line": 17,
           "column": 24
         },
         "stop": {
-          "line": 16,
+          "line": 17,
           "column": 25
         }
       },
@@ -186,11 +214,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 16,
+          "line": 17,
           "column": 27
         },
         "stop": {
-          "line": 16,
+          "line": 17,
           "column": 30
         }
       },
@@ -200,11 +228,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 16,
+          "line": 17,
           "column": 35
         },
         "stop": {
-          "line": 16,
+          "line": 17,
           "column": 43
         }
       },
@@ -214,11 +242,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 16,
+          "line": 17,
           "column": 35
         },
         "stop": {
-          "line": 16,
+          "line": 17,
           "column": 49
         }
       },
@@ -228,11 +256,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 16,
+          "line": 17,
           "column": 44
         },
         "stop": {
-          "line": 16,
+          "line": 17,
           "column": 48
         }
       },
@@ -242,11 +270,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 17,
+          "line": 18,
           "column": 15
         },
         "stop": {
-          "line": 17,
+          "line": 18,
           "column": 42
         }
       },
@@ -256,11 +284,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 17,
+          "line": 18,
           "column": 16
         },
         "stop": {
-          "line": 17,
+          "line": 18,
           "column": 20
         }
       },
@@ -270,11 +298,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 17,
+          "line": 18,
           "column": 16
         },
         "stop": {
-          "line": 17,
+          "line": 18,
           "column": 23
         }
       },
@@ -284,11 +312,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 17,
+          "line": 18,
           "column": 28
         },
         "stop": {
-          "line": 17,
+          "line": 18,
           "column": 29
         }
       },
@@ -298,11 +326,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 17,
+          "line": 18,
           "column": 33
         },
         "stop": {
-          "line": 17,
+          "line": 18,
           "column": 38
         }
       },
@@ -312,11 +340,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 17,
+          "line": 18,
           "column": 33
         },
         "stop": {
-          "line": 17,
+          "line": 18,
           "column": 41
         }
       },
@@ -326,11 +354,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 17,
+          "line": 18,
           "column": 39
         },
         "stop": {
-          "line": 17,
+          "line": 18,
           "column": 40
         }
       },
@@ -340,11 +368,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 20,
+          "line": 21,
           "column": 0
         },
         "stop": {
-          "line": 20,
+          "line": 21,
           "column": 9
         }
       },
@@ -354,11 +382,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 20,
+          "line": 21,
           "column": 12
         },
         "stop": {
-          "line": 20,
+          "line": 21,
           "column": 25
         }
       },
@@ -368,11 +396,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 20,
+          "line": 21,
           "column": 12
         },
         "stop": {
-          "line": 20,
+          "line": 21,
           "column": 27
         }
       },
@@ -382,11 +410,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 21,
+          "line": 22,
           "column": 0
         },
         "stop": {
-          "line": 21,
+          "line": 22,
           "column": 5
         }
       },
@@ -396,12 +424,26 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 21,
-          "column": 8
+          "line": 22,
+          "column": 7
         },
         "stop": {
-          "line": 21,
-          "column": 17
+          "line": 22,
+          "column": 21
+        }
+      },
+      "annotation": "typing.Type[typing.Sequence[libcst.tests.pyre.simple_class.Item]]"
+    },
+    {
+      "location": {
+        "path": "libcst/tests/pyre/simple_class.py",
+        "start": {
+          "line": 22,
+          "column": 24
+        },
+        "stop": {
+          "line": 22,
+          "column": 33
         }
       },
       "annotation": "libcst.tests.pyre.simple_class.ItemCollector"
@@ -410,12 +452,12 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 21,
-          "column": 8
+          "line": 22,
+          "column": 24
         },
         "stop": {
-          "line": 21,
-          "column": 27
+          "line": 22,
+          "column": 43
         }
       },
       "annotation": "typing.Callable(libcst.tests.pyre.simple_class.ItemCollector.get_items)[[Named(n, int)], typing.Sequence[libcst.tests.pyre.simple_class.Item]]"
@@ -424,12 +466,12 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 21,
-          "column": 8
+          "line": 22,
+          "column": 24
         },
         "stop": {
-          "line": 21,
-          "column": 30
+          "line": 22,
+          "column": 46
         }
       },
       "annotation": "typing.Sequence[libcst.tests.pyre.simple_class.Item]"
@@ -438,12 +480,12 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 21,
-          "column": 28
+          "line": 22,
+          "column": 44
         },
         "stop": {
-          "line": 21,
-          "column": 29
+          "line": 22,
+          "column": 45
         }
       },
       "annotation": "typing_extensions.Literal[3]"
@@ -452,11 +494,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 22,
+          "line": 23,
           "column": 4
         },
         "stop": {
-          "line": 22,
+          "line": 23,
           "column": 8
         }
       },
@@ -466,11 +508,11 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 22,
+          "line": 23,
           "column": 12
         },
         "stop": {
-          "line": 22,
+          "line": 23,
           "column": 17
         }
       },
@@ -480,15 +522,29 @@
       "location": {
         "path": "libcst/tests/pyre/simple_class.py",
         "start": {
-          "line": 23,
+          "line": 24,
           "column": 4
         },
         "stop": {
-          "line": 23,
+          "line": 24,
           "column": 8
         }
       },
       "annotation": "libcst.tests.pyre.simple_class.Item"
+    },
+    {
+      "location": {
+        "path": "libcst/tests/pyre/simple_class.py",
+        "start": {
+          "line": 24,
+          "column": 4
+        },
+        "stop": {
+          "line": 24,
+          "column": 15
+        }
+      },
+      "annotation": "int"
     }
   ]
 }

--- a/libcst/tests/pyre/simple_class.py
+++ b/libcst/tests/pyre/simple_class.py
@@ -3,13 +3,14 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-strict
 # fmt: off
 from typing import Sequence
 
 
 class Item:
     def __init__(self, n: int) -> None:
-        self.number = n
+        self.number: int = n
 
 
 class ItemCollector:
@@ -18,6 +19,6 @@ class ItemCollector:
 
 
 collector = ItemCollector()
-items = collector.get_items(3)
+items: Sequence[Item] = collector.get_items(3)
 for item in items:
     item.number

--- a/libcst/tests/test_pyre_integration.py
+++ b/libcst/tests/test_pyre_integration.py
@@ -43,18 +43,11 @@ class TypeVerificationVisitor(cst.CSTVisitor):
         tup = (start.line, start.column, end.line, end.column)
 
         # remove this if condition when the type issues are fixed.
-        if not any(
-            node.deep_equals(name)
-            for name in {
-                cst.Attribute(cst.Name("self"), attr=cst.Name("number")),
-                cst.Attribute(cst.Name("item"), attr=cst.Name("number")),
-            }
-        ):
-            self.test.assertIn(
-                tup,
-                self.lookup,
-                f"Attribute node {node} at {tup} found without inferred type.",
-            )
+        self.test.assertIn(
+            tup,
+            self.lookup,
+            f"Attribute node {node} at {tup} found without inferred type.",
+        )
 
     def leave_Attribute(self, original_node: cst.Attribute) -> None:
         self.attributes.pop()
@@ -73,7 +66,7 @@ class TypeVerificationVisitor(cst.CSTVisitor):
         # remove this if condition when the type issues are fixed.
         if not any(
             node.deep_equals(name) and tup == _tup
-            for (name, _tup) in {(cst.Name("i"), (17, 21, 17, 22)),}
+            for (name, _tup) in {(cst.Name("i"), (18, 21, 18, 22)),}
         ):
             self.test.assertIn(
                 tup,


### PR DESCRIPTION
## Summary
Based on feedback in https://github.com/Instagram/LibCST/pull/172/files, change to use strict mode for better test cases.
## Test Plan
Unit tests.

