### PR TITLE
[helper] add get_docstring() to Module, ClassDef and FunctionDef

### DIFF
--- a/libcst/_nodes/expression.py
+++ b/libcst/_nodes/expression.py
@@ -1020,6 +1020,23 @@ class ConcatenatedString(BaseString):
             self.whitespace_between._codegen(state)
             self.right._codegen(state)
 
+    @property
+    def evaluated_value(self) -> Optional[str]:
+        """
+        Return an :func:`ast.literal_eval` evaluated str of recursively concatenated :py:attr:`left` and :py:attr:`right`
+        if and only if both :py:attr:`left` and :py:attr:`right` are composed by :class:`SimpleString` or :class:`ConcatenatedString`
+        (:class:`FormattedString` cannot be evaluated).
+        """
+        left = self.left
+        right = self.right
+        if isinstance(left, FormattedString) or isinstance(right, FormattedString):
+            return None
+        left_val = left.evaluated_value
+        right_val = right.evaluated_value
+        if right_val is None:
+            return None
+        return left_val + right_val
+
 
 @add_slots
 @dataclass(frozen=True)

--- a/libcst/_nodes/module.py
+++ b/libcst/_nodes/module.py
@@ -4,12 +4,16 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Sequence, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Optional, Sequence, TypeVar, Union, cast
 
 from libcst._add_slots import add_slots
 from libcst._nodes.base import CSTNode
 from libcst._nodes.internal import CodegenState, visit_body_sequence, visit_sequence
-from libcst._nodes.statement import BaseCompoundStatement, SimpleStatementLine
+from libcst._nodes.statement import (
+    BaseCompoundStatement,
+    SimpleStatementLine,
+    get_docstring_impl,
+)
 from libcst._nodes.whitespace import EmptyLine
 from libcst._removal_sentinel import RemovalSentinel
 from libcst._visitors import CSTVisitorT
@@ -154,3 +158,9 @@ class Module(CSTNode):
             default_indent=self.default_indent,
             default_newline=self.default_newline,
         )
+
+    def get_docstring(self, clean=True) -> Optional[str]:
+        """
+        Returns a :func:`inspect.cleandoc` cleaned docstring if the docstring is available, ``None`` otherwise.
+        """
+        return get_docstring_impl(self.body, clean)

