### PR TITLE
[pyre] use --preserve-pythonpath to enable Pyre to read from site-packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
             source /tmp/libcst-env/bin/activate
             pip install --upgrade pip
             pip install -r requirements.txt -r requirements-dev.txt
-            pyre check
+            pyre --preserve-pythonpath check
             PYTHONPATH=`pwd` python libcst/tests/test_pyre_integration.py
             git diff --exit-code  # verify no generated changes
       - save_cache:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@
 import importlib.util
 from os import path
 
-# pyre-ignore Pyre doesn't know about setuptools.
 import setuptools
 
 

--- a/stubs/hypothesmith.pyi
+++ b/stubs/hypothesmith.pyi
@@ -1,1 +1,0 @@
-# pyre-placeholder-stub


### PR DESCRIPTION
##  Summary
Previously, pyre only looks into stub/ and thus it doesn't understand setuptools.

By adding --preserve-pythonpath to pyre check, it understand setuptools. We no longer need hypothesmith empty stub file since the source code is typed.

## Test Plan
Ci builds.
