### PR TITLE
Apply make_fixture_data() to codemod output

### DIFF
--- a/libcst/codemod/_testing.py
+++ b/libcst/codemod/_testing.py
@@ -119,7 +119,10 @@ class _CodemodTest:
                 # pyre-ignore This mixin needs to be used with a UnitTest subclass.
                 self.fail("Expected SkipFile but was not raised")
         # pyre-ignore This mixin needs to be used with a UnitTest subclass.
-        self.assertEqual(CodemodTest.make_fixture_data(after), output_tree.code)
+        self.assertEqual(
+            CodemodTest.make_fixture_data(after),
+            CodemodTest.make_fixture_data(output_tree.code),
+        )
         if expected_warnings is not None:
             # pyre-ignore This mixin needs to be used with a UnitTest subclass.
             self.assertSequenceEqual(expected_warnings, context.warnings)


### PR DESCRIPTION
## Summary
Apply make_fixture_data() to codemod output.
This is useful for codemod creates empty leading or trailing lines. Without this change, it's hard to test those cases.

## Test Plan
Existing tests.
