### PR TITLE
Support Python 3 syntax back to 3.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,8 +33,8 @@ A Concrete Syntax Tree (CST) parser and serializer library for Python
 
 .. intro-start
 
-LibCST parses Python 3.5, 3.6, 3.7 or 3.8 source code as a CST tree that keeps all
-formatting details (comments, whitespaces, parentheses, etc). It's useful for
+LibCST parses Python 3.0, 3.1, 3.3, 3.5, 3.6, 3.7 or 3.8 source code as a CST tree that keeps
+all formatting details (comments, whitespaces, parentheses, etc). It's useful for
 building automated refactoring (codemod) applications and linters.
 
 .. intro-end

--- a/libcst/__init__.py
+++ b/libcst/__init__.py
@@ -185,7 +185,10 @@ from libcst._nodes.whitespace import (
     TrailingWhitespace,
 )
 from libcst._parser.entrypoints import parse_expression, parse_module, parse_statement
-from libcst._parser.types.config import PartialParserConfig
+from libcst._parser.types.config import (
+    KNOWN_PYTHON_VERSION_STRINGS,
+    PartialParserConfig,
+)
 from libcst._removal_sentinel import RemovalSentinel, RemoveFromParent
 from libcst._version import LIBCST_VERSION
 from libcst._visitors import CSTNodeT, CSTTransformer, CSTVisitor, CSTVisitorT
@@ -201,6 +204,7 @@ from libcst.metadata.wrapper import MetadataWrapper
 
 
 __all__ = [
+    "KNOWN_PYTHON_VERSION_STRINGS",
     "LIBCST_VERSION",
     "BatchableCSTVisitor",
     "CSTNodeT",

--- a/libcst/_nodes/tests/base.py
+++ b/libcst/_nodes/tests/base.py
@@ -41,6 +41,20 @@ def _cst_node_equality_func(
         raise AssertionError(f"\n{a!r}\nis not deeply equal to \n{b!r}{suffix}")
 
 
+def parse_expression_as(**config: Any) -> Callable[[str], cst.BaseExpression]:
+    def inner(code: str) -> cst.BaseExpression:
+        return cst.parse_expression(code, config=cst.PartialParserConfig(**config))
+
+    return inner
+
+
+def parse_statement_as(**config: Any) -> Callable[[str], cst.BaseStatement]:
+    def inner(code: str) -> cst.BaseStatement:
+        return cst.parse_statement(code, config=cst.PartialParserConfig(**config))
+
+    return inner
+
+
 # We can't use an ABCMeta here, because of metaclass conflicts
 class CSTNodeTest(UnitTest):
     def setUp(self) -> None:
@@ -214,6 +228,18 @@ class CSTNodeTest(UnitTest):
         # the node, since that was easier to implement. We should fix that behavior in a
         # later version and tighten this check.
         self.assertEqual(node, node.visit(_NOOPVisitor()))
+
+    def assert_parses(
+        self,
+        code: str,
+        parser: Callable[[str], cst.BaseExpression],
+        expect_success: bool,
+    ) -> None:
+        if not expect_success:
+            with self.assertRaises(cst.ParserSyntaxError):
+                parser(code)
+        else:
+            parser(code)
 
 
 @dataclass(frozen=True)

--- a/libcst/_nodes/tests/test_atom.py
+++ b/libcst/_nodes/tests/test_atom.py
@@ -1037,8 +1037,8 @@ class AtomTest(CSTNodeTest):
             },
         )
     )
-    def test_versions(self, code, parser, expect_success) -> None:
-        self.assert_parses(code, parser, expect_success)
+    def test_versions(self, **kwargs: Any) -> None:
+        self.assert_parses(**kwargs)
 
 
 class StringHelperTest(CSTNodeTest):

--- a/libcst/_nodes/tests/test_atom.py
+++ b/libcst/_nodes/tests/test_atom.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import libcst as cst
 from libcst import parse_expression
-from libcst._nodes.tests.base import CSTNodeTest
+from libcst._nodes.tests.base import CSTNodeTest, parse_expression_as
 from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
@@ -1022,6 +1022,23 @@ class AtomTest(CSTNodeTest):
     )
     def test_invalid(self, **kwargs: Any) -> None:
         self.assert_invalid(**kwargs)
+
+    @data_provider(
+        (
+            {
+                "code": "u'x'",
+                "parser": parse_expression_as(python_version="3.3"),
+                "expect_success": True,
+            },
+            {
+                "code": "u'x'",
+                "parser": parse_expression_as(python_version="3.1"),
+                "expect_success": False,
+            },
+        )
+    )
+    def test_versions(self, code, parser, expect_success) -> None:
+        self.assert_parses(code, parser, expect_success)
 
 
 class StringHelperTest(CSTNodeTest):

--- a/libcst/_nodes/tests/test_dict.py
+++ b/libcst/_nodes/tests/test_dict.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import libcst as cst
 from libcst import parse_expression
-from libcst._nodes.tests.base import CSTNodeTest
+from libcst._nodes.tests.base import CSTNodeTest, parse_expression_as
 from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
@@ -172,3 +172,20 @@ class DictTest(CSTNodeTest):
     )
     def test_invalid(self, **kwargs: Any) -> None:
         self.assert_invalid(**kwargs)
+
+    @data_provider(
+        (
+            {
+                "code": "{**{}}",
+                "parser": parse_expression_as(python_version="3.5"),
+                "expect_success": True,
+            },
+            {
+                "code": "{**{}}",
+                "parser": parse_expression_as(python_version="3.3"),
+                "expect_success": False,
+            },
+        )
+    )
+    def test_versions(self, code, parser, expect_success) -> None:
+        self.assert_parses(code, parser, expect_success)

--- a/libcst/_nodes/tests/test_dict.py
+++ b/libcst/_nodes/tests/test_dict.py
@@ -187,5 +187,5 @@ class DictTest(CSTNodeTest):
             },
         )
     )
