### PR TITLE
[ScopeProvider][optimization] use batch set union in infer_accesses

### DIFF
--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -556,7 +556,6 @@ class ComprehensionScope(LocalScope):
 
 
 class ScopeVisitor(cst.CSTVisitor):
-    # TODO: Don't provide scope for formatting nodes (semicolon, which space, etc.)
     # since it's probably not useful. That can makes this visitor cleaner.
     def __init__(self, provider: "ScopeProvider") -> None:
         self.provider: ScopeProvider = provider
@@ -604,17 +603,6 @@ class ScopeVisitor(cst.CSTVisitor):
                         )
 
                 self.scope.record_assignment(name_value, node)
-
-        # visit remaining attributes
-        if isinstance(node, cst.Import):
-            remaining_attrs = [node.semicolon, node.whitespace_after_import]
-        else:
-            remaining_attrs = [node.semicolon, node.whitespace_after_import]
-
-        for attr in remaining_attrs:
-            if isinstance(attr, cst.CSTNode):
-                attr.visit(self)
-
         return False
 
     def visit_Import(self, node: cst.Import) -> Optional[bool]:
@@ -645,19 +633,6 @@ class ScopeVisitor(cst.CSTVisitor):
             node.params.visit(self)
             node.body.visit(self)
 
-            # visit remaining attributes
-            for attr in [
-                node.asynchronous,
-                node.leading_lines,
-                node.lines_after_decorators,
-                node.whitespace_after_def,
-                node.whitespace_after_name,
-                node.whitespace_before_params,
-                node.whitespace_before_colon,
-            ]:
-                if isinstance(attr, cst.CSTNode):
-                    attr.visit(self)
-
         for decorator in node.decorators:
             decorator.visit(self)
         returns = node.returns
@@ -670,16 +645,6 @@ class ScopeVisitor(cst.CSTVisitor):
         with self._new_scope(FunctionScope, node):
             node.params.visit(self)
             node.body.visit(self)
-
-            # visit remaining attributes
-            for attr in [
-                node.colon,
-                node.lpar,
-                node.rpar,
-                node.whitespace_after_lambda,
-            ]:
-                if isinstance(attr, cst.CSTNode):
-                    attr.visit(self)
         return False
 
     def visit_Param(self, node: cst.Param) -> Optional[bool]:
@@ -690,30 +655,13 @@ class ScopeVisitor(cst.CSTVisitor):
                 if field:
                     field.visit(self)
 
-        # visit remaining attributes
-        for attr in [
-            node.equal,
-            node.comma,
-            node.star,
-            node.whitespace_after_star,
-            node.whitespace_after_param,
-        ]:
-            if isinstance(attr, cst.CSTNode):
-                attr.visit(self)
         return False
 
     def visit_Arg(self, node: cst.Arg) -> bool:
         # The keyword of Arg is neither an Assignment nor an Access and we explicitly don't visit it.
-        for attr in [
-            node.value,
-            node.equal,
-            node.comma,
-            node.star,
-            node.whitespace_after_star,
-            node.whitespace_after_arg,
-        ]:
-            if isinstance(attr, cst.CSTNode):
-                attr.visit(self)
+        value = node.value
+        if value:
+            value.visit(self)
         return False
 
     def visit_ClassDef(self, node: cst.ClassDef) -> Optional[bool]:
@@ -728,39 +676,16 @@ class ScopeVisitor(cst.CSTVisitor):
         with self._new_scope(ClassScope, node, get_full_name_for_node(node.name)):
             for statement in node.body.body:
                 statement.visit(self)
-
-            # visit remaining attributes
-            for attr in [
-                node.lpar,
-                node.rpar,
-                node.leading_lines,
-                node.lines_after_decorators,
-                node.whitespace_after_class,
-                node.whitespace_after_name,
-                node.whitespace_before_colon,
-            ]:
-                if isinstance(attr, cst.CSTNode):
-                    attr.visit(self)
         return False
 
     def visit_Global(self, node: cst.Global) -> Optional[bool]:
         for name_item in node.names:
             self.scope.record_global_overwrite(name_item.name.value)
