### PR TITLE
Add "evaluated_value" support to number types

### DIFF
--- a/libcst/_nodes/expression.py
+++ b/libcst/_nodes/expression.py
@@ -410,12 +410,8 @@ class BaseNumber(BaseExpression, ABC):
 class Integer(BaseNumber):
     #: A string representation of the integer, such as ``"100000"`` or ``100_000``.
     #:
-    #: To convert this string representation to an ``int`` pass this ``value`` into
-    #: |int|_ or :func:`ast.literal_eval`.
-    #:
-    #: .. intersphinx doesn't pick up on the `int` builtin.
-    #: .. |int| replace:: :func:`int`
-    #: .. _int: https://docs.python.org/3.7/library/functions.html#int
+    #: To convert this string representation to an ``int``, use the calculated
+    #: property :attr:`~Integer.evaluated_value`.
     value: str
 
     lpar: Sequence[LeftParen] = ()
@@ -438,6 +434,13 @@ class Integer(BaseNumber):
         with self._parenthesize(state):
             state.add_token(self.value)
 
+    @property
+    def evaluated_value(self) -> int:
+        """
+        Return an :func:`ast.literal_eval` evaluated int of :py:attr:`value`.
+        """
+        return literal_eval(self.value)
+
 
 @add_slots
 @dataclass(frozen=True)
@@ -445,12 +448,8 @@ class Float(BaseNumber):
     #: A string representation of the floating point number, such as ``"0.05"``,
     #: ``".050"``, or ``"5e-2"``.
     #:
-    #: To convert this string representation to a ``float`` pass this ``value`` into
-    #: |float|_ or :func:`ast.literal_eval`.
-    #:
-    #: .. intersphinx doesn't pick up on the `float` builtin.
-    #: .. |float| replace:: :func:`float`
-    #: .. _float: https://docs.python.org/3.7/library/functions.html#float
+    #: To convert this string representation to an ``float``, use the calculated
+    #: property :attr:`~Float.evaluated_value`.
     value: str
 
     lpar: Sequence[LeftParen] = ()
@@ -473,18 +472,21 @@ class Float(BaseNumber):
         with self._parenthesize(state):
             state.add_token(self.value)
 
+    @property
+    def evaluated_value(self) -> float:
+        """
+        Return an :func:`ast.literal_eval` evaluated float of :py:attr:`value`.
+        """
+        return literal_eval(self.value)
+
 
 @add_slots
 @dataclass(frozen=True)
 class Imaginary(BaseNumber):
     #: A string representation of the imaginary (complex) number, such as ``"2j"``.
     #:
-    #: To convert this string representation to a ``complex`` pass this ``value`` into
-    #: |complex|_ or :func:`ast.literal_eval`.
-    #:
-    #: .. intersphinx doesn't pick up on the `complex` builtin.
-    #: .. |complex| replace:: :func:`complex`
-    #: .. _complex: https://docs.python.org/3.7/library/functions.html#complex
+    #: To convert this string representation to an ``complex``, use the calculated
+    #: property :attr:`~Imaginary.evaluated_value`.
     value: str
 
     lpar: Sequence[LeftParen] = ()
@@ -506,6 +508,13 @@ class Imaginary(BaseNumber):
     def _codegen_impl(self, state: CodegenState) -> None:
         with self._parenthesize(state):
             state.add_token(self.value)
+
+    @property
+    def evaluated_value(self) -> complex:
+        """
+        Return an :func:`ast.literal_eval` evaluated complex of :py:attr:`value`.
+        """
+        return literal_eval(self.value)
 
 
 class BaseString(BaseExpression, ABC):
@@ -567,7 +576,7 @@ class SimpleString(_BasePrefixedString):
     #: The texual representation of the string, including quotes, prefix characters, and
     #: any escape characters present in the original source code , such as
     #: ``r"my string\n"``. To remove the quotes and interpret any escape characters,
-    #: pass this ``value`` into :func:`ast.literal_eval`.
+    #: use the calculated property :attr:`~SimpleString.evaluated_value`.
     value: str
 
     lpar: Sequence[LeftParen] = ()