-    def test_versions(self, code, parser, expect_success) -> None:
-        self.assert_parses(code, parser, expect_success)
+    def test_versions(self, **kwargs: Any) -> None:
+        self.assert_parses(**kwargs)

--- a/libcst/_nodes/tests/test_funcdef.py
+++ b/libcst/_nodes/tests/test_funcdef.py
@@ -2004,5 +2004,5 @@ class FunctionDefParserTest(CSTNodeTest):
             },
         )
     )
-    def test_versions(self, code, parser, expect_success) -> None:
-        self.assert_parses(code, parser, expect_success)
+    def test_versions(self, **kwargs: Any) -> None:
+        self.assert_parses(**kwargs)

--- a/libcst/_nodes/tests/test_funcdef.py
+++ b/libcst/_nodes/tests/test_funcdef.py
@@ -8,7 +8,7 @@ from typing import Any, Callable
 
 import libcst as cst
 from libcst import parse_statement
-from libcst._nodes.tests.base import CSTNodeTest, DummyIndentedBlock
+from libcst._nodes.tests.base import CSTNodeTest, DummyIndentedBlock, parse_statement_as
 from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
@@ -1979,3 +1979,30 @@ class FunctionDefParserTest(CSTNodeTest):
     )
     def test_valid_38(self, node: cst.CSTNode, code: str) -> None:
         self.validate_node(node, code, _parse_statement_force_38)
+
+    @data_provider(
+        (
+            {
+                "code": "async def foo(): pass",
+                "parser": parse_statement_as(python_version="3.7"),
+                "expect_success": True,
+            },
+            {
+                "code": "async def foo(): pass",
+                "parser": parse_statement_as(python_version="3.6"),
+                "expect_success": True,
+            },
+            {
+                "code": "async def foo(): pass",
+                "parser": parse_statement_as(python_version="3.5"),
+                "expect_success": True,
+            },
+            {
+                "code": "async def foo(): pass",
+                "parser": parse_statement_as(python_version="3.3"),
+                "expect_success": False,
+            },
+        )
+    )
+    def test_versions(self, code, parser, expect_success) -> None:
+        self.assert_parses(code, parser, expect_success)

--- a/libcst/_nodes/tests/test_list.py
+++ b/libcst/_nodes/tests/test_list.py
@@ -8,7 +8,7 @@ from typing import Any, Callable
 
 import libcst as cst
 from libcst import parse_expression, parse_statement
-from libcst._nodes.tests.base import CSTNodeTest
+from libcst._nodes.tests.base import CSTNodeTest, parse_expression_as
 from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
@@ -111,3 +111,20 @@ class ListTest(CSTNodeTest):
         self, get_node: Callable[[], cst.CSTNode], expected_re: str
     ) -> None:
         self.assert_invalid(get_node, expected_re)
+
+    @data_provider(
+        (
+            {
+                "code": "[a, *b]",
+                "parser": parse_expression_as(python_version="3.5"),
+                "expect_success": True,
+            },
+            {
+                "code": "[a, *b]",
+                "parser": parse_expression_as(python_version="3.3"),
+                "expect_success": False,
+            },
+        )
+    )
+    def test_versions(self, code, parser, expect_success) -> None:
+        self.assert_parses(code, parser, expect_success)

--- a/libcst/_nodes/tests/test_list.py
+++ b/libcst/_nodes/tests/test_list.py
@@ -126,5 +126,5 @@ class ListTest(CSTNodeTest):
             },
         )
     )
-    def test_versions(self, code, parser, expect_success) -> None:
-        self.assert_parses(code, parser, expect_success)
+    def test_versions(self, **kwargs: Any) -> None:
+        self.assert_parses(**kwargs)

--- a/libcst/_nodes/tests/test_matrix_multiply.py
+++ b/libcst/_nodes/tests/test_matrix_multiply.py
@@ -1,0 +1,73 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from typing import Any
+
+import libcst as cst
+from libcst._nodes.tests.base import (
+    CSTNodeTest,
+    parse_expression_as,
+    parse_statement_as,
+)
+from libcst.testing.utils import data_provider
+
+
+class NamedExprTest(CSTNodeTest):
+    @data_provider(
+        (
+            {
+                "node": cst.BinaryOperation(
+                    left=cst.Name("a"),
+                    operator=cst.MatrixMultiply(),
+                    right=cst.Name("b"),
+                ),
+                "code": "a @ b",
+                "parser": parse_expression_as(python_version="3.8"),
+            },
+            {
+                "node": cst.SimpleStatementLine(
+                    body=(
+                        cst.AugAssign(
+                            target=cst.Name("a"),
+                            operator=cst.MatrixMultiplyAssign(),
+                            value=cst.Name("b"),
+                        ),
+                    ),
+                ),
+                "code": "a @= b\n",
+                "parser": parse_statement_as(python_version="3.8"),
+            },
+        )
+    )
+    def test_valid(self, **kwargs: Any) -> None:
+        self.validate_node(**kwargs)
+
+    @data_provider(
+        (
+            {
+                "code": "a @ b",
+                "parser": parse_expression_as(python_version="3.6"),
+                "expect_success": True,
+            },
+            {
+                "code": "a @ b",
+                "parser": parse_expression_as(python_version="3.3"),
+                "expect_success": False,
+            },
+            {
+                "code": "a @= b",
+                "parser": parse_statement_as(python_version="3.6"),
+                "expect_success": True,
+            },
+            {
+                "code": "a @= b",
+                "parser": parse_statement_as(python_version="3.3"),
+                "expect_success": False,
+            },
+        )
+    )
+    def test_versions(self, code, parser, expect_success) -> None:
+        self.assert_parses(code, parser, expect_success)