-
-        # visit remaining attributes
-        for attr in [node.whitespace_after_global, node.semicolon]:
-            if isinstance(attr, cst.CSTNode):
-                attr.visit(self)
         return False
 
     def visit_Nonlocal(self, node: cst.Nonlocal) -> Optional[bool]:
         for name_item in node.names:
             self.scope.record_nonlocal_overwrite(name_item.name.value)
-
-        # visit remaining attributes
-        for attr in [node.whitespace_after_nonlocal, node.semicolon]:
-            if isinstance(attr, cst.CSTNode):
-                attr.visit(self)
         return False
 
     def visit_ListComp(self, node: cst.ListComp) -> Optional[bool]:
@@ -827,26 +752,6 @@ class ScopeVisitor(cst.CSTVisitor):
                 node.value.visit(self)
             else:
                 node.elt.visit(self)
-
-            if isinstance(node, cst.ListComp):
-                remaining_attrs = [node.lbracket, node.rbracket, node.lpar, node.rpar]
-            elif isinstance(node, cst.SetComp):
-                remaining_attrs = [node.lbrace, node.rbrace, node.lpar, node.rpar]
-            elif isinstance(node, cst.DictComp):
-                remaining_attrs = [
-                    node.lbrace,
-                    node.rbrace,
-                    node.lpar,
-                    node.rpar,
-                    node.whitespace_before_colon,
-                    node.whitespace_after_colon,
-                ]
-            else:  # cst.GeneratorExp
-                remaining_attrs = [node.lpar, node.rpar]
-
-            for attr in remaining_attrs:
-                if isinstance(attr, cst.CSTNode):
-                    attr.visit(self)
         return False
 
     def infer_accesses(self) -> None:
@@ -868,6 +773,8 @@ class ScopeProvider(BatchableMetadataProvider[Optional[Scope]]):
     more advanced static analysis. E.g. given a :class:`~libcst.FunctionDef`
     node, we can check the type of its Scope to figure out whether it is a class method
     (:class:`ClassScope`) or a regular function (:class:`GlobalScope`).
+    Scope metadata is available for most node types other than formatting information nodes
+    (whitespace, parentheses, etc.).
     """
 
     METADATA_DEPENDENCIES = (ExpressionContextProvider,)

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -556,6 +556,8 @@ class ComprehensionScope(LocalScope):
 
 
 class ScopeVisitor(cst.CSTVisitor):
+    # TODO: Don't provide scope for formatting nodes (semicolon, which space, etc.)
+    # since it's probably not useful. That can makes this visitor cleaner.
     def __init__(self, provider: "ScopeProvider") -> None:
         self.provider: ScopeProvider = provider
         self.scope: Scope = GlobalScope()
@@ -700,7 +702,7 @@ class ScopeVisitor(cst.CSTVisitor):
                 attr.visit(self)
         return False
 
-    def visit_Arg(self, node: cst.Arg) -> Optional[bool]:
+    def visit_Arg(self, node: cst.Arg) -> bool:
         # The keyword of Arg is neither an Assignment nor an Access and we explicitly don't visit it.
         for attr in [
             node.value,

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -49,7 +49,7 @@ class ScopeProviderTest(UnitTest):
             """
         )
         global_scope = scopes[m]
-        self.assertEqual(global_scope["not_in_scope"], ())
+        self.assertEqual(global_scope["not_in_scope"], set())
 
     def test_accesses(self) -> None:
         m, scopes = get_scope_metadata_provider(
@@ -64,7 +64,7 @@ class ScopeProviderTest(UnitTest):
         )
         scope_of_module = scopes[m]
         self.assertIsInstance(scope_of_module, GlobalScope)
-        global_foo_assignments = scope_of_module["foo"]
+        global_foo_assignments = list(scope_of_module["foo"])
         self.assertEqual(len(global_foo_assignments), 1)
         foo_assignment = global_foo_assignments[0]
         self.assertEqual(len(foo_assignment.references), 2)
@@ -91,7 +91,7 @@ class ScopeProviderTest(UnitTest):
         self.assertIsInstance(scope_of_func_statement, FunctionScope)
         func_foo_assignments = scope_of_func_statement["foo"]
         self.assertEqual(len(func_foo_assignments), 1)
