### PR TITLE
Full Repo Metadata support in Codemod Tool

### DIFF
--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -564,6 +564,7 @@ def parallel_exec_transform_with_prettyprint(  # noqa: C901
     if repo_root:
         # Spin up a full repo metadata manager so that we can provide metadata
         # like type inference to individual forked processes.
+        print("Calculating full-repo metadata...", file=sys.stderr)
         metadata_manager = FullRepoManager(
             os.path.abspath(repo_root), files, transform.get_inherited_dependencies(),
         )
@@ -571,6 +572,7 @@ def parallel_exec_transform_with_prettyprint(  # noqa: C901
         transform.context = replace(
             transform.context, metadata_manager=metadata_manager,
         )
+    print("Executing codemod...", file=sys.stderr)
 
     # We place results in this queue inside _parallel_exec_process_stub
     # so that we can control when things get printed to the console.

--- a/libcst/codemod/_context.py
+++ b/libcst/codemod/_context.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 import libcst as cst
+import libcst.metadata as meta
 
 
 @dataclass(frozen=True)
@@ -43,6 +44,9 @@ class CodemodContext:
     #: the :meth:`~libcst.MetadataDependent.get_metadata` method on
     #: :class:`~libcst.codemod.Codemod`.
     wrapper: Optional[cst.MetadataWrapper] = None
+
+    #: The current repo-level metadata manager for the active codemod.
+    metadata_manager: Optional[meta.FullRepoManager] = None
 
     @property
     def module(self) -> Optional[cst.Module]:

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setuptools.setup(
     install_requires=[
         "dataclasses; python_version < '3.7'",
         "typing_extensions >= 3.7.2",
-        "typing_inspect >= 0.3.1",
+        "typing_inspect >= 0.4.0",
+        "pyyaml >= 5.2",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
## Summary

This makes it such that when you write a codemod, you need only to depend on the `TypeInferenceProvider` in your codemod, the way you would a non-full-repo metadata provider. `libcst.tool` will handle the rest, including cache computation and passing values around.

## Test Plan

pyre, existing tests, also installed libcst into a new virtualenv, initialized `libcst.tool` and `pyre` in a new directory, added a file with types and added a codemod that printed the type of each name it encountered. Types were printed as expected.