### PR TITLE
Add a --version flag to `libcst.tool`, single-source version.

### DIFF
--- a/libcst/__init__.py
+++ b/libcst/__init__.py
@@ -187,6 +187,7 @@ from libcst._nodes.whitespace import (
 from libcst._parser.entrypoints import parse_expression, parse_module, parse_statement
 from libcst._parser.types.config import PartialParserConfig
 from libcst._removal_sentinel import RemovalSentinel, RemoveFromParent
+from libcst._version import LIBCST_VERSION
 from libcst._visitors import CSTNodeT, CSTTransformer, CSTVisitor, CSTVisitorT
 from libcst.helpers import (  # from libcst import ensure_type is deprecated, will be removed in 0.4.0
     ensure_type,
@@ -200,6 +201,7 @@ from libcst.metadata.wrapper import MetadataWrapper
 
 
 __all__ = [
+    "LIBCST_VERSION",
     "BatchableCSTVisitor",
     "CSTNodeT",
     "CSTTransformer",

--- a/libcst/_version.py
+++ b/libcst/_version.py
@@ -1,0 +1,1 @@
+LIBCST_VERSION: str = "0.3.1"

--- a/libcst/tool.py
+++ b/libcst/tool.py
@@ -23,7 +23,14 @@ from typing import Any, Callable, Dict, List, Sequence, Tuple, Type
 
 import yaml
 
-from libcst import CSTNode, IndentedBlock, Module, PartialParserConfig, parse_module
+from libcst import (
+    LIBCST_VERSION,
+    CSTNode,
+    IndentedBlock,
+    Module,
+    PartialParserConfig,
+    parse_module,
+)
 from libcst._nodes.deep_equals import deep_equals
 from libcst.codemod import (
     CodemodCommand,
@@ -790,6 +797,12 @@ def main(proc_name: str, cli_args: List[str]) -> int:
         add_help=add_help,
         prog=proc_name,
         fromfile_prefix_chars="@",
+    )
+    parser.add_argument(
+        "--version",
+        help="Print current version of LibCST toolset.",
+        action="version",
+        version=f"LibCST version {LIBCST_VERSION}",
     )
     parser.add_argument(
         "action",

--- a/setup.py
+++ b/setup.py
@@ -3,22 +3,32 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import importlib.util
 from os import path
 
 # pyre-ignore Pyre doesn't know about setuptools.
 import setuptools
 
 
+# Grab the readme so that our package stays in sync with github.
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, "README.rst"), encoding="utf-8") as f:
     long_description = f.read()
+
+# Grab the version constant so that libcst.tool stays in sync with this package.
+spec = importlib.util.spec_from_file_location("version", path.join(this_directory, "libcst/_version.py"))
+version = importlib.util.module_from_spec(spec)
+# pyre-ignore Pyre doesn't know about importlib entirely.
+spec.loader.exec_module(version)
+# pyre-ignore Pyre has no way of knowing that this constant exists.
+LIBCST_VERSION = version.LIBCST_VERSION
 
 setuptools.setup(
     name="libcst",
     description="A concrete syntax tree with AST-like properties for Python 3.5, 3.6, 3.7 and 3.8 programs.",
     long_description=long_description,
     long_description_content_type="text/x-rst",
-    version="0.3.1",
+    version=LIBCST_VERSION,
     url="https://github.com/Instagram/LibCST",
     license="MIT",
     packages=setuptools.find_packages(),


### PR DESCRIPTION
## Summary

Basically what it says on the tin. I moved the version to a constant that's accessible inside libcst namespace so I could use it in `libcst.tool`. However, it might be useful for consumers of libcst to know programmatically what version they're working with. There's some convoluted stuff in setup.py because I wanted to make sure this was loaded by file, not by module in order to remove any setup dependencies on existing libcst installations. However, this means there's a single source of truth for both deploying the package as well as getting the version from inside the package.

## Test Plan

tox, pyre, ran `libcst --version` and saw it print the right thing, ran `python3 setup.py --help` and verified it parsed correctly with a version print inside it.