--- a/libcst/_nodes/tests/test_matrix_multiply.py
+++ b/libcst/_nodes/tests/test_matrix_multiply.py
@@ -69,5 +69,5 @@ class NamedExprTest(CSTNodeTest):
             },
         )
     )
-    def test_versions(self, code, parser, expect_success) -> None:
-        self.assert_parses(code, parser, expect_success)
+    def test_versions(self, **kwargs: Any) -> None:
+        self.assert_parses(**kwargs)

--- a/libcst/_nodes/tests/test_set.py
+++ b/libcst/_nodes/tests/test_set.py
@@ -8,7 +8,7 @@ from typing import Any, Callable
 
 import libcst as cst
 from libcst import parse_expression
-from libcst._nodes.tests.base import CSTNodeTest
+from libcst._nodes.tests.base import CSTNodeTest, parse_expression_as
 from libcst.testing.utils import data_provider
 
 
@@ -118,3 +118,20 @@ class ListTest(CSTNodeTest):
         self, get_node: Callable[[], cst.CSTNode], expected_re: str
     ) -> None:
         self.assert_invalid(get_node, expected_re)
+
+    @data_provider(
+        (
+            {
+                "code": "{*x, 2}",
+                "parser": parse_expression_as(python_version="3.5"),
+                "expect_success": True,
+            },
+            {
+                "code": "{*x, 2}",
+                "parser": parse_expression_as(python_version="3.3"),
+                "expect_success": False,
+            },
+        )
+    )
+    def test_versions(self, code, parser, expect_success) -> None:
+        self.assert_parses(code, parser, expect_success)

--- a/libcst/_nodes/tests/test_set.py
+++ b/libcst/_nodes/tests/test_set.py
@@ -133,5 +133,5 @@ class ListTest(CSTNodeTest):
             },
         )
     )
-    def test_versions(self, code, parser, expect_success) -> None:
-        self.assert_parses(code, parser, expect_success)
+    def test_versions(self, **kwargs: Any) -> None:
+        self.assert_parses(**kwargs)

--- a/libcst/_nodes/tests/test_tuple.py
+++ b/libcst/_nodes/tests/test_tuple.py
@@ -8,7 +8,7 @@ from typing import Any, Callable
 
 import libcst as cst
 from libcst import parse_expression, parse_statement
-from libcst._nodes.tests.base import CSTNodeTest
+from libcst._nodes.tests.base import CSTNodeTest, parse_expression_as
 from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
@@ -264,3 +264,20 @@ class TupleTest(CSTNodeTest):
         self, get_node: Callable[[], cst.CSTNode], expected_re: str
     ) -> None:
         self.assert_invalid(get_node, expected_re)
+
+    @data_provider(
+        (
+            {
+                "code": "(a, *b)",
+                "parser": parse_expression_as(python_version="3.5"),
+                "expect_success": True,
+            },
+            {
+                "code": "(a, *b)",
+                "parser": parse_expression_as(python_version="3.3"),
+                "expect_success": False,
+            },
+        )
+    )
+    def test_versions(self, code, parser, expect_success) -> None:
+        self.assert_parses(code, parser, expect_success)

--- a/libcst/_nodes/tests/test_tuple.py
+++ b/libcst/_nodes/tests/test_tuple.py
@@ -279,5 +279,5 @@ class TupleTest(CSTNodeTest):
             },
         )
     )
-    def test_versions(self, code, parser, expect_success) -> None:
-        self.assert_parses(code, parser, expect_success)
+    def test_versions(self, **kwargs: Any) -> None:
+        self.assert_parses(**kwargs)

--- a/libcst/_nodes/tests/test_with.py
+++ b/libcst/_nodes/tests/test_with.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import libcst as cst
 from libcst import PartialParserConfig, parse_statement
-from libcst._nodes.tests.base import CSTNodeTest, DummyIndentedBlock
+from libcst._nodes.tests.base import CSTNodeTest, DummyIndentedBlock, parse_statement_as
 from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
@@ -215,3 +215,20 @@ class WithTest(CSTNodeTest):
     )
     def test_invalid(self, **kwargs: Any) -> None:
         self.assert_invalid(**kwargs)
+
+    @data_provider(
+        (
+            {
+                "code": "with a, b: pass",
+                "parser": parse_statement_as(python_version="3.1"),
+                "expect_success": True,
+            },
+            {
+                "code": "with a, b: pass",
+                "parser": parse_statement_as(python_version="3.0"),
+                "expect_success": False,
+            },
+        )
+    )
+    def test_versions(self, code, parser, expect_success) -> None:
+        self.assert_parses(code, parser, expect_success)

--- a/libcst/_nodes/tests/test_with.py
+++ b/libcst/_nodes/tests/test_with.py
@@ -230,5 +230,5 @@ class WithTest(CSTNodeTest):
             },
         )
     )
-    def test_versions(self, code, parser, expect_success) -> None:
-        self.assert_parses(code, parser, expect_success)
+    def test_versions(self, **kwargs: Any) -> None:
+        self.assert_parses(**kwargs)

--- a/libcst/_nodes/tests/test_yield.py
+++ b/libcst/_nodes/tests/test_yield.py
@@ -8,7 +8,7 @@ from typing import Callable, Optional
 
 import libcst as cst
 from libcst import parse_statement
-from libcst._nodes.tests.base import CSTNodeTest
+from libcst._nodes.tests.base import CSTNodeTest, parse_statement_as
 from libcst.helpers import ensure_type
 from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
@@ -225,3 +225,20 @@ class YieldParsingTest(CSTNodeTest):
                 cst.Expr,
             ).value,
         )
+
+    @data_provider(
+        (
+            {
+                "code": "yield from x",
+                "parser": parse_statement_as(python_version="3.3"),
+                "expect_success": True,
+            },
+            {
+                "code": "yield from x",
+                "parser": parse_statement_as(python_version="3.1"),
+                "expect_success": False,
+            },
+        )
+    )
+    def test_versions(self, code, parser, expect_success) -> None:
+        self.assert_parses(code, parser, expect_success)

