### PR TITLE
Add support for current package to codemod context.

### DIFF
--- a/libcst/codemod/_context.py
+++ b/libcst/codemod/_context.py
@@ -39,6 +39,12 @@ class CodemodContext:
     #: running codemods from the command line.
     filename: Optional[str] = None
 
+    #: The current module if a codemod is being executed against a file that
+    #: lives on disk, and the repository root is correctly configured. This
+    #: Will take the form of a dotted name such as ``foo.bar.baz`` for a file
+    #: in the repo named ``foo/bar/baz.py``.
+    full_module_name: Optional[str] = None
+
     #: The current top level metadata wrapper for the module being modified.
     #: To access computed metadata when inside an actively running codemod, use
     #: the :meth:`~libcst.MetadataDependent.get_metadata` method on

--- a/libcst/codemod/tests/test_cli.py
+++ b/libcst/codemod/tests/test_cli.py
@@ -1,0 +1,46 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# pyre-strict
+from typing import Optional
+
+from libcst.codemod._cli import _calculate_module
+from libcst.testing.utils import UnitTest, data_provider
+
+
+class TestPackageCalculation(UnitTest):
+    @data_provider(
+        (
+            # Providing no root should give back no module.
+            (None, "/some/dummy/file.py", None),
+            # Providing a file outside the root should give back no module.
+            ("/home/username/root", "/some/dummy/file.py", None),
+            ("/home/username/root/", "/some/dummy/file.py", None),
+            ("/home/username/root", "/home/username/file.py", None),
+            # Various files inside the root should give back valid modules.
+            ("/home/username/root", "/home/username/root/file.py", "file"),
+            ("/home/username/root/", "/home/username/root/file.py", "file"),
+            (
+                "/home/username/root/",
+                "/home/username/root/some/dir/file.py",
+                "some.dir.file",
+            ),
+            # Various special files inside the root should give back valid modules.
+            (
+                "/home/username/root/",
+                "/home/username/root/some/dir/__init__.py",
+                "some.dir",
+            ),
+            (
+                "/home/username/root/",
+                "/home/username/root/some/dir/__main__.py",
+                "some.dir",
+            ),
+        ),
+    )
+    def test_calculate_module(
+        self, repo_root: Optional[str], filename: str, module: str
+    ) -> None:
+        self.assertEqual(_calculate_module(repo_root, filename), module)


### PR DESCRIPTION
## Summary

I want to add helpers to import nodes and in helper directory for getting the module/object/alias for an import in a way compatible with add/remove import transforms. Part of that includes support for relative imports. Until now, we had no way of figuring out the absolute package name from a relative one. So, add that support in preparation of closing that hole in LibCST.

## Test Plan

Added some tests for the new helper method, also modified the noop codemod to print the package name of each file and looked it over for irregularities.