### PR TITLE
Optimize Scope Analysis memory usage by removing unnecessary Assignment creation

### DIFF
--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -556,6 +556,8 @@ class ComprehensionScope(LocalScope):
 
 
 class ScopeVisitor(cst.CSTVisitor):
+    # TODO: Don't provide scope for formatting nodes (semicolon, which space, etc.)
+    # since it's probably not useful. That can makes this visitor cleaner.
     def __init__(self, provider: "ScopeProvider") -> None:
         self.provider: ScopeProvider = provider
         self.scope: Scope = GlobalScope()
@@ -700,7 +702,7 @@ class ScopeVisitor(cst.CSTVisitor):
                 attr.visit(self)
         return False
 
-    def visit_Arg(self, node: cst.Arg) -> Optional[bool]:
+    def visit_Arg(self, node: cst.Arg) -> bool:
         # The keyword of Arg is neither an Assignment nor an Access and we explicitly don't visit it.
         for attr in [
             node.value,

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -36,6 +36,8 @@ from libcst.metadata.expression_context_provider import (
 )
 
 
+@add_slots
+@dataclass(frozen=False)
 class Access:
     """
     An Access records an access of an assignment.
@@ -698,10 +700,19 @@ class ScopeVisitor(cst.CSTVisitor):
                 attr.visit(self)
         return False
 
-    def visit_Arg_keyword(self, node: cst.Arg) -> None:
-        keyword = node.keyword
-        if keyword is not None:
-            self.scope.record_assignment(keyword.value, node)
+    def visit_Arg(self, node: cst.Arg) -> Optional[bool]:
+        # The keyword of Arg is neither an Assignment nor an Access and we explicitly don't visit it.
+        for attr in [
+            node.value,
+            node.equal,
+            node.comma,
+            node.star,
+            node.whitespace_after_star,
+            node.whitespace_after_arg,
+        ]:
+            if isinstance(attr, cst.CSTNode):
+                attr.visit(self)
+        return False
 
     def visit_ClassDef(self, node: cst.ClassDef) -> Optional[bool]:
         self.scope.record_assignment(node.name.value, node)

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -987,3 +987,12 @@ class ScopeProviderTest(UnitTest):
             {ensure_type(del_a_b.target, cst.Attribute).value},
         )
         self.assertEqual(scope["b"], ())
+
+    def test_keyword_arg_in_call(self) -> None:
+        m, scopes = get_scope_metadata_provider("call(arg=val)")
+        call = ensure_type(
+            ensure_type(m.body[0], cst.SimpleStatementLine).body[0], cst.Expr
+        ).value
+        scope = scopes[call]
+        self.assertIsInstance(scope, GlobalScope)
+        self.assertEqual(len(scope["arg"]), 0)  # no assignment should exist


### PR DESCRIPTION
## Summary
In one of the use case, **the Scope Analysis consumed 6GB memory**.

The use case has lots of object creation (Call node) using keyword argument.

`Arg.keyword` is created as an `Assignment` and stored in the parent scope which doesn't make sense.

E.g. An "arg" `Assignment` was created and stored in `GlobalScope`.
```
call(arg=val)
```

Unless we create a `LocalScope` for `Call` node, no `Assignment` should be created in this case.

Adding a `LocalScope` for `Call` node probably won't be very useful since there won't be references.

For now, we just remove the `Assignment` creation.

This reduces memory usage from 6GB to 75MB and makes it **80X more memory** efficient for this specific benchmark.

Also include another small optimization which add slots to `Access`.

CC @zsol

## Test Plan
Added test case and it only pass with the new change.

Generate a Python file with lots of keyword args:
```
lines = []
for i in range(1000):
    offset = i * 1000
    args = ", ".join([f"arg{offset+j}=val{offset+j}" for j in range(100)])
    lines.append(f"func({args})\n")

with open("generated_test_file_massive_keyword_arg_calls.py", "w") as fp:
    fp.writelines(lines)
```
Benchmark script: `bench.py`
```
import libcst as cst
from libcst.metadata import MetadataWrapper, ScopeProvider


txt = open(
    "generated_test_file_massive_keyword_arg_calls.py"
).read()
m = cst.parse_module(txt)
r = MetadataWrapper(m, unsafe_skip_copy=True)
scopes = r.resolve(ScopeProvider)
```
Benchmark command: `time -f "%M" python bench.py`
Before this optimization: 470800
After this optimization: 332496
Memory usage -29.3%

