### PR TITLE
Implement basic templated statement/expression/module parsing

### DIFF
--- a/docs/source/best_practices.rst
+++ b/docs/source/best_practices.rst
@@ -155,6 +155,8 @@ That's because the ``updated_node`` tree contains the modification to ``other_fu
 By returning modifications to ``original_node`` instead of ``updated_node``, we accidentally
 discarded all the work done deeper in the tree.
 
+.. _libcst-config_best_practice:
+
 Provide a ``config`` when generating code from templates
 --------------------------------------------------------
 

--- a/docs/source/helpers.rst
+++ b/docs/source/helpers.rst
@@ -8,9 +8,26 @@ We add helpers as method of ``CSTNode`` or ``libcst.helpers`` package based on t
 - ``CSTNode`` method: simple, read-only and only require data of the direct children of a CSTNode.
 - ``libcst.helpers``: node transforms or require recursively traversing the syntax tree.
 
-libcst.helpers
---------------
+Construction Helpers
+--------------------
+
+Functions that assist in creating a new LibCST tree.
+
+.. autofunction:: libcst.helpers.parse_template_module
+.. autofunction:: libcst.helpers.parse_template_expression
+.. autofunction:: libcst.helpers.parse_template_statement
+
+Transformation Helpers
+----------------------
+
+Functions that assist in transforming an existing LibCST node.
 
 .. autofunction:: libcst.helpers.insert_header_comments
+
+Traversing Helpers
+------------------
+
+Functions that assist in traversing an existing LibCST tree.
+
 .. autofunction:: libcst.helpers.get_full_name_for_node
 .. autofunction:: libcst.helpers.ensure_type

--- a/libcst/helpers/__init__.py
+++ b/libcst/helpers/__init__.py
@@ -5,9 +5,21 @@
 #
 # pyre-strict
 
+from libcst.helpers._template import (
+    parse_template_expression,
+    parse_template_module,
+    parse_template_statement,
+)
 from libcst.helpers.common import ensure_type
 from libcst.helpers.expression import get_full_name_for_node
 from libcst.helpers.module import insert_header_comments
 
 
-__all__ = ["get_full_name_for_node", "ensure_type", "insert_header_comments"]
+__all__ = [
+    "get_full_name_for_node",
+    "ensure_type",
+    "insert_header_comments",
+    "parse_template_module",
+    "parse_template_statement",
+    "parse_template_expression",
+]