--- a/libcst/_nodes/tests/test_yield.py
+++ b/libcst/_nodes/tests/test_yield.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 import libcst as cst
 from libcst import parse_statement
@@ -240,5 +240,5 @@ class YieldParsingTest(CSTNodeTest):
             },
         )
     )
-    def test_versions(self, code, parser, expect_success) -> None:
-        self.assert_parses(code, parser, expect_success)
+    def test_versions(self, **kwargs: Any) -> None:
+        self.assert_parses(**kwargs)

--- a/libcst/_parser/conversions/expression.py
+++ b/libcst/_parser/conversions/expression.py
@@ -1103,13 +1103,16 @@ def convert_fstring_format_spec(
 
 @with_production(
     "testlist_comp_tuple",
-    "(test|star_expr) ( comp_for | (',' (test|star_expr))* [','] )",
-    version="<=3.7",
+    "(namedexpr_test|star_expr) ( comp_for | (',' (namedexpr_test|star_expr))* [','] )",
+    version=">=3.8",
 )
 @with_production(
     "testlist_comp_tuple",
-    "(namedexpr_test|star_expr) ( comp_for | (',' (namedexpr_test|star_expr))* [','] )",
-    version=">=3.8",
+    "(test|star_expr) ( comp_for | (',' (test|star_expr))* [','] )",
+    version=">=3.5,<3.8",
+)
+@with_production(
+    "testlist_comp_tuple", "(test) ( comp_for | (',' (test))* [','] )", version="<3.5",
 )
 def convert_testlist_comp_tuple(
     config: ParserConfig, children: typing.Sequence[typing.Any]
@@ -1125,13 +1128,16 @@ def convert_testlist_comp_tuple(
 
 @with_production(
     "testlist_comp_list",
-    "(test|star_expr) ( comp_for | (',' (test|star_expr))* [','] )",
-    version="<=3.7",
+    "(namedexpr_test|star_expr) ( comp_for | (',' (namedexpr_test|star_expr))* [','] )",
+    version=">=3.8",
 )
 @with_production(
     "testlist_comp_list",
-    "(namedexpr_test|star_expr) ( comp_for | (',' (namedexpr_test|star_expr))* [','] )",
-    version=">=3.8",
+    "(test|star_expr) ( comp_for | (',' (test|star_expr))* [','] )",
+    version=">=3.5,<3.8",
+)
+@with_production(
+    "testlist_comp_list", "(test) ( comp_for | (',' (test))* [','] )", version="<3.5",
 )
 def convert_testlist_comp_list(
     config: ParserConfig, children: typing.Sequence[typing.Any]
@@ -1242,6 +1248,17 @@ def _convert_sequencelike(
         + "((test | star_expr) "
         + " (comp_for | (',' (test | star_expr))* [','])) )"
     ),
+    version=">=3.5",
+)
+@with_production(
+    "dictorsetmaker",
+    (
+        "( ((test ':' test)"
+        + " (comp_for | (',' (test ':' test))* [','])) |"
+        + "((test) "
+        + " (comp_for | (',' (test))* [','])) )"
+    ),
+    version="<3.5",
 )
 def convert_dictorsetmaker(
     config: ParserConfig, children: typing.Sequence[typing.Any]

--- a/libcst/_parser/conversions/expression.py
+++ b/libcst/_parser/conversions/expression.py
@@ -478,7 +478,8 @@ def convert_star_expr(
 @with_production("and_expr", "shift_expr ('&' shift_expr)*")
 @with_production("shift_expr", "arith_expr (('<<'|'>>') arith_expr)*")
 @with_production("arith_expr", "term (('+'|'-') term)*")
-@with_production("term", "factor (('*'|'@'|'/'|'%'|'//') factor)*")
+@with_production("term", "factor (('*'|'@'|'/'|'%'|'//') factor)*", version=">=3.5")
+@with_production("term", "factor (('*'|'/'|'%'|'//') factor)*", version="<3.5")
 def convert_binop(
     config: ParserConfig, children: typing.Sequence[typing.Any]
 ) -> typing.Any:

--- a/libcst/_parser/conversions/expression.py
+++ b/libcst/_parser/conversions/expression.py
@@ -1556,7 +1556,8 @@ def convert_yield_expr(
     return WithLeadingWhitespace(yield_node, yield_token.whitespace_before)
 
 
-@with_production("yield_arg", "'from' test | testlist", version="<=3.7")
+@with_production("yield_arg", "testlist", version="<3.3")
+@with_production("yield_arg", "'from' test | testlist", version=">=3.3,<3.8")
 @with_production("yield_arg", "'from' test | testlist_star_expr", version=">=3.8")
 def convert_yield_arg(
     config: ParserConfig, children: typing.Sequence[typing.Any]

--- a/libcst/_parser/conversions/statement.py
+++ b/libcst/_parser/conversions/statement.py
@@ -306,6 +306,15 @@ def convert_annassign(config: ParserConfig, children: Sequence[Any]) -> Any:
         "('+=' | '-=' | '*=' | '@=' | '/=' | '%=' | '&=' | '|=' | '^=' | '<<=' | "
         + "'>>=' | '**=' | '//=') (yield_expr | testlist)"
     ),
+    version=">=3.5",
+)
+@with_production(
+    "augassign",
+    (
+        "('+=' | '-=' | '*=' | '/=' | '%=' | '&=' | '|=' | '^=' | '<<=' | "
+        + "'>>=' | '**=' | '//=') (yield_expr | testlist)"
+    ),
+    version="<3.5",
 )
 def convert_augassign(config: ParserConfig, children: Sequence[Any]) -> Any:
     op, expr = children

--- a/libcst/_parser/conversions/statement.py
+++ b/libcst/_parser/conversions/statement.py
@@ -979,7 +979,10 @@ def convert_except_clause(config: ParserConfig, children: Sequence[Any]) -> Any:
     )
 
 
-@with_production("with_stmt", "'with' with_item (',' with_item)*  ':' suite")
+@with_production(
+    "with_stmt", "'with' with_item (',' with_item)*  ':' suite", version=">=3.1"
+)
+@with_production("with_stmt", "'with' with_item ':' suite", version="<3.1")
 def convert_with_stmt(config: ParserConfig, children: Sequence[Any]) -> Any:
     (with_token, *items, colon_token, suite) = children
     item_nodes: List[WithItem] = []

--- a/libcst/_parser/conversions/statement.py
+++ b/libcst/_parser/conversions/statement.py
@@ -1060,7 +1060,8 @@ def _extract_async(
 
 
 @with_production("asyncable_funcdef", "['async'] funcdef", version=">=3.7")
-@with_production("asyncable_funcdef", "[ASYNC] funcdef", version="<=3.6")
+@with_production("asyncable_funcdef", "[ASYNC] funcdef", version=">=3.5,<3.7")
+@with_production("asyncable_funcdef", "funcdef", version="<3.5")
 def convert_asyncable_funcdef(config: ParserConfig, children: Sequence[Any]) -> Any:
     leading_lines, asyncnode, funcdef = _extract_async(config, children)
 
@@ -1309,8 +1310,9 @@ def convert_decorated(config: ParserConfig, children: Sequence[Any]) -> Any:
     "asyncable_stmt", "['async'] (funcdef | with_stmt | for_stmt)", version=">=3.7"
 )
 @with_production(
-    "asyncable_stmt", "[ASYNC] (funcdef | with_stmt | for_stmt)", version="<=3.6"
+    "asyncable_stmt", "[ASYNC] (funcdef | with_stmt | for_stmt)", version=">=3.5,<3.7"
 )
+@with_production("asyncable_stmt", "funcdef | with_stmt | for_stmt", version="<3.5")
 def convert_asyncable_stmt(config: ParserConfig, children: Sequence[Any]) -> Any:
     leading_lines, asyncnode, stmtnode = _extract_async(config, children)
     if isinstance(stmtnode, FunctionDef):

--- a/libcst/_parser/detect_config.py
+++ b/libcst/_parser/detect_config.py
@@ -10,7 +10,7 @@ import re
 from dataclasses import dataclass
 from io import BytesIO
 from tokenize import detect_encoding as py_tokenize_detect_encoding
-from typing import Iterable, Iterator, Pattern, Set, Union
+from typing import FrozenSet, Iterable, Iterator, Pattern, Set, Union
 
 from libcst._nodes.whitespace import NEWLINE_RE
 from libcst._parser.parso.python.token import PythonTokenTypes, TokenType
@@ -84,7 +84,7 @@ def _detect_trailing_newline(source_str: str) -> bool:
     )
 
 
-def _detect_future_imports(tokens: Iterable[Token]) -> Set[str]:
+def _detect_future_imports(tokens: Iterable[Token]) -> FrozenSet[str]:
     """
     Finds __future__ imports in their proper locations.
 
@@ -113,7 +113,7 @@ def _detect_future_imports(tokens: Iterable[Token]) -> Set[str]:
             state = 0
         else:
             break
-    return future_imports
+    return frozenset(future_imports)
 
 
 def detect_config(

--- a/libcst/_parser/entrypoints.py
+++ b/libcst/_parser/entrypoints.py
@@ -40,7 +40,7 @@ def _parse(
         detect_default_newline=detect_default_newline,
     )
     validate_grammar()
-    grammar = get_grammar(config.parsed_python_version)
+    grammar = get_grammar(config.parsed_python_version, config.future_imports)
 
     parser = PythonCSTParser(
         tokens=detection_result.tokens,

--- a/libcst/_parser/parso/python/tokenize.py
+++ b/libcst/_parser/parso/python/tokenize.py
@@ -101,9 +101,11 @@ def _all_string_prefixes(
     # The valid string prefixes. Only contain the lower case versions,
     #  and don't contain any permuations (include 'fr', but not
     #  'rf'). The various permutations will be generated.
-    valid_string_prefixes = ["b", "r", "u"]
+    valid_string_prefixes = ["b", "r"]
     if version_info >= (3, 0):
         valid_string_prefixes.append("br")
+    if version_info < (3, 0) or version_info >= (3, 3):
+        valid_string_prefixes.append("u")
 
     result = set([""])
     if version_info >= (3, 6) and include_fstring:

--- a/libcst/_parser/production_decorator.py
+++ b/libcst/_parser/production_decorator.py
@@ -18,7 +18,11 @@ _NonterminalConversionT = TypeVar(
 # We could version our grammar at a later point by adding a version metadata kwarg to
 # this decorator.
 def with_production(
-    production_name: str, children: str, *, version: Optional[str] = None
+    production_name: str,
+    children: str,
+    *,
+    version: Optional[str] = None,
+    future: Optional[str] = None,
 ) -> Callable[[_NonterminalConversionT], _NonterminalConversionT]:
     """
     Attaches a bit of grammar to a conversion function. The parser extracts all of these
@@ -38,7 +42,7 @@ def with_production(
                 + f"'{fn_name}'."
             )
         # pyre-ignore: Pyre doesn't know about this magic field we added
-        fn.productions.append(Production(production_name, children, version))
+        fn.productions.append(Production(production_name, children, version, future))
         return fn
 
     return inner

--- a/libcst/_parser/python_parser.py
+++ b/libcst/_parser/python_parser.py
@@ -35,7 +35,9 @@ class PythonCSTParser(BaseParser[Token, TokenType, Any]):
         )
         self.config = config
         self.terminal_conversions = get_terminal_conversions()
-        self.nonterminal_conversions = get_nonterminal_conversions(config.version)
+        self.nonterminal_conversions = get_nonterminal_conversions(
+            config.version, config.future_imports
+        )
 
     def convert_nonterminal(self, nonterminal: str, children: Sequence[Any]) -> Any:
         return self.nonterminal_conversions[nonterminal](self.config, children)

--- a/libcst/_parser/tests/test_detect_config.py
+++ b/libcst/_parser/tests/test_detect_config.py
@@ -28,7 +28,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=False,
                     version=PythonVersionInfo(3, 7),
-                    future_imports=set(),
+                    future_imports=frozenset(),
                 ),
             },
             "detect_trailing_newline_disabled": {
@@ -43,7 +43,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=False,
                     version=PythonVersionInfo(3, 7),
-                    future_imports=set(),
+                    future_imports=frozenset(),
                 ),
             },
             "detect_default_newline_disabled": {
@@ -58,7 +58,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=False,
                     version=PythonVersionInfo(3, 7),
-                    future_imports=set(),
+                    future_imports=frozenset(),
                 ),
             },
             "newline_inferred": {
@@ -73,7 +73,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\r\n",
                     has_trailing_newline=True,
                     version=PythonVersionInfo(3, 7),
-                    future_imports=set(),
+                    future_imports=frozenset(),
                 ),
             },
             "newline_partial_given": {
@@ -90,7 +90,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",  # The given partial disables inference
                     has_trailing_newline=True,
                     version=PythonVersionInfo(3, 7),
-                    future_imports=set(),
+                    future_imports=frozenset(),
                 ),
             },
             "indent_inferred": {
@@ -105,7 +105,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=True,
                     version=PythonVersionInfo(3, 7),
-                    future_imports=set(),
+                    future_imports=frozenset(),
                 ),
             },
             "indent_partial_given": {
@@ -122,7 +122,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=True,
                     version=PythonVersionInfo(3, 7),
-                    future_imports=set(),
+                    future_imports=frozenset(),
                 ),
             },
             "encoding_inferred": {
@@ -142,7 +142,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=True,
                     version=PythonVersionInfo(3, 7),
-                    future_imports=set(),
+                    future_imports=frozenset(),
                 ),
             },
             "encoding_partial_given": {
@@ -164,7 +164,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=True,
                     version=PythonVersionInfo(3, 7),
-                    future_imports=set(),
+                    future_imports=frozenset(),
                 ),
             },
             "encoding_str_not_bytes_disables_inference": {
@@ -184,7 +184,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=True,
                     version=PythonVersionInfo(3, 7),
-                    future_imports=set(),
+                    future_imports=frozenset(),
                 ),
             },
             "encoding_non_ascii_compatible_utf_16_with_bom": {
@@ -199,7 +199,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=False,
                     version=PythonVersionInfo(3, 7),
-                    future_imports=set(),
+                    future_imports=frozenset(),
                 ),
             },
             "detect_trailing_newline_missing_newline": {
@@ -214,7 +214,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=False,
                     version=PythonVersionInfo(3, 7),
-                    future_imports=set(),
+                    future_imports=frozenset(),
                 ),
             },
             "detect_trailing_newline_has_newline": {
@@ -229,7 +229,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=True,
                     version=PythonVersionInfo(3, 7),
-                    future_imports=set(),
+                    future_imports=frozenset(),
                 ),
             },
             "detect_trailing_newline_missing_newline_after_line_continuation": {
@@ -244,7 +244,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=False,
                     version=PythonVersionInfo(3, 7),
-                    future_imports=set(),
+                    future_imports=frozenset(),
                 ),
             },
             "detect_trailing_newline_has_newline_after_line_continuation": {
@@ -259,7 +259,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=True,
                     version=PythonVersionInfo(3, 7),
-                    future_imports=set(),
+                    future_imports=frozenset(),
                 ),
             },
             "future_imports_in_correct_position": {
@@ -279,7 +279,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=True,
                     version=PythonVersionInfo(3, 7),
-                    future_imports={"a"},
+                    future_imports=frozenset({"a"}),
                 ),
             },
             "future_imports_in_mixed_position": {
@@ -302,7 +302,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=True,
                     version=PythonVersionInfo(3, 7),
-                    future_imports={"a", "b"},
+                    future_imports=frozenset({"a", "b"}),
                 ),
             },
         }

