### PR TITLE
Bump LibCST to 0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
+# 0.2.7 - 2020-01-07
+
+## Updated
+
+ - Command-line interface now shows rough estimate of time remaining while executing a codemod.
+ - Add needed import now supports import aliases.
+
 # 0.2.6 - 2020-01-01
 
 ## Added
+
  - Added Codemod framework for running code transform over a codebase in parallel.
    - Codemod for code transform logic.
    - CodemodContext for preserving states across transforms.
@@ -12,10 +20,12 @@
  - Added FullRepoManager for metadata inter-process cache handing.
 
 ## Fixed
+
  - Fixed usage link in README.
  - Fixed type annotation for Mypy compatibility.
 
 ## Updated
+
  - Upgraded Pyre to 0.0.38
 
 # 0.2.5 - 2019-12-05

--- a/README.rst
+++ b/README.rst
@@ -188,7 +188,6 @@ Future
 ======
 
 - Python 3.8 support, both in running on Python 3.8 and parsing 3.8 code.
-- Additional layer providing command-line frontend for executing refactors.
 - Advanced full repository facts providers like fully qualified name and call graph.
 
 License

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     description="A concrete syntax tree with AST-like properties for Python 3.5, 3.6 and 3.7 programs.",
     long_description=long_description,
     long_description_content_type="text/x-rst",
-    version="0.2.6",
+    version="0.2.7",
     url="https://github.com/Instagram/LibCST",
     license="MIT",
     packages=setuptools.find_packages(),


### PR DESCRIPTION
## Summary

Minor version bump to include a few things that were modified over the break. This brings open-source up to date with the internal version of libcst.codemod, which will be going away soon.

## Test Plan

tox, pyre