--- a/libcst/helpers/_template.py
+++ b/libcst/helpers/_template.py
@@ -1,0 +1,190 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# pyre-strict
+
+from typing import Dict, Set, Union
+
+import libcst as cst
+from libcst.helpers.common import ensure_type
+
+
+TEMPLATE_PREFIX: str = "__LIBCST_MANGLED_NAME_"
+TEMPLATE_SUFFIX: str = "_EMAN_DELGNAM_TSCBIL__"
+
+
+def mangled_name(var: str) -> str:
+    return f"{TEMPLATE_PREFIX}{var}{TEMPLATE_SUFFIX}"
+
+
+def mangle_template(template: str, template_vars: Set[str]) -> str:
+    if TEMPLATE_PREFIX in template or TEMPLATE_SUFFIX in template:
+        raise Exception("Cannot parse a template containing reserved strings")
+
+    for var in template_vars:
+        original = f"{{{var}}}"
+        if original not in template:
+            raise Exception(
+                f"Template string is missing a reference to {var} referred to in kwargs"
+            )
+        template = template.replace(original, mangled_name(var))
+    return template
+
+
+class TemplateTransformer(cst.CSTTransformer):
+    def __init__(self, template_replacements: Dict[str, cst.CSTNode]) -> None:
+        self.simple_replacements: Dict[str, cst.BaseExpression] = {
+            name: value
+            for name, value in template_replacements.items()
+            if isinstance(value, cst.BaseExpression)
+        }
+
+        # Figure out if there are any variables that we can't support
+        # inserting into templates.
+        unsupported_vars = {
+            name
+            for name in template_replacements
+            if name not in self.simple_replacements
+        }
+        if unsupported_vars:
+            raise Exception(
+                f"Template replacement for {next(iter(unsupported_vars))} is unsupported"
+            )
+
+    def leave_Name(
+        self, original_node: cst.Name, updated_node: cst.Name
+    ) -> cst.BaseExpression:
+        if (
+            TEMPLATE_PREFIX in updated_node.value
+            and TEMPLATE_SUFFIX in updated_node.value
+        ):
+            prefix, name_and_suffix = updated_node.value.split(TEMPLATE_PREFIX, 1)
+            name, suffix = name_and_suffix.split(TEMPLATE_SUFFIX, 1)
+            if prefix or suffix:
+                # This is not a valid name, don't modify it
+                return updated_node
+            if name not in self.simple_replacements:
+                # This is not a valid name, don't modify it
+                return updated_node
+            return self.simple_replacements[name].deep_clone()
+        return updated_node
+
+
+class TemplateChecker(cst.CSTVisitor):
+    def __init__(self, template_vars: Set[str]) -> None:
+        self.template_vars = template_vars
+
+    def visit_Name(self, node: cst.Name) -> None:
+        for var in self.template_vars:
+            if node.value == mangled_name(var):
+                raise Exception(f"Template variable {var} was not replaced properly",)
+
+
+def unmangle_nodes(
+    tree: cst.CSTNode, template_replacements: Dict[str, cst.CSTNode]
+) -> cst.CSTNode:
+    unmangler = TemplateTransformer(template_replacements)
+    return ensure_type(tree.visit(unmangler), cst.CSTNode)
+
+
+_DEFAULT_PARTIAL_PARSER_CONFIG: cst.PartialParserConfig = cst.PartialParserConfig()
+
+
+def parse_template_module(
+    template: str,
+    config: cst.PartialParserConfig = _DEFAULT_PARTIAL_PARSER_CONFIG,
+    **template_replacements: cst.CSTNode,
+) -> cst.Module:
+    """
+    Accepts an entire python module template, including all leading and trailing
+    whitespace. Any :class:`~libcst.CSTNode` provided as a keyword argument to
+    this function will be inserted into the template at the appropriate location
+    similar to an f-string expansion. For example::
+
+      module = parse_template_module("from {mod} import Foo\\n", mod=Name("bar"))
+
+    The above code will parse to a module containing a single
+    :class:`~libcst.FromImport` statement, referencing module ``bar`` and importing
+    object ``Foo`` from it. Remember that if you are parsing a template as part
+    of a substitution inside a transform, its considered
+    :ref:`best practice <libcst-config_best_practice>` to pass in a ``config``
+    from the current module under transformation.
+
+    Note that unlike :func:`~libcst.parse_module`, this function does not support
+    bytes as an input. This is due to the fact that it is processed as a template
+    before parsing as a module.
+    """
+
+    source = mangle_template(template, {name for name in template_replacements})
+    module = cst.parse_module(source, config)
+    new_module = ensure_type(unmangle_nodes(module, template_replacements), cst.Module)
+    new_module.visit(TemplateChecker({name for name in template_replacements}))
+    return new_module
+
+
+def parse_template_statement(
+    template: str,
+    config: cst.PartialParserConfig = _DEFAULT_PARTIAL_PARSER_CONFIG,
+    **template_replacements: cst.CSTNode,
+) -> Union[cst.SimpleStatementLine, cst.BaseCompoundStatement]:
+    """
+    Accepts a statement template followed by a trailing newline. If a trailing
+    newline is not provided, one will be added. Any :class:`~libcst.CSTNode`
+    provided as a keyword argument to this function will be inserted into the
+    template at the appropriate location similar to an f-string expansion. For
+    example::
+
+      statement = parse_template_statement("assert x > 0, {msg}", msg=SimpleString('"Uh oh!"'))
+
+    The above code will parse to an assert statement checking that some variable
+    ``x`` is greater than zero, or providing the assert message ``"Uh oh!"``.
+
+    Remember that if you are parsing a template as part of a substitution inside
+    a transform, its considered :ref:`best practice <libcst-config_best_practice>`
+    to pass in a ``config`` from the current module under transformation.
+    """
+
+    source = mangle_template(template, {name for name in template_replacements})
+    statement = cst.parse_statement(source, config)
+    new_statement = unmangle_nodes(statement, template_replacements)
+    if not isinstance(
+        new_statement, (cst.SimpleStatementLine, cst.BaseCompoundStatement)
+    ):
+        raise Exception(
+            f"Expected a statement bot got a {new_statement.__class__.__name__}!"
+        )
+    new_statement.visit(TemplateChecker({name for name in template_replacements}))
+    return new_statement
+
+
+def parse_template_expression(
+    template: str,
+    config: cst.PartialParserConfig = _DEFAULT_PARTIAL_PARSER_CONFIG,
+    **template_replacements: cst.CSTNode,
+) -> cst.BaseExpression:
+    """
+    Accepts an expression template on a single line. Leading and trailing whitespace
+    is not valid (there’s nowhere to store it on the expression node). Any
+    :class:`~libcst.CSTNode` provided as a keyword argument to this function will
+    be inserted into the template at the appropriate location similar to an
+    f-string expansion. For example::
+
+      expression = parse_template_expression("x + {foo}", foo=Name("y")))
+
+    The above code will parse to a :class:`~libcst.BinaryOperation` expression
+    adding two names (``x`` and ``y``) together.
+
+    Remember that if you are parsing a template as part of a substitution inside
+    a transform, its considered :ref:`best practice <libcst-config_best_practice>`
+    to pass in a ``config`` from the current module under transformation.
+    """
+
+    source = mangle_template(template, {name for name in template_replacements})
+    expression = cst.parse_expression(source, config)
+    new_expression = ensure_type(
+        unmangle_nodes(expression, template_replacements), cst.BaseExpression
+    )
+    new_expression.visit(TemplateChecker({name for name in template_replacements}))
+    return new_expression