--- a/libcst/_parser/tests/test_detect_config.py
+++ b/libcst/_parser/tests/test_detect_config.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
+import dataclasses
 from typing import Union
 
 from libcst._parser.detect_config import detect_config
@@ -27,6 +28,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=False,
                     version=PythonVersionInfo(3, 7),
+                    future_imports=set(),
                 ),
             },
             "detect_trailing_newline_disabled": {
@@ -41,6 +43,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=False,
                     version=PythonVersionInfo(3, 7),
+                    future_imports=set(),
                 ),
             },
             "detect_default_newline_disabled": {
@@ -55,6 +58,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=False,
                     version=PythonVersionInfo(3, 7),
+                    future_imports=set(),
                 ),
             },
             "newline_inferred": {
@@ -69,6 +73,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\r\n",
                     has_trailing_newline=True,
                     version=PythonVersionInfo(3, 7),
+                    future_imports=set(),
                 ),
             },
             "newline_partial_given": {
@@ -85,6 +90,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",  # The given partial disables inference
                     has_trailing_newline=True,
                     version=PythonVersionInfo(3, 7),
+                    future_imports=set(),
                 ),
             },
             "indent_inferred": {
@@ -99,6 +105,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=True,
                     version=PythonVersionInfo(3, 7),
+                    future_imports=set(),
                 ),
             },
             "indent_partial_given": {
@@ -115,6 +122,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=True,
                     version=PythonVersionInfo(3, 7),
+                    future_imports=set(),
                 ),
             },
             "encoding_inferred": {
@@ -134,6 +142,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=True,
                     version=PythonVersionInfo(3, 7),
+                    future_imports=set(),
                 ),
             },
             "encoding_partial_given": {
@@ -155,6 +164,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=True,
                     version=PythonVersionInfo(3, 7),
+                    future_imports=set(),
                 ),
             },
             "encoding_str_not_bytes_disables_inference": {
@@ -174,6 +184,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=True,
                     version=PythonVersionInfo(3, 7),
+                    future_imports=set(),
                 ),
             },
             "encoding_non_ascii_compatible_utf_16_with_bom": {
@@ -188,6 +199,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=False,
                     version=PythonVersionInfo(3, 7),
+                    future_imports=set(),
                 ),
             },
             "detect_trailing_newline_missing_newline": {
@@ -202,6 +214,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=False,
                     version=PythonVersionInfo(3, 7),
+                    future_imports=set(),
                 ),
             },
             "detect_trailing_newline_has_newline": {
@@ -216,6 +229,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=True,
                     version=PythonVersionInfo(3, 7),
+                    future_imports=set(),
                 ),
             },
             "detect_trailing_newline_missing_newline_after_line_continuation": {
@@ -230,6 +244,7 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=False,
                     version=PythonVersionInfo(3, 7),
+                    future_imports=set(),
                 ),
             },
             "detect_trailing_newline_has_newline_after_line_continuation": {
@@ -244,6 +259,50 @@ class TestDetectConfig(UnitTest):
                     default_newline="\n",
                     has_trailing_newline=True,
                     version=PythonVersionInfo(3, 7),
+                    future_imports=set(),
+                ),
+            },
+            "future_imports_in_correct_position": {
+                "source": b"# C\n''' D '''\nfrom __future__ import a as b\n",
+                "partial": PartialParserConfig(python_version="3.7"),
+                "detect_trailing_newline": True,
+                "detect_default_newline": True,
+                "expected_config": ParserConfig(
+                    lines=[
+                        "# C\n",
+                        "''' D '''\n",
+                        "from __future__ import a as b\n",
+                        "",
+                    ],
+                    encoding="utf-8",
+                    default_indent="    ",
+                    default_newline="\n",
+                    has_trailing_newline=True,
+                    version=PythonVersionInfo(3, 7),
+                    future_imports={"a"},
+                ),
+            },
+            "future_imports_in_mixed_position": {
+                "source": (
+                    b"from __future__ import a, b\nimport os\n"
+                    b"from __future__ import c\n"
+                ),
+                "partial": PartialParserConfig(python_version="3.7"),
+                "detect_trailing_newline": True,
+                "detect_default_newline": True,
+                "expected_config": ParserConfig(
+                    lines=[
+                        "from __future__ import a, b\n",
+                        "import os\n",
+                        "from __future__ import c\n",
+                        "",
+                    ],
+                    encoding="utf-8",
+                    default_indent="    ",
+                    default_newline="\n",
+                    has_trailing_newline=True,
+                    version=PythonVersionInfo(3, 7),
+                    future_imports={"a", "b"},
                 ),
             },
         }
