### PR TITLE
[metadata][QualifiedNameProvider] don't provide qualified name for names in Attribute().attr

### DIFF
--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -619,6 +619,10 @@ class ScopeVisitor(cst.CSTVisitor):
     def visit_ImportFrom(self, node: cst.ImportFrom) -> Optional[bool]:
         return self._visit_import_alike(node)
 
+    def visit_Attribute(self, node: cst.Attribute) -> Optional[bool]:
+        node.value.visit(self)  # explicitly not visiting attr
+        return False
+
     def visit_Name(self, node: cst.Name) -> Optional[bool]:
         # not all Name have ExpressionContext
         context = self.provider.get_metadata(ExpressionContextProvider, node, None)

--- a/libcst/metadata/tests/test_qualified_name_provider.py
+++ b/libcst/metadata/tests/test_qualified_name_provider.py
@@ -244,3 +244,23 @@ class ScopeProviderTest(UnitTest):
                 )
 
         MetadataWrapper(cst.parse_module("import a;a.b.c()")).visit(TestVisitor(self))
+
+    def test_name_in_attribute(self) -> None:
+        m, names = get_qualified_name_metadata_provider(
+            """
+            obj = object()
+            obj.eval
+            """
+        )
+        attr = ensure_type(
+            ensure_type(
+                ensure_type(m.body[1], cst.SimpleStatementLine).body[0], cst.Expr
+            ).value,
+            cst.Attribute,
+        )
+        self.assertEqual(
+            names[attr],
+            {QualifiedName(name="obj.eval", source=QualifiedNameSource.LOCAL)},
+        )
+        eval = attr.attr
+        self.assertEqual(names[eval], set())


### PR DESCRIPTION
##  Summary
Example code:
```
obj = object()
obj.eval
```
The current QualifiedNameProvider provide the wrong qualified name `{QualifiedName("builtins.eval", QualifiedNameSource.BUILTIN)}` for `Name("eval")` in attribute `obj.eval`.
The names should be an empty set.

## Test Plan
Unit test.