-        foo_assignment = func_foo_assignments[0]
+        foo_assignment = list(func_foo_assignments)[0]
         self.assertEqual(len(foo_assignment.references), 1)
         fn3_call_arg = ensure_type(
             ensure_type(
@@ -145,7 +145,7 @@ class ScopeProviderTest(UnitTest):
                 len(scope_of_module[in_scope]), 1, f"{in_scope} should be in scope."
             )
 
-            assignment = cast(Assignment, scope_of_module[in_scope][0])
+            assignment = cast(Assignment, list(scope_of_module[in_scope])[0])
             self.assertEqual(
                 assignment.name,
                 in_scope,
@@ -171,7 +171,7 @@ class ScopeProviderTest(UnitTest):
             self.assertEqual(
                 len(scope_of_module[in_scope]), 1, f"{in_scope} should be in scope."
             )
-            import_assignment = cast(Assignment, scope_of_module[in_scope][0])
+            import_assignment = cast(Assignment, list(scope_of_module[in_scope])[0])
             self.assertEqual(
                 import_assignment.name,
                 in_scope,
@@ -226,7 +226,7 @@ class ScopeProviderTest(UnitTest):
         )
         scope_of_module = scopes[m]
         self.assertIsInstance(scope_of_module, GlobalScope)
-        cls_assignments = scope_of_module["Cls"]
+        cls_assignments = list(scope_of_module["Cls"])
         self.assertEqual(len(cls_assignments), 1)
         cls_assignment = cast(Assignment, cls_assignments[0])
         cls_def = ensure_type(m.body[1], cst.ClassDef)
@@ -444,14 +444,14 @@ class ScopeProviderTest(UnitTest):
         scope_of_outer_f = scopes[outer_f.body.body[0]]
         self.assertIsInstance(scope_of_outer_f, FunctionScope)
         self.assertTrue("f" in scope_of_outer_f)
-        out_f_assignment = scope_of_module["f"][0]
+        out_f_assignment = list(scope_of_module["f"])[0]
         self.assertEqual(cast(Assignment, out_f_assignment).node, outer_f)
 
         inner_f = ensure_type(outer_f.body.body[0], cst.FunctionDef)
         scope_of_inner_f = scopes[inner_f.body.body[0]]
         self.assertIsInstance(scope_of_inner_f, FunctionScope)
         self.assertTrue("f" in scope_of_inner_f)
-        inner_f_assignment = scope_of_outer_f["f"][0]
+        inner_f_assignment = list(scope_of_outer_f["f"])[0]
         self.assertEqual(cast(Assignment, inner_f_assignment).node, inner_f)
 
     def test_func_param_scope(self) -> None:
@@ -505,11 +505,11 @@ class ScopeProviderTest(UnitTest):
         self.assertTrue("kwarg" not in scope_of_module)
         self.assertTrue("kwarg" in scope_of_f)
 
-        self.assertEqual(cast(Assignment, scope_of_f["x"][0]).node, x)
-        self.assertEqual(cast(Assignment, scope_of_f["vararg"][0]).node, vararg)
-        self.assertEqual(cast(Assignment, scope_of_f["y"][0]).node, y)
-        self.assertEqual(cast(Assignment, scope_of_f["z"][0]).node, z)
-        self.assertEqual(cast(Assignment, scope_of_f["kwarg"][0]).node, kwarg)
+        self.assertEqual(cast(Assignment, list(scope_of_f["x"])[0]).node, x)
+        self.assertEqual(cast(Assignment, list(scope_of_f["vararg"])[0]).node, vararg)
+        self.assertEqual(cast(Assignment, list(scope_of_f["y"])[0]).node, y)
+        self.assertEqual(cast(Assignment, list(scope_of_f["z"])[0]).node, z)
+        self.assertEqual(cast(Assignment, list(scope_of_f["kwarg"])[0]).node, kwarg)
 
     def test_lambda_param_scope(self) -> None:
         m, scopes = get_scope_metadata_provider(
@@ -556,11 +556,11 @@ class ScopeProviderTest(UnitTest):
         self.assertTrue("kwarg" not in scope_of_module)
         self.assertTrue("kwarg" in scope_of_f)
 
-        self.assertEqual(cast(Assignment, scope_of_f["x"][0]).node, x)
-        self.assertEqual(cast(Assignment, scope_of_f["vararg"][0]).node, vararg)
-        self.assertEqual(cast(Assignment, scope_of_f["y"][0]).node, y)
-        self.assertEqual(cast(Assignment, scope_of_f["z"][0]).node, z)
-        self.assertEqual(cast(Assignment, scope_of_f["kwarg"][0]).node, kwarg)
+        self.assertEqual(cast(Assignment, list(scope_of_f["x"])[0]).node, x)
+        self.assertEqual(cast(Assignment, list(scope_of_f["vararg"])[0]).node, vararg)
+        self.assertEqual(cast(Assignment, list(scope_of_f["y"])[0]).node, y)
+        self.assertEqual(cast(Assignment, list(scope_of_f["z"])[0]).node, z)
+        self.assertEqual(cast(Assignment, list(scope_of_f["kwarg"])[0]).node, kwarg)
 
     def test_except_handler(self) -> None:
         """
@@ -581,7 +581,7 @@ class ScopeProviderTest(UnitTest):
         self.assertIsInstance(scope_of_module, GlobalScope)
         self.assertTrue("ex" in scope_of_module)
         self.assertEqual(
-            cast(Assignment, scope_of_module["ex"][0]).node,
+            cast(Assignment, list(scope_of_module["ex"])[0]).node,
             ensure_type(
                 ensure_type(m.body[0], cst.Try).handlers[0].name, cst.AsName
             ).name,
@@ -598,7 +598,7 @@ class ScopeProviderTest(UnitTest):
         self.assertIsInstance(scope_of_module, GlobalScope)
         self.assertTrue("f" in scope_of_module)
         self.assertEqual(
-            cast(Assignment, scope_of_module["f"][0]).node,
+            cast(Assignment, list(scope_of_module["f"])[0]).node,
             ensure_type(
                 ensure_type(m.body[0], cst.With).items[0].asname, cst.AsName
             ).name,
@@ -806,11 +806,10 @@ class ScopeProviderTest(UnitTest):
         scope_of_module = scopes[a_outer_assign]
         a_outer_assignments = scope_of_module.assignments[a_outer_access]
         self.assertEqual(len(a_outer_assignments), 1)
+        a_outer_assignment = list(a_outer_assignments)[0]
+        self.assertEqual(cast(Assignment, a_outer_assignment).node, a_outer_assign)
         self.assertEqual(
-            cast(Assignment, list(a_outer_assignments)[0]).node, a_outer_assign
-        )
-        self.assertEqual(
-            {i.node for i in list(a_outer_assignments)[0].references}, {a_outer_access}
+            {i.node for i in a_outer_assignment.references}, {a_outer_access}
         )
 
         a_outer_assesses = scope_of_module.accesses[a_outer_assign]
@@ -986,7 +985,7 @@ class ScopeProviderTest(UnitTest):
             {i.node for i in a_assign.references},
             {ensure_type(del_a_b.target, cst.Attribute).value},
         )
-        self.assertEqual(scope["b"], ())
+        self.assertEqual(scope["b"], set())
 
     def test_keyword_arg_in_call(self) -> None:
         m, scopes = get_scope_metadata_provider("call(arg=val)")


### PR DESCRIPTION
## Summary
Aggregate access with the same name and batch add with set union as an optimization.
In worst case, all accesses (m) and assignments (n) refer to the same name,
the time complexity is O(m x n), this optimizes it as O(m + n).

This also changed the return of scope assignments from Tuple to Set to make it faster without creating Tuple.
Checked current use cases and all of them just iterate on the returned assignments which don't explicit use it as a Tuple. This change is safe.

@zsol 

## Test Plan
Existing unit tests.

Test on a file with 70k lines with 50k access of the same name. Combine both the optimization of not visiting formatting info and this infer access optimization.
Before the optimization: `7min 49.90secs`
After both optimization: `2min 25.19secs` (3.2X faster)