### PR TITLE
Remove deprecated attributes and objects in metadata

### DIFF
--- a/libcst/__init__.py
+++ b/libcst/__init__.py
@@ -185,7 +185,6 @@ from libcst._nodes.whitespace import (
 )
 from libcst._parser.entrypoints import parse_expression, parse_module, parse_statement
 from libcst._parser.types.config import PartialParserConfig
-from libcst._position import CodePosition, CodeRange
 from libcst._removal_sentinel import RemovalSentinel, RemoveFromParent
 from libcst._visitors import CSTNodeT, CSTTransformer, CSTVisitor, CSTVisitorT
 from libcst.metadata.base_provider import (
@@ -198,8 +197,6 @@ from libcst.metadata.wrapper import MetadataWrapper
 
 __all__ = [
     "BatchableCSTVisitor",
-    "CodePosition",  # Deprecated export, import from libcst.metadata instead
-    "CodeRange",  # Deprecated export, import from libcst.metadata instead
     "CSTNodeT",
     "CSTTransformer",
     "CSTValidationError",

--- a/libcst/matchers/tests/test_extract.py
+++ b/libcst/matchers/tests/test_extract.py
@@ -15,10 +15,10 @@ from libcst.testing.utils import UnitTest
 class MatchersExtractTest(UnitTest):
     def _make_coderange(
         self, start: Tuple[int, int], end: Tuple[int, int]
-    ) -> cst.CodeRange:
-        return cst.CodeRange(
-            start=cst.CodePosition(line=start[0], column=start[1]),
-            end=cst.CodePosition(line=end[0], column=end[1]),
+    ) -> meta.CodeRange:
+        return meta.CodeRange(
+            start=meta.CodePosition(line=start[0], column=start[1]),
+            end=meta.CodePosition(line=end[0], column=end[1]),
         )
 
     def test_extract_sentinel(self) -> None:

--- a/libcst/matchers/tests/test_matchers_with_metadata.py
+++ b/libcst/matchers/tests/test_matchers_with_metadata.py
@@ -32,10 +32,10 @@ class MatchersMetadataTest(UnitTest):
 
     def _make_coderange(
         self, start: Tuple[int, int], end: Tuple[int, int]
-    ) -> cst.CodeRange:
-        return cst.CodeRange(
-            start=cst.CodePosition(line=start[0], column=start[1]),
-            end=cst.CodePosition(line=end[0], column=end[1]),
+    ) -> meta.CodeRange:
+        return meta.CodeRange(
+            start=meta.CodePosition(line=start[0], column=start[1]),
+            end=meta.CodePosition(line=end[0], column=end[1]),
         )
 
     def test_simple_matcher_true(self) -> None:

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -7,7 +7,6 @@
 
 import abc
 import builtins
-import warnings
 from collections import defaultdict
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -99,21 +98,6 @@ class BaseAssignment(abc.ABC):
         """Return all accesses of the assignment."""
         # we don't want to publicly expose the mutable version of this
         return self.__accesses
-
-    @property
-    def accesses(self) -> Tuple[Access, ...]:
-        """Return all accesses of the assignment.
-
-        .. warning::
-           Deprecated: This will be removed soon. Please use
-           :attr:`~libcst.metadata.BaseAssignment.references` instead!
-        """
-        # we don't want to publicly expose the mutable version of this
-        warnings.warn(
-            "This will be removed soon. Please use `.references` instead!",
-            DeprecationWarning,
-        )
-        return tuple(self.__accesses)
 
     def __hash__(self) -> int:
         return id(self)

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -810,9 +810,6 @@ class ScopeProviderTest(UnitTest):
             cast(Assignment, list(a_outer_assignments)[0]).node, a_outer_assign
         )
         self.assertEqual(
-            {i.node for i in list(a_outer_assignments)[0].accesses}, {a_outer_access}
-        )
-        self.assertEqual(
             {i.node for i in list(a_outer_assignments)[0].references}, {a_outer_access}
         )
 


### PR DESCRIPTION
## Summary

Remove deprecated imports and attributes in libcst.metadata in preparation of LibCST 0.3.0.

## Test Plan

tox, pyre