### PR TITLE
Parse posonly param indicator in functions/lambdas.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,9 +28,9 @@ A Concrete Syntax Tree (CST) parser and serializer library for Python
 
 .. intro-start
 
-LibCST parses Python 3.5, 3.6 or 3.7 source code as a CST tree that keeps all formatting
-details (comments, whitespaces, parentheses, etc). It's useful for building 
-automated refactoring (codemod) applications and linters.
+LibCST parses Python 3.5, 3.6, 3.7 or 3.8 source code as a CST tree that keeps all
+formatting details (comments, whitespaces, parentheses, etc). It's useful for
+building automated refactoring (codemod) applications and linters.
 
 .. intro-end
 
@@ -187,7 +187,6 @@ To generate documents, do the following in the root:
 Future
 ======
 
-- Python 3.8 support, both in running on Python 3.8 and parsing 3.8 code.
 - Advanced full repository facts providers like fully qualified name and call graph.
 
 License

--- a/docs/source/helpers.rst
+++ b/docs/source/helpers.rst
@@ -4,8 +4,9 @@ Helpers
 
 Helpers are higher level functions built for reducing recurring code boilerplate.
 We add helpers as method of ``CSTNode`` or ``libcst.helpers`` package based on those principles:
-  - ``CSTNode`` method: simple, read-only and only require data of the direct children of a CSTNode.
-  - ``libcst.helpers``: node transforms or require recursively traversing the syntax tree.
+
+- ``CSTNode`` method: simple, read-only and only require data of the direct children of a CSTNode.
+- ``libcst.helpers``: node transforms or require recursively traversing the syntax tree.
 
 libcst.helpers
 --------------

--- a/libcst/_nodes/tests/test_lambda.py
+++ b/libcst/_nodes/tests/test_lambda.py
@@ -486,6 +486,12 @@ class LambdaCreationTest(CSTNodeTest):
         self.assert_invalid(get_node, expected_re)
 
 
+def _parse_expression_force_38(code: str) -> cst.BaseExpression:
+    return cst.parse_expression(
+        code, config=cst.PartialParserConfig(python_version="3.8")
+    )
+
+
 class LambdaParserTest(CSTNodeTest):
     @data_provider(
         (
@@ -929,3 +935,39 @@ class LambdaParserTest(CSTNodeTest):
         self, node: cst.CSTNode, code: str, position: Optional[CodeRange] = None
     ) -> None:
         self.validate_node(node, code, parse_expression, position)
+
+    @data_provider(
+        (
+            # Test basic positional only params
+            {
+                "node": cst.Lambda(
+                    cst.Parameters(
+                        posonly_params=(
+                            cst.Param(
+                                cst.Name("bar"),
+                                star="",
+                                comma=cst.Comma(
+                                    whitespace_after=cst.SimpleWhitespace(" ")
+                                ),
+                            ),
+                            cst.Param(
+                                cst.Name("baz"),
+                                star="",
+                                comma=cst.Comma(
+                                    whitespace_after=cst.SimpleWhitespace(" ")
+                                ),
+                            ),
+                        ),
+                        posonly_ind=cst.ParamSlash(),
+                    ),
+                    cst.Integer("5"),
+                    whitespace_after_lambda=cst.SimpleWhitespace(" "),
+                ),
+                "code": "lambda bar, baz, /: 5",
+            },
+        )
+    )
+    def test_valid_38(
+        self, node: cst.CSTNode, code: str, position: Optional[CodeRange] = None
+    ) -> None:
+        self.validate_node(node, code, _parse_expression_force_38, position)

--- a/libcst/_parser/grammar.py
+++ b/libcst/_parser/grammar.py
@@ -64,6 +64,7 @@ from libcst._parser.conversions.params import (
     convert_argslist,
     convert_fpdef,
     convert_fpdef_assign,
+    convert_fpdef_slash,
     convert_fpdef_star,
     convert_fpdef_starstar,
 )
@@ -209,6 +210,7 @@ _NONTERMINAL_CONVERSIONS_SEQUENCE: Tuple[NonterminalConversion, ...] = (
     convert_asyncable_stmt,
     convert_parameters,
     convert_argslist,
+    convert_fpdef_slash,
     convert_fpdef_star,
     convert_fpdef_starstar,
     convert_fpdef_assign,

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(path.join(this_directory, "README.rst"), encoding="utf-8") as f:
 
 setuptools.setup(
     name="libcst",
-    description="A concrete syntax tree with AST-like properties for Python 3.5, 3.6 and 3.7 programs.",
+    description="A concrete syntax tree with AST-like properties for Python 3.5, 3.6, 3.7 and 3.8 programs.",
     long_description=long_description,
     long_description_content_type="text/x-rst",
     version="0.2.7",
@@ -51,6 +51,7 @@ setuptools.setup(
         "Topic :: Software Development :: Libraries",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     zip_safe=False,  # for mypy compatibility https://mypy.readthedocs.io/en/latest/installed_packages.html
 )


### PR DESCRIPTION
## Summary

Implement parsing of posonly param indicator ('/'). This brings us to full 3.8 compatibility.

## Test Plan

added a decent amount of new tests, pyre, existing tests, also ran the fuzzers for 3.6,3.7 and 3.8.
