### PR TITLE
Refactor string split helper method into core attributes.

### DIFF
--- a/libcst/_nodes/tests/test_atom.py
+++ b/libcst/_nodes/tests/test_atom.py
@@ -1022,3 +1022,26 @@ class AtomTest(CSTNodeTest):
     )
     def test_invalid(self, **kwargs: Any) -> None:
         self.assert_invalid(**kwargs)
+
+
+class StringHelperTest(CSTNodeTest):
+    def test_string_prefix_and_quotes(self) -> None:
+        """
+        Test our helpers out for various strings.
+        """
+        emptybytestring = cst.ensure_type(parse_expression('b""'), cst.SimpleString)
+        bytestring = cst.ensure_type(parse_expression('b"abc"'), cst.SimpleString)
+        multilinestring = cst.ensure_type(parse_expression('""""""'), cst.SimpleString)
+        formatstring = cst.ensure_type(parse_expression('f""""""'), cst.FormattedString)
+
+        self.assertEqual(emptybytestring.prefix, "b")
+        self.assertEqual(emptybytestring.quote, '"')
+        self.assertEqual(emptybytestring.raw_value, "")
+        self.assertEqual(bytestring.prefix, "b")
+        self.assertEqual(bytestring.quote, '"')
+        self.assertEqual(bytestring.raw_value, "abc")
+        self.assertEqual(multilinestring.prefix, "")
+        self.assertEqual(multilinestring.quote, '"""')
+        self.assertEqual(multilinestring.raw_value, "")
+        self.assertEqual(formatstring.prefix, "f")
+        self.assertEqual(formatstring.quote, '"""')

--- a/libcst/codemod/commands/tests/test_convert_format_to_fstring.py
+++ b/libcst/codemod/commands/tests/test_convert_format_to_fstring.py
@@ -5,10 +5,7 @@
 #
 # pyre-strict
 from libcst.codemod import CodemodTest
-from libcst.codemod.commands.convert_format_to_fstring import (
-    ConvertFormatStringCommand,
-    _string_prefix_and_quotes,
-)
+from libcst.codemod.commands.convert_format_to_fstring import ConvertFormatStringCommand
 
 
 class ConvertFormatStringCommandTest(CodemodTest):
@@ -36,13 +33,6 @@ class ConvertFormatStringCommandTest(CodemodTest):
         """
 
         self.assertCodemod(before, after)
-
-    def test_string_prefix_and_quotes(self) -> None:
-        """
-        Test some edge cases not covered by below tests.
-        """
-        self.assertEqual(_string_prefix_and_quotes('b""'), ("b", '"', ""))
-        self.assertEqual(_string_prefix_and_quotes('f""""""'), ("f", '"""', ""))
 
     def test_unsupported_expansion(self) -> None:
         """


### PR DESCRIPTION
## Summary

We have a helper in one of our codemods that should really be universally available. So, move the relevant bits into libcst core, remove them from the codemod, update the codemod to use the new behavior and update the tests accordingly.

## Test Plan

tox, pyre, new tests