### PR TITLE
Remove deprecated position provider objects

### DIFF
--- a/docs/source/scope_tutorial.ipynb
+++ b/docs/source/scope_tutorial.ipynb
@@ -90,7 +90,7 @@
    "source": [
     "Warn on unused imports and undefined references\n",
     "===============================================\n",
-    "To find all unused imports, we iterate through :attr:`~libcst.metadata.Scope.assignments` and an assignment is unused when its :attr:`~libcst.metadata.BaseAssignment.references` is empty. To find all undefined references, we iterate through :attr:`~libcst.metadata.Scope.accesses` (we focus on :class:`~libcst.Import`/:class:`~libcst.ImportFrom` assignments) and an access is undefined reference when its :attr:`~libcst.metadata.Access.referents` is empty. When reporting the warning to developer, we'll want to report the line number and column offset along with the suggestion to make it more clear. We can get position information from :class:`~libcst.metadata.SyntacticPositionProvider` and print the warnings as follows.\n"
+    "To find all unused imports, we iterate through :attr:`~libcst.metadata.Scope.assignments` and an assignment is unused when its :attr:`~libcst.metadata.BaseAssignment.references` is empty. To find all undefined references, we iterate through :attr:`~libcst.metadata.Scope.accesses` (we focus on :class:`~libcst.Import`/:class:`~libcst.ImportFrom` assignments) and an access is undefined reference when its :attr:`~libcst.metadata.Access.referents` is empty. When reporting the warning to developer, we'll want to report the line number and column offset along with the suggestion to make it more clear. We can get position information from :class:`~libcst.metadata.PositionProvider` and print the warnings as follows.\n"
    ]
   },
   {
@@ -104,7 +104,7 @@
     "\n",
     "unused_imports: Dict[Union[cst.Import, cst.ImportFrom], Set[str]] = defaultdict(set)\n",
     "undefined_references: Dict[cst.CSTNode, Set[str]] = defaultdict(set)\n",
-    "ranges = wrapper.resolve(cst.metadata.SyntacticPositionProvider)\n",
+    "ranges = wrapper.resolve(cst.metadata.PositionProvider)\n",
     "for scope in scopes:\n",
     "    for assignment in scope.assignments:\n",
     "        node = assignment.node\n",

--- a/libcst/codemod/tests/test_metadata.py
+++ b/libcst/codemod/tests/test_metadata.py
@@ -9,25 +9,25 @@ from textwrap import dedent
 import libcst as cst
 from libcst import parse_module
 from libcst.codemod import CodemodContext, ContextAwareTransformer, ContextAwareVisitor
-from libcst.metadata import SyntacticPositionProvider
+from libcst.metadata import PositionProvider
 from libcst.testing.utils import UnitTest
 
 
 class TestingCollector(ContextAwareVisitor):
 
-    METADATA_DEPENDENCIES = (SyntacticPositionProvider,)
+    METADATA_DEPENDENCIES = (PositionProvider,)
 
     def visit_Pass(self, node: cst.Pass) -> None:
-        position = self.get_metadata(SyntacticPositionProvider, node)
+        position = self.get_metadata(PositionProvider, node)
         self.context.scratch["pass"] = (position.start.line, position.start.column)
 
 
 class TestingTransform(ContextAwareTransformer):
 
-    METADATA_DEPENDENCIES = (SyntacticPositionProvider,)
+    METADATA_DEPENDENCIES = (PositionProvider,)
 
     def visit_FunctionDef(self, node: cst.FunctionDef) -> None:
-        position = self.get_metadata(SyntacticPositionProvider, node)
+        position = self.get_metadata(PositionProvider, node)
         self.context.scratch[node.name.value] = (
             position.start.line,
             position.start.column,

--- a/libcst/matchers/_matcher_base.py
+++ b/libcst/matchers/_matcher_base.py
@@ -581,7 +581,7 @@ class MatchMetadataIfTrue(_BaseMetadataMatcher):
         m.Name(
             value="foo",
             metadata=m.MatchMetadataIfTrue(
-                meta.SyntacticPositionProvider,
+                meta.PositionProvider,
                 lambda position: position.start.column == 0,
             )
         )

--- a/libcst/matchers/tests/test_extract.py
+++ b/libcst/matchers/tests/test_extract.py
@@ -178,7 +178,7 @@ class MatchersExtractTest(UnitTest):
                             left=m.Name(
                                 metadata=m.SaveMatchedNode(
                                     m.MatchMetadata(
-                                        meta.SyntacticPositionProvider,
+                                        meta.PositionProvider,
                                         self._make_coderange((1, 0), (1, 1)),
                                     ),
                                     "left",
@@ -207,7 +207,7 @@ class MatchersExtractTest(UnitTest):
                             left=m.Name(
                                 metadata=m.SaveMatchedNode(
                                     m.MatchMetadata(
-                                        meta.SyntacticPositionProvider,
+                                        meta.PositionProvider,
                                         self._make_coderange((1, 0), (1, 2)),
                                     ),
                                     "left",

--- a/libcst/matchers/tests/test_matchers_with_metadata.py
+++ b/libcst/matchers/tests/test_matchers_with_metadata.py
@@ -47,8 +47,7 @@ class MatchersMetadataTest(UnitTest):
                 m.Name(
                     value="foo",
                     metadata=m.MatchMetadata(
-                        meta.SyntacticPositionProvider,
-                        self._make_coderange((1, 0), (1, 3)),
+                        meta.PositionProvider, self._make_coderange((1, 0), (1, 3)),
                     ),
                 ),
                 metadata_resolver=wrapper,
@@ -61,12 +60,10 @@ class MatchersMetadataTest(UnitTest):
                 node,
                 m.BinaryOperation(
                     left=m.MatchMetadata(
-                        meta.SyntacticPositionProvider,
-                        self._make_coderange((1, 0), (1, 1)),
+                        meta.PositionProvider, self._make_coderange((1, 0), (1, 1)),
                     ),
                     right=m.MatchMetadata(
-                        meta.SyntacticPositionProvider,
-                        self._make_coderange((1, 4), (1, 5)),
+                        meta.PositionProvider, self._make_coderange((1, 4), (1, 5)),
                     ),
                 ),
                 metadata_resolver=wrapper,
@@ -82,8 +79,7 @@ class MatchersMetadataTest(UnitTest):
                 m.Name(
                     value="foo",
                     metadata=m.MatchMetadata(
-                        meta.SyntacticPositionProvider,
-                        self._make_coderange((2, 0), (2, 3)),
+                        meta.PositionProvider, self._make_coderange((2, 0), (2, 3)),
                     ),
                 ),
                 metadata_resolver=wrapper,
@@ -96,12 +92,10 @@ class MatchersMetadataTest(UnitTest):
                 node,
                 m.BinaryOperation(
                     left=m.MatchMetadata(
-                        meta.SyntacticPositionProvider,
-                        self._make_coderange((1, 0), (1, 1)),
+                        meta.PositionProvider, self._make_coderange((1, 0), (1, 1)),
                     ),
                     right=m.MatchMetadata(
-                        meta.SyntacticPositionProvider,
-                        self._make_coderange((1, 4), (1, 5)),
+                        meta.PositionProvider, self._make_coderange((1, 4), (1, 5)),
                     ),
                 ),
                 metadata_resolver=wrapper,
@@ -113,10 +107,10 @@ class MatchersMetadataTest(UnitTest):
         matcher = m.BinaryOperation(
             left=m.OneOf(
                 m.MatchMetadata(
-                    meta.SyntacticPositionProvider, self._make_coderange((1, 0), (1, 1))
+                    meta.PositionProvider, self._make_coderange((1, 0), (1, 1))
                 ),
                 m.MatchMetadata(
-                    meta.SyntacticPositionProvider, self._make_coderange((1, 0), (1, 2))
+                    meta.PositionProvider, self._make_coderange((1, 0), (1, 2))
                 ),
             )
         )
@@ -131,7 +125,7 @@ class MatchersMetadataTest(UnitTest):
         matcher = m.BinaryOperation(
             left=m.AllOf(
                 m.MatchMetadata(
-                    meta.SyntacticPositionProvider, self._make_coderange((1, 0), (1, 1))
+                    meta.PositionProvider, self._make_coderange((1, 0), (1, 1))
                 ),
                 m.MatchMetadata(
                     meta.ExpressionContextProvider, meta.ExpressionContext.LOAD
@@ -159,10 +153,10 @@ class MatchersMetadataTest(UnitTest):
         matcher = m.BinaryOperation(
             left=(
                 m.MatchMetadata(
-                    meta.SyntacticPositionProvider, self._make_coderange((1, 0), (1, 1))
+                    meta.PositionProvider, self._make_coderange((1, 0), (1, 1))
                 )
                 | m.MatchMetadata(
-                    meta.SyntacticPositionProvider, self._make_coderange((1, 0), (1, 2))
+                    meta.PositionProvider, self._make_coderange((1, 0), (1, 2))
                 )
             )
         )
@@ -177,7 +171,7 @@ class MatchersMetadataTest(UnitTest):
         matcher = m.BinaryOperation(
             left=(
                 m.MatchMetadata(
-                    meta.SyntacticPositionProvider, self._make_coderange((1, 0), (1, 1))
+                    meta.PositionProvider, self._make_coderange((1, 0), (1, 1))
                 )
                 & m.MatchMetadata(
                     meta.ExpressionContextProvider, meta.ExpressionContext.LOAD
@@ -208,12 +202,10 @@ class MatchersMetadataTest(UnitTest):
             left=m.Name(
                 metadata=m.OneOf(
                     m.MatchMetadata(
-                        meta.SyntacticPositionProvider,
-                        self._make_coderange((1, 0), (1, 1)),
+                        meta.PositionProvider, self._make_coderange((1, 0), (1, 1)),
                     ),
                     m.MatchMetadata(
-                        meta.SyntacticPositionProvider,
-                        self._make_coderange((1, 0), (1, 2)),
+                        meta.PositionProvider, self._make_coderange((1, 0), (1, 2)),
                     ),
                 )
             )
@@ -224,12 +216,10 @@ class MatchersMetadataTest(UnitTest):
             left=m.Integer(
                 metadata=m.OneOf(
                     m.MatchMetadata(
-                        meta.SyntacticPositionProvider,
-                        self._make_coderange((1, 0), (1, 1)),
+                        meta.PositionProvider, self._make_coderange((1, 0), (1, 1)),
                     ),
                     m.MatchMetadata(
-                        meta.SyntacticPositionProvider,
-                        self._make_coderange((1, 0), (1, 2)),
+                        meta.PositionProvider, self._make_coderange((1, 0), (1, 2)),
                     ),
                 )
             )
@@ -244,8 +234,7 @@ class MatchersMetadataTest(UnitTest):
             left=m.Name(
                 metadata=m.AllOf(
                     m.MatchMetadata(
-                        meta.SyntacticPositionProvider,
-                        self._make_coderange((1, 0), (1, 1)),
+                        meta.PositionProvider, self._make_coderange((1, 0), (1, 1)),
                     ),
                     m.MatchMetadata(
                         meta.ExpressionContextProvider, meta.ExpressionContext.LOAD
@@ -276,10 +265,10 @@ class MatchersMetadataTest(UnitTest):
         matcher = m.BinaryOperation(
             left=m.Name(
                 metadata=m.MatchMetadata(
-                    meta.SyntacticPositionProvider, self._make_coderange((1, 0), (1, 1))
+                    meta.PositionProvider, self._make_coderange((1, 0), (1, 1))
                 )
                 | m.MatchMetadata(
-                    meta.SyntacticPositionProvider, self._make_coderange((1, 0), (1, 2))
+                    meta.PositionProvider, self._make_coderange((1, 0), (1, 2))
                 )
             )
         )
@@ -288,10 +277,10 @@ class MatchersMetadataTest(UnitTest):
         matcher = m.BinaryOperation(
             left=m.Integer(
                 metadata=m.MatchMetadata(
-                    meta.SyntacticPositionProvider, self._make_coderange((1, 0), (1, 1))
+                    meta.PositionProvider, self._make_coderange((1, 0), (1, 1))
                 )
                 | m.MatchMetadata(
-                    meta.SyntacticPositionProvider, self._make_coderange((1, 0), (1, 2))
+                    meta.PositionProvider, self._make_coderange((1, 0), (1, 2))
                 )
             )
         )
@@ -304,7 +293,7 @@ class MatchersMetadataTest(UnitTest):
         matcher = m.BinaryOperation(
             left=m.Name(
                 metadata=m.MatchMetadata(
-                    meta.SyntacticPositionProvider, self._make_coderange((1, 0), (1, 1))
+                    meta.PositionProvider, self._make_coderange((1, 0), (1, 1))
                 )
                 & m.MatchMetadata(
                     meta.ExpressionContextProvider, meta.ExpressionContext.LOAD

--- a/libcst/metadata/__init__.py
+++ b/libcst/metadata/__init__.py
@@ -19,9 +19,7 @@ from libcst.metadata.expression_context_provider import (
 from libcst.metadata.full_repo_manager import FullRepoManager
 from libcst.metadata.parent_node_provider import ParentNodeProvider
 from libcst.metadata.position_provider import (
-    BasicPositionProvider,
     PositionProvider,
-    SyntacticPositionProvider,
     WhitespaceInclusivePositionProvider,
 )
 from libcst.metadata.reentrant_codegen import (
@@ -54,8 +52,6 @@ __all__ = [
     "CodeRange",
     "WhitespaceInclusivePositionProvider",
     "PositionProvider",
-    "BasicPositionProvider",  # deprecated name for backwards compatibility
-    "SyntacticPositionProvider",  # deprecated name for backwards compatibility
     "BaseMetadataProvider",
     "ExpressionContext",
     "ExpressionContextProvider",

--- a/libcst/metadata/position_provider.py
+++ b/libcst/metadata/position_provider.py
@@ -139,9 +139,3 @@ class PositionProvider(BaseMetadataProvider[CodeRange]):
             provider=self,
         )
         module._codegen(state)
-
-
-# DEPRECATED: These names are here for backwards compatibility and will be removed in
-# the future.
-BasicPositionProvider = WhitespaceInclusivePositionProvider
-SyntacticPositionProvider = PositionProvider


### PR DESCRIPTION
## Summary

As it says on the tin! Prepare for LibCST 0.3.0 release by removing these deprecated objects.

## Test Plan

pyre, tox