### PR TITLE
[scope] add support for tracking reference in del expression context

### DIFF
--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -624,7 +624,7 @@ class ScopeVisitor(cst.CSTVisitor):
         context = self.provider.get_metadata(ExpressionContextProvider, node, None)
         if context == ExpressionContext.STORE:
             self.scope.record_assignment(node.value, node)
-        elif context == ExpressionContext.LOAD:
+        elif context in (ExpressionContext.LOAD, ExpressionContext.DEL):
             access = Access(node, self.scope)
             self.__deferred_accesses.append(access)
             self.scope.record_access(node.value, access)


### PR DESCRIPTION
## Summary
In the use case like rename a variable, we'll want to track the reference even it's in a `del` context.

## Test Plan
Unit test.