@@ -258,11 +317,13 @@ class TestDetectConfig(UnitTest):
         expected_config: ParserConfig,
     ) -> None:
         self.assertEqual(
-            detect_config(
-                source,
-                partial=partial,
-                detect_trailing_newline=detect_trailing_newline,
-                detect_default_newline=detect_default_newline,
-            ).config,
-            expected_config,
+            dataclasses.asdict(
+                detect_config(
+                    source,
+                    partial=partial,
+                    detect_trailing_newline=detect_trailing_newline,
+                    detect_default_newline=detect_default_newline,
+                ).config
+            ),
+            dataclasses.asdict(expected_config),
         )

--- a/libcst/_parser/types/config.py
+++ b/libcst/_parser/types/config.py
@@ -10,7 +10,7 @@ import codecs
 import re
 from dataclasses import dataclass, field, fields
 from enum import Enum
-from typing import List, Pattern, Sequence, Union
+from typing import List, Pattern, Sequence, Set, Union
 
 from libcst._add_slots import add_slots
 from libcst._nodes.whitespace import NEWLINE_RE
@@ -45,6 +45,7 @@ class ParserConfig(BaseWhitespaceParserConfig):
     default_newline: str
     has_trailing_newline: bool
     version: PythonVersionInfo
+    future_imports: Set[str]
 
 
 class AutoConfig(Enum):
