### PR TITLE
Augment format() -> f-string Codemod

### DIFF
--- a/libcst/codemod/commands/tests/test_convert_format_to_fstring.py
+++ b/libcst/codemod/commands/tests/test_convert_format_to_fstring.py
@@ -89,7 +89,7 @@ class ConvertFormatStringCommandTest(CodemodTest):
             def foobarbaz() -> str:
                 return "{}".format('\\n')
 
-            def awaitable() -> str:
+            async def awaitable() -> str:
                 return "{}".format(await bla())
         """
         after = """
@@ -113,7 +113,7 @@ class ConvertFormatStringCommandTest(CodemodTest):
             def foobarbaz() -> str:
                 return "{}".format('\\n')
 
-            def awaitable() -> str:
+            async def awaitable() -> str:
                 return "{}".format(await bla())
         """
 
@@ -130,6 +130,46 @@ class ConvertFormatStringCommandTest(CodemodTest):
             ],
             # await isn't supported inside functions in 3.6
             python_version="3.7",
+        )
+
+    def test_enable_unsupported_comments(self) -> None:
+        """
+        Should codemod code with a comment in it, by removing the comment.
+        """
+
+        before = """
+            def foobar() -> str:
+                return "{}".format((
+                    1 +
+                    # Woah, comment
+                    2
+                ))
+        """
+        after = """
+            def foobar() -> str:
+                return f"{( 1 + 2 )}"
+        """
+
+        self.assertCodemod(
+            before, after, allow_strip_comments=True, python_version="3.7",
+        )
+
+    def test_enable_unsupported_await(self) -> None:
+        """
+        Should codemod code with an await in it, by enabling 3.7+ behavior.
+        """
+
+        before = """
+            async def awaitable() -> str:
+                return "{}".format(await bla())
+        """
+        after = """
+            async def awaitable() -> str:
+                return f"{await bla()}"
+        """
+
+        self.assertCodemod(
+            before, after, allow_await=True, python_version="3.7",
         )
 
     def test_unsupported_formatspec(self) -> None:

--- a/libcst/codemod/commands/tests/test_convert_format_to_fstring.py
+++ b/libcst/codemod/commands/tests/test_convert_format_to_fstring.py
@@ -172,22 +172,39 @@ class ConvertFormatStringCommandTest(CodemodTest):
             before, after, allow_await=True, python_version="3.7",
         )
 
-    def test_unsupported_formatspec(self) -> None:
+    def test_formatspec_conversion(self) -> None:
         """
-        Should do nothing, we don't support format-specs right now.
+        Should convert a format specifier which includes format-spec mini language
+        of its own as well as several basic varieties.
         """
         before = """
             def foo() -> str:
                 return "{0:#0{1}x}".format(1, 4)
+
+            def bar() -> str:
+                return "{:#0{}x} {}".format(1, 4, 5)
+
+            def baz() -> str:
+                return "{x:#0{y}x}".format(x=1, y=4)
+
+            def foobar() -> str:
+                return "{:0>3d}".format(x)
         """
         after = """
             def foo() -> str:
-                return "{0:#0{1}x}".format(1, 4)
+                return f"{1:#0{4}x}"
+
+            def bar() -> str:
+                return f"{1:#0{4}x} {5}"
+
+            def baz() -> str:
+                return f"{1:#0{4}x}"
+
+            def foobar() -> str:
+                return f"{x:0>3d}"
         """
         self.assertCodemod(
-            before,
-            after,
-            expected_warnings=["Unsupported format_spec #0{1}x in format() call"],
+            before, after,
         )
 
     def test_position_replacement(self) -> None:


### PR DESCRIPTION
## Summary

This closes a few holes in the format() to f-string codemod. Namely, it adds switches to some more dangerous behavior, and fixes the fact that we had a TODO for format specifications. This should be able to handle far more edge cases now.

## Test Plan

Added several new tests.