### PR TITLE
Add a provider for tracking node positions using byte offsets

### DIFF
--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -72,6 +72,7 @@ not use the visitor pattern for computing metadata for a tree.
 Metadata Providers
 ------------------
 :class:`~libcst.metadata.PositionProvider`,
+:class:`~libcst.metadata.ByteSpanPositionProvider`,
 :class:`~libcst.metadata.WhitespaceInclusivePositionProvider`,
 :class:`~libcst.metadata.ExpressionContextProvider`,
 :class:`~libcst.metadata.ScopeProvider`,
@@ -82,8 +83,14 @@ are currently provided. Each metadata provider may has its own custom data struc
 
 Position Metadata
 -----------------
-Position (line and column numbers) metadata are accessible through the metadata
-interface by declaring the one of the following providers as a dependency. For
+There are two types of position metadata available. They both track the same
+position concept, but differ in terms of representation. One represents
+position with line and column numbers, while the other outputs byte offset and
+length pairs.
+
+Line and column numbers are available through the metadata interface by
+declaring one of :class:`~libcst.metadata.PositionProvider` or
+:class:`~libcst.metadata.WhitespaceInclusivePositionProvider`. For
 most cases, :class:`~libcst.metadata.PositionProvider` is what you probably
 want.
 
@@ -96,6 +103,15 @@ objects. See :ref:`the above example<libcst-metadata-position-example>`.
 .. autoclass:: libcst.metadata.CodeRange
 .. autoclass:: libcst.metadata.CodePosition
 
+Byte offset and length pairs can be accessed using
+:class:`~libcst.metadata.ByteSpanPositionProvider`. This provider represents
+positions using :class:`~libcst.metadata.CodeSpan`, which will contain the
+byte offsets of a :class:`~libcst.CSTNode` from the start of the file, and
+its length (also in bytes).
+
+.. autoclass:: libcst.metadata.ByteSpanPositionProvider
+
+.. autoclass:: libcst.metadata.CodeSpan
 
 Expression Context Metadata
 ---------------------------

--- a/libcst/metadata/__init__.py
+++ b/libcst/metadata/__init__.py
@@ -43,6 +43,7 @@ from libcst.metadata.scope_provider import (
     Scope,
     ScopeProvider,
 )
+from libcst.metadata.span_provider import ByteSpanPositionProvider, CodeSpan
 from libcst.metadata.type_inference_provider import TypeInferenceProvider
 from libcst.metadata.wrapper import MetadataWrapper
 
