### PR TITLE
Add decorator support to get_full_name helper

### DIFF
--- a/libcst/helpers/expression.py
+++ b/libcst/helpers/expression.py
@@ -11,7 +11,8 @@ import libcst as cst
 
 def get_full_name_for_node(node: Union[str, cst.CSTNode]) -> Optional[str]:
     """Return a dot concatenated full name for str, :class:`~libcst.Name`, :class:`~libcst.Attribute`.
-    :class:`~libcst.Call`, :class:`~libcst.Subscript`, :class:`~libcst.FunctionDef`, :class:`~libcst.ClassDef`.
+    :class:`~libcst.Call`, :class:`~libcst.Subscript`, :class:`~libcst.FunctionDef`, :class:`~libcst.ClassDef`,
+    :class:`~libcst.Decorator`.
     Return ``None`` for not supported Node.
     """
     if isinstance(node, cst.Name):
@@ -26,4 +27,6 @@ def get_full_name_for_node(node: Union[str, cst.CSTNode]) -> Optional[str]:
         return get_full_name_for_node(node.value)
     elif isinstance(node, (cst.FunctionDef, cst.ClassDef)):
         return get_full_name_for_node(node.name)
+    elif isinstance(node, cst.Decorator):
+        return get_full_name_for_node(node.decorator)
     return None

--- a/libcst/helpers/tests/test_expression.py
+++ b/libcst/helpers/tests/test_expression.py
@@ -8,7 +8,7 @@ from ast import literal_eval
 from typing import Optional, Union
 
 import libcst as cst
-from libcst.helpers import get_full_name_for_node
+from libcst.helpers import ensure_type, get_full_name_for_node
 from libcst.testing.utils import UnitTest, data_provider
 
 
@@ -22,6 +22,12 @@ class ExpressionTest(UnitTest):
             (cst.parse_expression("a.b.c[i]"), "a.b.c"),
             (cst.parse_statement("def fun():  pass"), "fun"),
             (cst.parse_statement("class cls:  pass"), "cls"),
+            (
+                cst.Decorator(
+                    ensure_type(cst.parse_expression("a.b.c.d"), cst.Attribute)
+                ),
+                "a.b.c.d",
+            ),
             (cst.parse_statement("(a.b()).c()"), None),  # not a supported Node type
         )
     )


### PR DESCRIPTION
## Summary

Similar to existing functionality for `Call` and `FunctionDef` nodes, it makes sense to be able to ask what the full name of a decorator is. Add that support.

## Test Plan

existing tests, pyre.