--- a/libcst/helpers/tests/test_template.py
+++ b/libcst/helpers/tests/test_template.py
@@ -1,0 +1,85 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# pyre-strict
+
+import os
+from textwrap import dedent
+
+import libcst as cst
+from libcst.helpers import (
+    parse_template_expression,
+    parse_template_module,
+    parse_template_statement,
+)
+from libcst.testing.utils import UnitTest
+
+
+class TemplateTest(UnitTest):
+    def dedent(self, code: str) -> str:
+        lines = dedent(code).split(os.linesep)
+        if not lines[0].strip():
+            lines = lines[1:]
+        if not lines[-1].strip():
+            lines = [
+                *lines[:-1],
+                os.linesep,
+            ]
+        return os.linesep.join(lines)
+
+    def code(self, node: cst.CSTNode) -> str:
+        return cst.Module([]).code_for_node(node)
+
+    def test_simple_module(self) -> None:
+        module = parse_template_module(
+            self.dedent(
+                """
+                from {module} import {obj}
+
+                def foo() -> {obj}:
+                    return {obj}()
+                """
+            ),
+            module=cst.Name("foo"),
+            obj=cst.Name("Bar"),
+        )
+        self.assertEqual(
+            module.code,
+            self.dedent(
+                """
+                from foo import Bar
+
+                def foo() -> Bar:
+                    return Bar()
+                """
+            ),
+        )
+
+    def test_simple_statement(self) -> None:
+        statement = parse_template_statement(
+            "assert {test}, {msg}\n",
+            test=cst.Name("True"),
+            msg=cst.SimpleString('"Somehow True is no longer True..."'),
+        )
+        self.assertEqual(
+            self.code(statement), 'assert True, "Somehow True is no longer True..."\n',
+        )
+
+    def test_simple_expression(self) -> None:
+        expression = parse_template_expression(
+            "{a} + {b} + {c}",
+            a=cst.Name("one"),
+            b=cst.Name("two"),
+            c=cst.BinaryOperation(
+                lpar=(cst.LeftParen(),),
+                left=cst.Name("three"),
+                operator=cst.Multiply(),
+                right=cst.Name("four"),
+                rpar=(cst.RightParen(),),
+            ),
+        )
+        self.assertEqual(
+            self.code(expression), "one + two + (three * four)",
+        )


### PR DESCRIPTION
## Summary

Implement basic templated statement/expression/module parsing. This has some corner cases that we do not currently handle, but those will come in a later commit. For example, if you try to substitute a `Parameters` node, it will currently fail. There are checks to let you know that it is not supported, but additional smarts will have to be added to make this work in the future.

## Test Plan

Added some basic tests, pyre, existing tests.