@@ -50,8 +51,10 @@ from libcst.metadata.wrapper import MetadataWrapper
 __all__ = [
     "CodePosition",
     "CodeRange",
+    "CodeSpan",
     "WhitespaceInclusivePositionProvider",
     "PositionProvider",
+    "ByteSpanPositionProvider",
     "BaseMetadataProvider",
     "ExpressionContext",
     "ExpressionContextProvider",

--- a/libcst/metadata/span_provider.py
+++ b/libcst/metadata/span_provider.py
@@ -1,0 +1,112 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Callable, Iterator, List, Optional
+
+from libcst import CSTNode, Module
+from libcst._nodes.internal import CodegenState
+from libcst.metadata.base_provider import BaseMetadataProvider
+
+
+@dataclass(frozen=True)
+class CodeSpan:
+    """
+    Represents the position of a piece of code by its starting position and length.
+
+    Note: This class does not specify the unit of distance - it can be bytes,
+    Unicode characters, or something else entirely.
+    """
+
+    #: Offset of the code from the beginning of the file. Can be 0.
+    start: int
+    #: Length of the span
+    length: int
+
+
+@dataclass(frozen=False)
+class SpanProvidingCodegenState(CodegenState):
+    provider: BaseMetadataProvider[CodeSpan]
+    get_length: Optional[Callable[[str], int]] = None
+    position: int = 0
+    _stack: List[int] = field(default_factory=list)
+
+    def add_indent_tokens(self) -> None:
+        super().add_indent_tokens()
+        for token in self.indent_tokens:
+            self._update_position(token)
+
+    def add_token(self, value: str) -> None:
+        super().add_token(value)
+        self._update_position(value)
+
+    def _update_position(self, value: str) -> None:
+        get_length = self.get_length or len
+        self.position += get_length(value)
+
+    def before_codegen(self, node: CSTNode) -> None:
+        self._stack.append(self.position)
+
+    def after_codegen(self, node: CSTNode) -> None:
+        start = self._stack.pop()
+
+        if node not in self.provider._computed:
+            end = self.position
+            self.provider._computed[node] = CodeSpan(start, length=end - start)
+
+    @contextmanager
+    def record_syntactic_position(
+        self,
+        node: CSTNode,
+        *,
+        start_node: Optional[CSTNode] = None,
+        end_node: Optional[CSTNode] = None,
+    ) -> Iterator[None]:
+        start = self.position
+        try:
+            yield
+        finally:
+            end = self.position
+            start = (
+                self.provider._computed[start_node].start
+                if start_node is not None
+                else start
+            )
+            if end_node is not None:
+                end_span = self.provider._computed[end_node]
+                length = (end_span.start + end_span.length) - start
+            else:
+                length = end - start
+            self.provider._computed[node] = CodeSpan(start, length=length)
+
+
+def byte_length_in_utf8(value: str) -> int:
+    return len(value.encode("utf8"))
+
+
+class ByteSpanPositionProvider(BaseMetadataProvider[CodeSpan]):
+    """
+    Generates offset and length metadata for nodes' positions.
+
+    For each :class:`CSTNode` this provider generates a :class:`CodeSpan` that
+    contains the byte-offset of the node from the start of the file, and its
+    length (also in bytes). The whitespace owned by the node is not included in
+    this length.
+
+    Note: offset and length measure bytes, not characters (which is significant for
+    example in the case of Unicode characters encoded in more than one byte)
+    """
+
+    def _gen_impl(self, module: Module) -> None:
+        state = SpanProvidingCodegenState(
+            default_indent=module.default_indent,
+            default_newline=module.default_newline,
+            provider=self,
+            get_length=byte_length_in_utf8,
+        )
+        module._codegen(state)

--- a/libcst/metadata/tests/test_span_provider.py
+++ b/libcst/metadata/tests/test_span_provider.py
@@ -1,0 +1,108 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import libcst as cst
+from libcst.metadata.span_provider import (
+    ByteSpanPositionProvider,
+    CodeSpan,
+    SpanProvidingCodegenState,
+    byte_length_in_utf8,
+)
+from libcst.testing.utils import UnitTest
+
+
+class SpanProvidingCodegenStateTest(UnitTest):
+    def test_initial_position(self) -> None:
+        state = SpanProvidingCodegenState(
+            " " * 4,
+            "\n",
+            get_length=byte_length_in_utf8,
+            provider=ByteSpanPositionProvider(),
+        )
+        self.assertEqual(state.position, 0)
+
+    def test_add_token(self) -> None:
+        state = SpanProvidingCodegenState(
+            " " * 4,
+            "\n",
+            get_length=byte_length_in_utf8,
+            provider=ByteSpanPositionProvider(),
+        )
+        state.add_token("12")
+        self.assertEqual(state.position, 2)
+
+    def test_add_non_ascii_token(self) -> None:
+        state = SpanProvidingCodegenState(
+            " " * 4,
+            "\n",
+            get_length=byte_length_in_utf8,
+            provider=ByteSpanPositionProvider(),
+        )
+        state.add_token("🤡")
+        self.assertEqual(state.position, 4)
+
+    def test_add_indent_tokens(self) -> None:
+        state = SpanProvidingCodegenState(
+            " " * 4,
+            "\n",
+            get_length=byte_length_in_utf8,
+            provider=ByteSpanPositionProvider(),
+        )
+        state.increase_indent(state.default_indent)
+        state.add_indent_tokens()
+        self.assertEqual(state.position, 4)
+
+    def test_span(self) -> None:
+        node = cst.Pass()
+        state = SpanProvidingCodegenState(
+            " " * 4,
+            "\n",
+            get_length=byte_length_in_utf8,
+            provider=ByteSpanPositionProvider(),
+        )
+        state.before_codegen(node)
+        state.add_token(" ")
+        with state.record_syntactic_position(node):
+            state.add_token("pass")
+        state.add_token(" ")
+        state.after_codegen(node)
+
+        span = state.provider._computed[node]
+        self.assertEqual(span.start, 1)
+        self.assertEqual(span.length, 4)
+
+
+class ByteSpanPositionProviderTest(UnitTest):
+    def test_visitor_provider(self) -> None:
+        test = self
+
+        class SomeVisitor(cst.CSTVisitor):
+            METADATA_DEPENDENCIES = (ByteSpanPositionProvider,)
+
+            def visit_Pass(self, node: cst.Pass) -> None:
+                test.assertEqual(
+                    self.get_metadata(ByteSpanPositionProvider, node),
+                    CodeSpan(start=0, length=4),
+                )
+
+        wrapper = cst.MetadataWrapper(cst.parse_module("pass"))
+        wrapper.visit(SomeVisitor())
+
+    def test_batchable_provider(self) -> None:
+        test = self
+
+        class SomeVisitor(cst.BatchableCSTVisitor):
+            METADATA_DEPENDENCIES = (ByteSpanPositionProvider,)
+
+            def visit_Pass(self, node: cst.Pass) -> None:
+                test.assertEqual(
+                    self.get_metadata(ByteSpanPositionProvider, node),
+                    CodeSpan(start=0, length=4),
+                )
+
+        wrapper = cst.MetadataWrapper(cst.parse_module("pass"))
+        wrapper.visit_batched([SomeVisitor()])


### PR DESCRIPTION
## Summary
This PR implements `ByteSpanPositionProvider` which tracks the positions of cst nodes using a pair of (offset, length) integers, representing

* the byte offset from the start of the file until the first non-whitespace character of the node
* the length of the node in bytes, not counting any trailing whitespace the node owns
## Test Plan
Added unit tests.