@@ -95,6 +96,9 @@ class PartialParserConfig:
     #: inferred from the contents of the parsed source code. When parsing a ``str``,
     #: this value defaults to ``"utf-8"``.
     encoding: Union[str, AutoConfig] = AutoConfig.token
+
+    #: Detected ``__future__`` import names
+    future_imports: Union[Set[str], AutoConfig] = AutoConfig.token
 
     #: The indentation of the file, expressed as a series of tabs and/or spaces. This
     #: value is inferred from the contents of the parsed source code by default.

--- a/libcst/_parser/types/config.py
+++ b/libcst/_parser/types/config.py
@@ -59,6 +59,9 @@ class AutoConfig(Enum):
         return str(self)
 
 
+KNOWN_PYTHON_VERSION_STRINGS = ["3.3", "3.5", "3.6", "3.7", "3.8"]
+
+
 @add_slots
 @dataclass(frozen=True)
 class PartialParserConfig:
@@ -84,7 +87,7 @@ class PartialParserConfig:
     #: run LibCST. For example, you can parse code as 3.7 with a CPython 3.6
     #: interpreter.
     #:
-    #: Currently, only Python 3.5, 3.6, 3.7 and 3.8 syntax is supported.
+    #: Currently, only Python 3.3, 3.5, 3.6, 3.7 and 3.8 syntax is supported.
     python_version: Union[str, AutoConfig] = AutoConfig.token
 
     #: A named tuple with the ``major`` and ``minor`` Python version numbers. This is
