### PR TITLE
Upgrade Pyre to 0.0.39

### DIFF
--- a/libcst/testing/utils.py
+++ b/libcst/testing/utils.py
@@ -167,7 +167,6 @@ class BaseTestMeta(type):
     def __new__(mcs, name: str, bases: Tuple[type, ...], dct: Dict[str, Any]) -> object:
         validate_provider_tests(dct)
         populate_data_provider_tests(dct)
-        # pyre-ignore Pyre doesn't seem to know about __new__
         return super().__new__(mcs, name, bases, dict(dct))
 
 

--- a/libcst/tests/pyre/simple_class.json
+++ b/libcst/tests/pyre/simple_class.json
@@ -2,7 +2,6 @@
   "types": [
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 8,
           "column": 19
@@ -16,7 +15,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 11,
           "column": 6
@@ -30,7 +28,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 12,
           "column": 8
@@ -44,7 +41,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 12,
           "column": 17
@@ -58,7 +54,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 12,
           "column": 23
@@ -72,7 +67,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 12,
           "column": 26
@@ -86,7 +80,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 12,
           "column": 34
@@ -100,7 +93,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 13,
           "column": 8
@@ -114,7 +106,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 13,
           "column": 8
@@ -128,7 +119,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 13,
           "column": 21
@@ -142,7 +132,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 13,
           "column": 27
@@ -156,7 +145,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 16,
           "column": 6
@@ -170,7 +158,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 17,
           "column": 8
@@ -184,7 +171,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 17,
           "column": 18
@@ -198,7 +184,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 17,
           "column": 24
@@ -212,7 +197,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 17,
           "column": 27
@@ -226,7 +210,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 17,
           "column": 35
@@ -240,7 +223,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 17,
           "column": 35
@@ -254,7 +236,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 17,
           "column": 44
@@ -268,7 +249,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 18,
           "column": 15
@@ -282,7 +262,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 18,
           "column": 16
@@ -296,7 +275,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 18,
           "column": 16
@@ -310,7 +288,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 18,
           "column": 28
@@ -324,7 +301,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 18,
           "column": 33
@@ -338,7 +314,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 18,
           "column": 33
@@ -352,7 +327,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 18,
           "column": 39
@@ -366,7 +340,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 21,
           "column": 0
@@ -380,7 +353,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 21,
           "column": 12
@@ -394,7 +366,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 21,
           "column": 12
@@ -408,7 +379,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 22,
           "column": 0
@@ -422,7 +392,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 22,
           "column": 7
@@ -436,7 +405,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 22,
           "column": 24
@@ -450,7 +418,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 22,
           "column": 24
@@ -464,7 +431,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 22,
           "column": 24
@@ -478,7 +444,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 22,
           "column": 44
@@ -492,7 +457,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 23,
           "column": 4
@@ -506,7 +470,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 23,
           "column": 12
@@ -520,7 +483,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 24,
           "column": 4
@@ -534,7 +496,6 @@
     },
     {
       "location": {
-        "path": "libcst/tests/pyre/simple_class.py",
         "start": {
           "line": 24,
           "column": 4

--- a/libcst/tool.py
+++ b/libcst/tool.py
@@ -734,7 +734,7 @@ def main(proc_name: str, cli_args: List[str]) -> int:
     add_help = first_arg in {"--help", "-h"}
 
     # Create general parser to determine which command we are invoking.
-    parser = argparse.ArgumentParser(
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(
         description="Collection of utilities that ship with LibCST.",
         add_help=add_help,
         prog=proc_name,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,6 @@ git+https://github.com/jimmylai/sphinx.git@slots_type_annotation
 isort==4.3.20
 jupyter==1.0.0
 nbsphinx==0.4.2
-pyre-check==0.0.38
+pyre-check==0.0.39
 sphinx-rtd-theme==0.4.3
 prompt-toolkit==2.0.9


### PR DESCRIPTION
## Summary
Upgrade Pyre to 0.0.39. It removed the redundant file path from pyre query which make the output more compact and performant.

## Test Plan
Pyre check.