### PR TITLE
Add Various Import Helpers

### DIFF
--- a/libcst/_nodes/statement.py
+++ b/libcst/_nodes/statement.py
@@ -985,6 +985,33 @@ class ImportAlias(CSTNode):
         elif isinstance(comma, Comma):
             comma._codegen(state)
 
+    def _name(self, node: CSTNode) -> str:
+        # Unrolled version of get_full_name_for_node to avoid circular imports.
+        if isinstance(node, Name):
+            return node.value
+        elif isinstance(node, Attribute):
+            return f"{self._name(node.value)}.{node.attr.value}"
+        else:
+            raise Exception("Logic error!")
+
+    @property
+    def evaluated_name(self) -> str:
+        """
+        Returns the string name this :class:`ImportAlias` represents.
+        """
+        return self._name(self.name)
+
+    @property
+    def evaluated_alias(self) -> Optional[str]:
+        """
+        Returns the string name for any alias that this :class:`ImportAlias`
+        has. If there is no ``asname`` attribute, this returns ``None``.
+        """
+        asname = self.asname
+        if asname is not None:
+            return self._name(asname.name)
+        return None
+
 
 @add_slots
 @dataclass(frozen=True)

--- a/libcst/codemod/commands/ensure_import_present.py
+++ b/libcst/codemod/commands/ensure_import_present.py
@@ -39,9 +39,23 @@ class EnsureImportPresentCommand(MagicArgsCodemodCommand):
             type=str,
             default=None,
         )
+        parser.add_argument(
+            "--alias",
+            dest="alias",
+            metavar="ALIAS",
+            help=(
+                "Alias that will be used for the imported module or entity. If left "
+                "empty, no alias will be applied."
+            ),
+            type=str,
+            default=None,
+        )
 
     def get_transforms(self) -> Generator[Type[Codemod], None, None]:
         AddImportsVisitor.add_needed_import(
-            self.context, self.context.scratch["module"], self.context.scratch["entity"]
+            self.context,
+            self.context.scratch["module"],
+            self.context.scratch["entity"],
+            self.context.scratch["alias"],
         )
         yield AddImportsVisitor

--- a/libcst/codemod/commands/tests/test_ensure_import_present.py
+++ b/libcst/codemod/commands/tests/test_ensure_import_present.py
@@ -14,14 +14,24 @@ class EnsureImportPresentCommandTest(CodemodTest):
     def test_import_module(self) -> None:
         before = ""
         after = "import a"
-        self.assertCodemod(before, after, module="a", entity=None)
+        self.assertCodemod(before, after, module="a", entity=None, alias=None)
 
     def test_import_entity(self) -> None:
         before = ""
         after = "from a import b"
-        self.assertCodemod(before, after, module="a", entity="b")
+        self.assertCodemod(before, after, module="a", entity="b", alias=None)
 
     def test_import_wildcard(self) -> None:
         before = "from a import *"
         after = "from a import *"
-        self.assertCodemod(before, after, module="a", entity="b")
+        self.assertCodemod(before, after, module="a", entity="b", alias=None)
+
+    def test_import_module_aliased(self) -> None:
+        before = ""
+        after = "import a as c"
+        self.assertCodemod(before, after, module="a", entity=None, alias="c")
+
+    def test_import_entity_aliased(self) -> None:
+        before = ""
+        after = "from a import b as c"
+        self.assertCodemod(before, after, module="a", entity="b", alias="c")

--- a/libcst/codemod/visitors/tests/test_add_imports.py
+++ b/libcst/codemod/visitors/tests/test_add_imports.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 #
 # pyre-strict
-from libcst.codemod import CodemodTest
+from libcst.codemod import CodemodContext, CodemodTest
 from libcst.codemod.visitors import AddImportsVisitor
 
 
