### PR TITLE
add SimpleString.evaluated_value

### DIFF
--- a/libcst/_nodes/expression.py
+++ b/libcst/_nodes/expression.py
@@ -7,6 +7,7 @@
 
 import re
 from abc import ABC, abstractmethod
+from ast import literal_eval
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum, auto
@@ -605,6 +606,13 @@ class SimpleString(_BasePrefixedString):
     def _codegen_impl(self, state: CodegenState) -> None:
         with self._parenthesize(state):
             state.add_token(self.value)
+
+    @property
+    def evaluated_value(self) -> str:
+        """
+        Return an :func:`ast.literal_eval` evaluated str of :py:attr:`value`.
+        """
+        return literal_eval(self.value)
 
 
 class BaseFormattedStringContent(CSTNode, ABC):

--- a/libcst/helpers/tests/test_expression.py
+++ b/libcst/helpers/tests/test_expression.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 #
 # pyre-strict
+from ast import literal_eval
 from typing import Optional, Union
 
 import libcst as cst
@@ -28,3 +29,11 @@ class ExpressionTest(UnitTest):
         self, input: Union[str, cst.CSTNode], output: Optional[str],
     ) -> None:
         self.assertEqual(get_full_name_for_node(input), output)
+
+    def test_simplestring_evaluated_value(self) -> None:
+        raw_string = '"a string."'
+        node = cst.helpers.ensure_type(
+            cst.parse_expression(raw_string), cst.SimpleString
+        )
+        self.assertEqual(node.value, raw_string)
+        self.assertEqual(node.evaluated_value, literal_eval(raw_string))


### PR DESCRIPTION
## Summary
`literal_eval(node.value)` has been used often to get the evaluated string value from a `SimpleString`.
It requires `from ast import literal`. This helper is a shortcut to make it easier.

## Test Plan
unit test.
