### PR TITLE
Add docs for CodemodTest

### DIFF
--- a/docs/source/codemods.rst
+++ b/docs/source/codemods.rst
@@ -40,6 +40,16 @@ emitted up to the exception being thrown will be preserved in the result.
 
 .. autoclass:: libcst.codemod.SkipFile
 
+Finally, its often easier to test codemods by writing verification tests instead of
+running repeatedly on your project. LibCST makes this easy with
+:class:`~libcst.codemod.CodemodTest`. Often you can develop the majority of your
+codemod using just tests, augmenting functionality when you run into an unexpected
+edge case when running it against your repository.
+
+.. autoclass:: libcst.codemod.CodemodTest
+  :inherited-members:
+  :exclude-members: addCleanup, addTypeEqualityFunc, assertAlmostEqual, assertAlmostEquals, assertCountEqual, assertDictContainsSubset, assertDictEqual, assertEqual, assertEquals, assertFalse, assertGreater, assertGreaterEqual, assertIn, assertIs, assertIsInstance, assertIsNone, assertIsNot, assertIsNotNone, assertLess, assertLessEqual, assertListEqual, assertLogs, assertMultiLineEqual, assertNotAlmostEqual, assertNotAlmostEquals, assertNotEqual, assertNotEquals, assertNotIn, assertNotIsInstance, assertNotRegex, assertNotRegexpMatches, assertRaises, assertRaisesRegex, assertRaisesRegexp, assertRegex, assertRegexpMatches, assertSequenceEqual, assertSetEqual, assertTrue, assertTupleEqual, assertWarns, assertWarnsRegex, assert_, countTestCases, debug, defaultTestResult, doCleanups, fail, failIf, failIfAlmostEqual, failIfEqual, failUnless, failUnlessAlmostEqual, failUnlessEqual, failUnlessRaises, failureException, id, longMessage, maxDiff, run, setUp, classmethod, setUpClass, shortDescription, skipTest, subTest, tearDown, tearDownClass
+
 -------------------
 Execution Interface
 -------------------

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -187,12 +187,12 @@ We provide :class:`~libcst.metadata.ParentNodeProvider` for those use cases.
 
 Type Inference Metadata
 -----------------------
-`Type inference <https://en.wikipedia.org/wiki/Type_inference>`_ is to automatically infer
+`Type inference <https://en.wikipedia.org/wiki/Type_inference>`__ is to automatically infer
 data types of expression for deeper understanding source code.
 In Python, type checkers like `Mypy <https://github.com/python/mypy>`_ or
-`Pyre <https://pyre-check.org/>`_ analyze `type annotations <https://docs.python.org/3/library/typing.html>`_
+`Pyre <https://pyre-check.org/>`__ analyze `type annotations <https://docs.python.org/3/library/typing.html>`__
 and infer types for expressions.
-:class:`~libcst.metadata.TypeInferenceProvider` is provided by `Pyre Query API <https://pyre-check.org/docs/querying-pyre.html>`_
+:class:`~libcst.metadata.TypeInferenceProvider` is provided by `Pyre Query API <https://pyre-check.org/docs/querying-pyre.html>`__
 which requires `setup watchman <https://pyre-check.org/docs/watchman-integration.html>`_ for incremental typechecking.
 :class:`~libcst.metadata.FullRepoManger` is built for manage the inter process communication to Pyre.
 

--- a/libcst/metadata/position_provider.py
+++ b/libcst/metadata/position_provider.py
@@ -127,9 +127,7 @@ class PositionProvider(BaseMetadataProvider[CodeRange]):
     significant.
 
     The positions provided by this provider should eventually match the positions used
-    by Pyre_ for equivalent nodes.
-
-    .. _Pyre: https://github.com/facebook/pyre-check
+    by `Pyre <https://github.com/facebook/pyre-check>`__ for equivalent nodes.
     """
 
     def _gen_impl(self, module: Module) -> None:


### PR DESCRIPTION
## Summary

Add docs for `CodemodTest`, so that people know how to test their codemods. Unfortunately it looks like sphinx cannot both include inherited members AND specify an explicit list of members, so in order to get documentation to show up right for this class I had to explicitly opt out all of `Unittest`. What a pain. However, it works, and the documentation rendering properly is more important than the code looking nice.

I also fixed the warnings that crept into the docs process during this PR.

## Test Plan

tox -e docs, verified no errors, verified docs rendered right.

![codemodtest](https://user-images.githubusercontent.com/421365/72023008-a664ee80-3226-11ea-8f8a-e5768ef3a377.png)