### PR TITLE
Implement a --python-version override flag to "libcst.tool print".

### DIFF
--- a/libcst/tool.py
+++ b/libcst/tool.py
@@ -23,7 +23,7 @@ from typing import Any, Callable, Dict, List, Sequence, Tuple, Type
 
 import yaml
 
-from libcst import CSTNode, IndentedBlock, Module, parse_module
+from libcst import CSTNode, IndentedBlock, Module, PartialParserConfig, parse_module
 from libcst._nodes.deep_equals import deep_equals
 from libcst.codemod import (
     CodemodCommand,
@@ -242,6 +242,17 @@ def _print_tree_impl(proc_name: str, command_args: List[str]) -> int:
         action="store_true",
         help="Show values that exist only for syntax, like commas or semicolons",
     )
+    parser.add_argument(
+        "-p",
+        "--python-version",
+        metavar="VERSION",
+        help=(
+            "Override the version string used for parsing Python source files. Defaults "
+            + "to the version of python used to run this tool."
+        ),
+        type=str,
+        default=None,
+    )
     args = parser.parse_args(command_args)
     infile = args.infile
 
@@ -252,7 +263,14 @@ def _print_tree_impl(proc_name: str, command_args: List[str]) -> int:
         with open(infile, "rb") as fp:
             code = fp.read()
 
-    tree = parse_module(code)
+    tree = parse_module(
+        code,
+        config=(
+            PartialParserConfig(python_version=args.python_version)
+            if args.python_version is not None
+            else PartialParserConfig()
+        ),
+    )
     print(
         dump(
             tree,


### PR DESCRIPTION
## Summary

I ran into this when testing f-strings in 3.8, where I wanted to parse and print trees on a newer python than my system python. We already have a version override for `libcst.tool codemod`, so there is no reason not to support it as well for `libcst.tool print`. Copied wholesale over from the `codemod` command so it works identically.

## Test Plan

Tested with named expr parsing using system python 3.7.