--- a/libcst/codegen/gen_matcher_classes.py
+++ b/libcst/codegen/gen_matcher_classes.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
-import ast
 from dataclasses import dataclass, fields
 from typing import Generator, List, Optional, Sequence, Set, Tuple, Type, Union
 
@@ -94,11 +93,7 @@ class MatcherClassToLibCSTClass(cst.CSTTransformer):
     def leave_SimpleString(
         self, original_node: cst.SimpleString, updated_node: cst.SimpleString
     ) -> Union[cst.SimpleString, cst.Attribute]:
-        try:
-            value = ast.literal_eval(updated_node.value)
-        except SyntaxError:
-            return updated_node
-
+        value = updated_node.evaluated_value
         if value in CST_DIR:
             return cst.Attribute(cst.Name("cst"), cst.Name(value))
         return updated_node
@@ -287,7 +282,7 @@ def _get_raw_name(node: cst.CSTNode) -> Optional[str]:
     if isinstance(node, cst.Name):
         return node.value
     elif isinstance(node, cst.SimpleString):
-        return ast.literal_eval(node.value)
+        return node.evaluated_value
     elif isinstance(node, cst.SubscriptElement):
         return _get_raw_name(node.slice)
     elif isinstance(node, cst.Index):

--- a/libcst/codegen/transforms.py
+++ b/libcst/codegen/transforms.py
@@ -36,13 +36,11 @@ class DoubleQuoteForwardRefsTransformer(m.MatcherDecoratableTransformer):
         self, original_node: cst.SimpleString, updated_node: cst.SimpleString
     ) -> cst.SimpleString:
         # For prettiness, convert all single-quoted forward refs to double-quoted.
-        if updated_node.value.startswith("'") and updated_node.value.endswith("'"):
+        if "'" in updated_node.quote:
             new_value = f'"{updated_node.value[1:-1]}"'
             try:
-                if ast.literal_eval(updated_node.value) == ast.literal_eval(new_value):
-                    return updated_node.with_changes(
-                        value=f'"{updated_node.value[1:-1]}"'
-                    )
+                if updated_node.evaluated_value == ast.literal_eval(new_value):
+                    return updated_node.with_changes(value=new_value)
             except SyntaxError:
                 pass
         return updated_node

--- a/libcst/helpers/common.py
+++ b/libcst/helpers/common.py
@@ -21,6 +21,6 @@ def ensure_type(node: object, nodetype: Type[CSTNodeT]) -> CSTNodeT:
 
     if not isinstance(node, nodetype):
         raise Exception(
-            f"Expected a {nodetype.__name__} bot got a {node.__class__.__name__}!"
+            f"Expected a {nodetype.__name__} but got a {node.__class__.__name__}!"
         )
     return node

--- a/libcst/helpers/tests/test_expression.py
+++ b/libcst/helpers/tests/test_expression.py
@@ -37,3 +37,21 @@ class ExpressionTest(UnitTest):
         )
         self.assertEqual(node.value, raw_string)
         self.assertEqual(node.evaluated_value, literal_eval(raw_string))
+
+    def test_integer_evaluated_value(self) -> None:
+        raw_value = "5"
+        node = cst.helpers.ensure_type(cst.parse_expression(raw_value), cst.Integer)
+        self.assertEqual(node.value, raw_value)
+        self.assertEqual(node.evaluated_value, literal_eval(raw_value))
+
+    def test_float_evaluated_value(self) -> None:
+        raw_value = "5.5"
+        node = cst.helpers.ensure_type(cst.parse_expression(raw_value), cst.Float)
+        self.assertEqual(node.value, raw_value)
+        self.assertEqual(node.evaluated_value, literal_eval(raw_value))
+
+    def test_complex_evaluated_value(self) -> None:
+        raw_value = "5j"
+        node = cst.helpers.ensure_type(cst.parse_expression(raw_value), cst.Imaginary)
+        self.assertEqual(node.value, raw_value)
+        self.assertEqual(node.evaluated_value, literal_eval(raw_value))


### PR DESCRIPTION
## Summary

Extend the support for `evaluated_value` from just strings to numbers as well. Follow up with a few tweaks to code that used `literal_eval` and swap it over to using the calculated properties. Update the docs to encourage using the properties instead of `literal_eval` as well.

## Test Plan

new and existing tests, pyre, tox