@@ -558,3 +558,65 @@ class TestAddImportsCodemod(CodemodTest):
         """
 
         self.assertCodemod(before, after, [("argparse", None, None)])
+
+    def test_dont_add_relative_object_simple(self) -> None:
+        """
+        Should not add object as an import since it exists.
+        """
+
+        before = """
+            from .c import D
+
+            def foo() -> None:
+                pass
+
+            def bar() -> int:
+                return 5
+        """
+        after = """
+            from .c import D
+
+            def foo() -> None:
+                pass
+
+            def bar() -> int:
+                return 5
+        """
+
+        self.assertCodemod(
+            before,
+            after,
+            [("a.b.c", "D", None)],
+            context_override=CodemodContext(full_module_name="a.b.foobar"),
+        )
+
+    def test_add_object_relative_modify_simple(self) -> None:
+        """
+        Should modify existing import to add new object
+        """
+
+        before = """
+            from .c import E, F
+
+            def foo() -> None:
+                pass
+
+            def bar() -> int:
+                return 5
+        """
+        after = """
+            from .c import D, E, F
+
+            def foo() -> None:
+                pass
+
+            def bar() -> int:
+                return 5
+        """
+
+        self.assertCodemod(
+            before,
+            after,
+            [("a.b.c", "D", None)],
+            context_override=CodemodContext(full_module_name="a.b.foobar"),
+        )

--- a/libcst/helpers/__init__.py
+++ b/libcst/helpers/__init__.py
@@ -5,6 +5,10 @@
 #
 # pyre-strict
 
+from libcst.helpers._statement import (
+    get_absolute_module_for_import,
+    get_absolute_module_for_import_or_raise,
+)
 from libcst.helpers._template import (
     parse_template_expression,
     parse_template_module,
@@ -19,6 +23,8 @@ from libcst.helpers.module import insert_header_comments
 
 
 __all__ = [
+    "get_absolute_module_for_import",
+    "get_absolute_module_for_import_or_raise",
     "get_full_name_for_node",
     "get_full_name_for_node_or_raise",
     "ensure_type",

--- a/libcst/helpers/_statement.py
+++ b/libcst/helpers/_statement.py
@@ -1,0 +1,53 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# pyre-strict
+from typing import Optional
+
+import libcst as cst
+from libcst.helpers.expression import get_full_name_for_node
+
+
+def get_absolute_module_for_import(
+    current_module: Optional[str], import_node: cst.ImportFrom
+) -> Optional[str]:
+    # First, let's try to grab the module name, regardless of relative status.
+    module = import_node.module
+    module_name = get_full_name_for_node(module) if module is not None else None
+    # Now, get the relative import location if it exists.
+    num_dots = len(import_node.relative)
+    if num_dots == 0:
+        # This is an absolute import, so the module is correct.
+        return module_name
+    if current_module is None:
+        # We don't actually have the current module available, so we can't compute
+        # the absolute module from relative.
+        return None
+    # We have the current module, as well as the relative, let's compute the base.
+    modules = current_module.split(".")
+    if len(modules) < num_dots:
+        # This relative import goes past the base of the repository, so we can't calculate it.
+        return None
+    base_module = ".".join(modules[:-num_dots])
+    # Finally, if the module name was supplied, append it to the end.
+    if module_name:
+        # If we went all the way to the top, the base module should be empty, so we
+        # should return the relative bit as absolute. Otherwise, combine the base
+        # module and module name using a dot separator.
+        base_module = (
+            f"{base_module}.{module_name}" if len(base_module) > 0 else module_name
+        )
+    # If they tried to import all the way to the root, return None. Otherwise,
+    # return the module itself.
+    return base_module if len(base_module) > 0 else None
+
+
+def get_absolute_module_for_import_or_raise(
+    current_module: Optional[str], import_node: cst.ImportFrom
+) -> str:
+    module = get_absolute_module_for_import(current_module, import_node)
+    if module is None:
+        raise Exception(f"Unable to compute absolute module for {import_node}")
+    return module

--- a/libcst/helpers/tests/test_statement.py
+++ b/libcst/helpers/tests/test_statement.py
@@ -1,0 +1,85 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# pyre-strict
+from typing import Optional
+
+import libcst as cst
+from libcst.helpers import (
+    ensure_type,
+    get_absolute_module_for_import,
+    get_absolute_module_for_import_or_raise,
+)
+from libcst.testing.utils import UnitTest, data_provider
+
+
+class StatementTest(UnitTest):
+    @data_provider(
+        (
+            # Simple imports that are already absolute.
+            (None, "from a.b import c", "a.b"),
+            ("x.y.z", "from a.b import c", "a.b"),
+            # Relative import that can't be resolved due to missing module.
+            (None, "from ..w import c", None),
+            # Relative import that goes past the module level.
+            ("x", "from ...y import z", None),
+            ("x.y.z", "from .....w import c", None),
+            ("x.y.z", "from ... import c", None),
+            # Correct resolution of absolute from relative modules.
+            ("x.y.z", "from . import c", "x.y"),
+            ("x.y.z", "from .. import c", "x"),
+            ("x.y.z", "from .w import c", "x.y.w"),
+            ("x.y.z", "from ..w import c", "x.w"),
+            ("x.y.z", "from ...w import c", "w"),
+        )
+    )
+    def test_get_absolute_module(
+        self, module: Optional[str], importfrom: str, output: Optional[str],
+    ) -> None:
+        node = ensure_type(cst.parse_statement(importfrom), cst.SimpleStatementLine)
+        assert len(node.body) == 1, "Unexpected number of statements!"
+        import_node = ensure_type(node.body[0], cst.ImportFrom)
+
+        self.assertEqual(get_absolute_module_for_import(module, import_node), output)
+        if output is None:
+            with self.assertRaises(Exception):
+                get_absolute_module_for_import_or_raise(module, import_node)
+        else:
+            self.assertEqual(
+                get_absolute_module_for_import_or_raise(module, import_node), output
+            )
+
+    @data_provider(
+        (
+            # Nodes without an asname
+            (cst.ImportAlias(name=cst.Name("foo")), "foo", None),
+            (
+                cst.ImportAlias(name=cst.Attribute(cst.Name("foo"), cst.Name("bar"))),
+                "foo.bar",
+                None,
+            ),
+            # Nodes with an asname
+            (
+                cst.ImportAlias(
+                    name=cst.Name("foo"), asname=cst.AsName(name=cst.Name("baz"))
+                ),
+                "foo",
+                "baz",
+            ),
+            (
+                cst.ImportAlias(
+                    name=cst.Attribute(cst.Name("foo"), cst.Name("bar")),
+                    asname=cst.AsName(name=cst.Name("baz")),
+                ),
+                "foo.bar",
+                "baz",
+            ),
+        )
+    )
+    def test_importalias_helpers(
+        self, alias_node: cst.ImportAlias, full_name: str, alias: Optional[str]
+    ) -> None:
+        self.assertEqual(alias_node.evaluated_name, full_name)
+        self.assertEqual(alias_node.evaluated_alias, alias)


### PR DESCRIPTION
## Summary

This PR is split across three different commits. The end goal is to get easier insight into import statements with various helpers.

In the first commit, I add several helpers to LibCST in various places:
 - `evaluated_name` and `evaluated_alias` on `ImportAlias`. I noticed a common pattern where we need to know the string name and alias for imports. This helps with that by taking lots of boilerplate away. It makes `ImportAlias` compatible with the existing import gathering and import adding visitors, as well as an upcoming import removal visitor.
 - `get_absolute_module_for_import` (and a version that throws instead of returning `None`). It is actually quite tricky to resolve the absolute module of an import given the current module and an `ImportFrom` node. There are many edge cases. So, I encapsulated all of those in a helper that takes the current absolute module as well as an `ImportFrom` statement and returns a string name of the module that is actually referenced. This is compatible with our existing and upcoming import visitors.

In the second commit, I simply add alias support to the existing CLI tool for adding a new import to a file.

In the third commit, I simplify both the import gatherer and import adder visitors by using the helpers from the first commit. In doing so, I also enabled support for relative imports in both codemods, removing a long-standing known issue with both. I added new tests for verifying relative imports, and the existing tests all pass.

## Test Plan

Added a lot of new tests, pyre, tox, existing tests.