### PR TITLE
Clarify documentation about f-string spacing

### DIFF
--- a/libcst/_nodes/expression.py
+++ b/libcst/_nodes/expression.py
@@ -677,8 +677,9 @@ class FormattedStringExpression(BaseFormattedStringContent):
         ""
     )
 
-    #: Whitespace after the ``expression``, ``conversion``, and ``format_spec``, but
-    #: before the closing curly brace (``}``).
+    #: Whitespace after the ``expression``, but before the ``conversion``,
+    #: ``format_spec`` and the closing curly brace (``}``). Python does not
+    #: allow whitespace inside or after a ``conversion`` or ``format_spec``.
     whitespace_after_expression: BaseParenthesizableWhitespace = SimpleWhitespace.field(
         ""
     )


### PR DESCRIPTION
## Summary

We parse this correctly, but the documentation is wrong. Update it to match Python 3 actual behavior.

## Test Plan

Opened python in console, verified you could not have spacing inside or after conversion or format_spec.