### PR TITLE
Improve KeyError message for missing metadata

### DIFF
--- a/docs/source/metadata_tutorial.ipynb
+++ b/docs/source/metadata_tutorial.ipynb
@@ -122,7 +122,7 @@
     "\n",
     "module = cst.parse_module(\"def foo(x):\\n    y = 1\\n    return x + y\")\n",
     "wrapper = cst.MetadataWrapper(module)\n",
-    "result = wrapper.visit(ParamPrinter())"
+    "result = wrapper.visit(ParamPrinter())  # NB: wrapper.visit not module.visit"
    ]
   }
  ],

--- a/libcst/_metadata_dependent.py
+++ b/libcst/_metadata_dependent.py
@@ -103,6 +103,11 @@ class MetadataDependent(ABC):
                 f"{key.__name__} is not declared as a dependency in {type(self).__name__}.METADATA_DEPENDENCIES."
             )
 
+        if key not in self.metadata:
+            raise KeyError(
+                f"{key.__name__} is a dependency, but not set; did you forget a MetadataWrapper?"
+            )
+
         if default is not _UNDEFINED_DEFAULT:
             return cast(_T, self.metadata[key].get(node, default))
         else:

--- a/libcst/metadata/tests/test_metadata_provider.py
+++ b/libcst/metadata/tests/test_metadata_provider.py
@@ -300,7 +300,10 @@ class MetadataProviderTest(UnitTest):
                 self.get_metadata(ProviderA, node)
                 return True
 
-        with self.assertRaises(KeyError):
+        with self.assertRaisesRegex(
+            KeyError,
+            "ProviderA is a dependency, but not set; did you forget a MetadataWrapper?",
+        ):
             cst.Module([]).visit(AVisitor())
 
     def test_undeclared_metadata(self) -> None:


### PR DESCRIPTION
## Summary

Adds a more useful message to KeyError when a metadata provider is missing.  This is easy to trigger if you call `.resolve` and let it finish before accessing (because it clears) or if you forget to `.visit` on the MetadataWrapper instead of Module.

## Test Plan

New test.