@@ -121,15 +124,14 @@ class PartialParserConfig:
 
         # Once we add support for more versions of Python, we can change this to detect
         # the supported version range.
-        if parsed_python_version not in (
-            PythonVersionInfo(3, 5),
-            PythonVersionInfo(3, 6),
-            PythonVersionInfo(3, 7),
-            PythonVersionInfo(3, 8),
+        if not any(
+            parsed_python_version == parse_version_string(v)
+            for v in KNOWN_PYTHON_VERSION_STRINGS
         ):
+            comma_versions = ", ".join(KNOWN_PYTHON_VERSION_STRINGS)
             raise ValueError(
                 "LibCST can only parse code using one of the following versions of "
-                + "Python's grammar: 3.5, 3.6, 3.7, 3.8. More versions may be "
+                + f"Python's grammar: {comma_versions}. More versions may be "
                 + "supported by future releases."
             )
 

--- a/libcst/_parser/types/config.py
+++ b/libcst/_parser/types/config.py
@@ -59,7 +59,7 @@ class AutoConfig(Enum):
         return str(self)
 
 
-KNOWN_PYTHON_VERSION_STRINGS = ["3.3", "3.5", "3.6", "3.7", "3.8"]
+KNOWN_PYTHON_VERSION_STRINGS = ["3.0", "3.1", "3.3", "3.5", "3.6", "3.7", "3.8"]
 
 
 @add_slots
@@ -87,7 +87,7 @@ class PartialParserConfig:
     #: run LibCST. For example, you can parse code as 3.7 with a CPython 3.6
     #: interpreter.
     #:
-    #: Currently, only Python 3.3, 3.5, 3.6, 3.7 and 3.8 syntax is supported.
+    #: Currently, only Python 3.0, 3.1, 3.3, 3.5, 3.6, 3.7 and 3.8 syntax is supported.
     python_version: Union[str, AutoConfig] = AutoConfig.token
 
     #: A named tuple with the ``major`` and ``minor`` Python version numbers. This is

--- a/libcst/_parser/types/config.py
+++ b/libcst/_parser/types/config.py
@@ -10,7 +10,7 @@ import codecs
 import re
 from dataclasses import dataclass, field, fields
 from enum import Enum
-from typing import List, Pattern, Sequence, Set, Union
+from typing import FrozenSet, List, Pattern, Sequence, Union
 
 from libcst._add_slots import add_slots
 from libcst._nodes.whitespace import NEWLINE_RE
@@ -45,7 +45,7 @@ class ParserConfig(BaseWhitespaceParserConfig):
     default_newline: str
     has_trailing_newline: bool
     version: PythonVersionInfo
-    future_imports: Set[str]
+    future_imports: FrozenSet[str]
 
 
 class AutoConfig(Enum):
@@ -98,7 +98,7 @@ class PartialParserConfig:
     encoding: Union[str, AutoConfig] = AutoConfig.token
 
     #: Detected ``__future__`` import names
-    future_imports: Union[Set[str], AutoConfig] = AutoConfig.token
+    future_imports: Union[FrozenSet[str], AutoConfig] = AutoConfig.token
 
     #: The indentation of the file, expressed as a series of tabs and/or spaces. This
     #: value is inferred from the contents of the parsed source code by default.

--- a/libcst/_parser/types/production.py
+++ b/libcst/_parser/types/production.py
@@ -14,6 +14,7 @@ class Production:
     name: str
     children: str
     version: Optional[str]
+    future: Optional[str]
 
     def __str__(self) -> str:
         return f"{self.name}: {self.children}"


### PR DESCRIPTION
## Summary

This adds support for machine-readable supported versions, and the minor changes necessary to support 3.0, 3.1, and 3.3.  This includes future detection for future Python 2 parsing, but isn't required here given the PEP 401 findings.

Machine-readable versions are at `libcst.KNOWN_PYTHON_VERSION_STRINGS`.

## Test Plan

New included tests, and ran against my `python-grammar-changes` project.  Each entry should either have ".." or "oo" to say that the LibCST success matches that cpython version.

```
[tim@rygel python-grammar-changes]$ ../LibCST/.tox/py37/bin/python metarun.py
                                                  30 31 33 35 36 37 38
examples/py31-0002-with1.py                       oo oo oo oo oo oo oo 
examples/py31-0002-with2.py                       .. oo oo oo oo oo oo 
examples/py31-0002-with3.py                       .. oo oo oo oo oo oo 
examples/py33-0011-yield-from.py                  .. .. oo oo oo oo oo 
examples/py33-0012-uprefix1.py                    .. .. oo oo oo oo oo 
examples/py35-0008-else-in-call1.py               oo oo oo oo oo oo oo 
examples/py35-0008-else-in-call2.py               oo oo oo oo oo oo oo 
examples/py35-0009-async-def.py                   .. .. .. oo oo oo oo 
examples/py35-0010-dict-literals.py               .. .. .. oo oo oo oo 
examples/py36-0005-types1.py                      .. .. .. .. oo oo oo 
examples/py36-0006-fstrings.py                    .. .. .. .. oo oo oo 
examples/py36-0007-trailing-comma-def.py          .. .. .. .. oo oo oo 
examples/py36-0028-variable-annotations-pep526.py .. .. .. .. oo oo oo 
examples/py38-0003-walrus1.py                     .. .. .. .. .. .. oo 
examples/py38-0003-walrus2.py                     .. .. .. .. .. .. oo 
examples/py38-0003-walrus3.py                     .. .. .. .. .. .. .. 
examples/py38-0003-walrus4.py                     .. .. .. .. .. .. oo 
Legend:
 green header means will test with libcst

 first result is python, second [optional] result is libcst
 o   parses
 .   does not parse
```