--- a/libcst/_nodes/tests/test_docstring.py
+++ b/libcst/_nodes/tests/test_docstring.py
@@ -1,0 +1,143 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from textwrap import dedent
+from typing import Optional
+
+import libcst as cst
+from libcst.helpers import ensure_type
+from libcst.testing.utils import UnitTest, data_provider
+
+
+class DocstringTest(UnitTest):
+    @data_provider(
+        (
+            ("", None),
+            ('""', ""),
+            ("# comment is not docstring", None),
+            (
+                '''
+                # comment
+                """docstring in triple quotes."""
+                ''',
+                "docstring in triple quotes.",
+            ),
+            ('''"docstring in single quotes."''', "docstring in single quotes.",),
+            (
+                '''
+                # comment
+                """docstring in """ "concatenated strings."
+                ''',
+                "docstring in concatenated strings.",
+            ),
+        )
+    )
+    def test_module_docstring(self, code: str, docstring: Optional[str]) -> None:
+        self.assertEqual(cst.parse_module(dedent(code)).get_docstring(), docstring)
+
+    @data_provider(
+        (
+            (
+                """
+                def f():  # comment"
+                    pass
+                """,
+                None,
+            ),
+            ('def f():"docstring"', "docstring"),
+            (
+                '''
+                def f():
+                    """
+                    This function has no input
+                    and always returns None.
+                    """
+                ''',
+                "This function has no input\nand always returns None.",
+            ),
+            (
+                """
+            def fn():  # comment 1
+                # comment 2
+                
+                
+                
+                "docstring"
+            """,
+                "docstring",
+            ),
+            (
+                """
+                def fn():
+                    ("docstring")
+                """,
+                "docstring",
+            ),
+        )
+    )
+    def test_function_docstring(self, code: str, docstring: Optional[str]) -> None:
+        self.assertEqual(
+            ensure_type(
+                cst.parse_statement(dedent(code)), cst.FunctionDef
+            ).get_docstring(),
+            docstring,
+        )
+
+    @data_provider(
+        (
+            (
+                """
+                class C:  # comment"
+                    pass
+                """,
+                None,
+            ),
+            ('class C(Base):"docstring"', "docstring"),
+            (
+                '''
+                class C(Base):
+                    # a comment
+                    
+                    """
+                    This class has a multi-
+                    line docstring.
+                    """
+                ''',
+                "This class has a multi-\nline docstring.",
+            ),
+            (
+                """
+            class C(A, B):  # comment 1
+                # comment 2
+                "docstring"
+            """,
+                "docstring",
+            ),
+        )
+    )
+    def test_class_docstring(self, code: str, docstring: Optional[str]) -> None:
+        self.assertEqual(
+            ensure_type(
+                cst.parse_statement(dedent(code)), cst.ClassDef
+            ).get_docstring(),
+            docstring,
+        )
+
+    def test_clean_docstring(self) -> None:
+        code = '''
+               """   A docstring with indentation one first line
+                 and the second line.
+               """
+               '''
+        self.assertEqual(
+            cst.parse_module(dedent(code)).get_docstring(),
+            "A docstring with indentation one first line\nand the second line.",
+        )
+        self.assertEqual(
+            cst.parse_module(dedent(code)).get_docstring(clean=False),
+            "   A docstring with indentation one first line\n  and the second line.\n",
+        )

--- a/libcst/helpers/tests/test_expression.py
+++ b/libcst/helpers/tests/test_expression.py
@@ -68,3 +68,17 @@ class ExpressionTest(UnitTest):
         node = ensure_type(cst.parse_expression(raw_value), cst.Imaginary)
         self.assertEqual(node.value, raw_value)
         self.assertEqual(node.evaluated_value, literal_eval(raw_value))
+
+    def test_concatenated_string_evaluated_value(self) -> None:
+        code = '"This " "is " "a " "concatenated " "string."'
+        node = ensure_type(cst.parse_expression(code), cst.ConcatenatedString)
+        self.assertEqual(node.evaluated_value, "This is a concatenated string.")
+        code = 'b"A concatenated" b" byte."'
+        node = ensure_type(cst.parse_expression(code), cst.ConcatenatedString)
+        self.assertEqual(node.evaluated_value, b"A concatenated byte.")
+        code = '"var=" f" {var}"'
+        node = ensure_type(cst.parse_expression(code), cst.ConcatenatedString)
+        self.assertEqual(node.evaluated_value, None)
+        code = '"var" "=" f" {var}"'
+        node = ensure_type(cst.parse_expression(code), cst.ConcatenatedString)
+        self.assertEqual(node.evaluated_value, None)


### PR DESCRIPTION
## Summary
Add `get_docstring()` to `Module`, `ClassDef` and `FunctionDef`.
Docstring is the first expression (ignoring comments and empty lines) of `Module`, `ClassDef` or `FunctionDef` and it needs to be a `SimpleString` or `ConcatenatedString`.
Note that `ConcatenatedString` can be a tree of nested `ConcatenatedString`. So we need to traverse the entire tree. It returns `None` if any part of the tree is a f-string.
The reason why docstring cannot be a f-string was discussed in https://bugs.python.org/issue28739.

References:
- `ast.get_docstring` https://docs.python.org/3/library/ast.html#ast.get_docstring
    and https://github.com/python/cpython/blob/89aa4694fc8c6d190325ef8ed6ce6a6b8efb3e50/Lib/ast.py#L254
- PEP 257 https://www.python.org/dev/peps/pep-0257/


## Test Plan
Unit tests.
