### PR TITLE
Add codemod command for removing unused imports

### DIFF
--- a/libcst/codemod/commands/remove_unused_imports.py
+++ b/libcst/codemod/commands/remove_unused_imports.py
@@ -1,0 +1,22 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# pyre-strict
+
+from libcst import Import, ImportFrom
+from libcst.codemod import VisitorBasedCodemodCommand
+from libcst.codemod.visitors import RemoveImportsVisitor
+
+
+class RemoveUnusedImportsCommand(VisitorBasedCodemodCommand):
+    DESCRIPTION: str = "Remove all imports that are not used in a file."
+
+    def visit_Import(self, node: Import) -> bool:
+        RemoveImportsVisitor.remove_unused_import_by_node(self.context, node)
+        return False
+
+    def visit_ImportFrom(self, node: ImportFrom) -> bool:
+        RemoveImportsVisitor.remove_unused_import_by_node(self.context, node)
+        return False

--- a/libcst/codemod/commands/remove_unused_imports.py
+++ b/libcst/codemod/commands/remove_unused_imports.py
@@ -11,7 +11,23 @@ from libcst.codemod.visitors import RemoveImportsVisitor
 
 
 class RemoveUnusedImportsCommand(VisitorBasedCodemodCommand):
-    DESCRIPTION: str = "Remove all imports that are not used in a file."
+    """
+    Remove all unused imports from a file based on scope analysis.
+
+    This command analyses individual files in isolation and does not attempt
+    to track cross-references between them. If a symbol is imported in a file
+    but otherwise unused in it, that import will be removed even if it is being
+    referenced from another file.
+
+    It currently doesn't keep track of string type annotations, so an import
+    for `MyType` used only in `def f() -> "MyType"` will be removed.
+    """
+
+    DESCRIPTION: str = (
+        "Remove all imports that are not used in a file. "
+        "Note: only considers the file in isolation. "
+        "Note: does not account for usages in string type annotations. "
+    )
 
     def visit_Import(self, node: Import) -> bool:
         RemoveImportsVisitor.remove_unused_import_by_node(self.context, node)

--- a/libcst/codemod/commands/tests/test_remove_unused_imports.py
+++ b/libcst/codemod/commands/tests/test_remove_unused_imports.py
@@ -1,0 +1,50 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# pyre-strict
+
+from libcst.codemod import CodemodTest
+from libcst.codemod.commands.remove_unused_imports import RemoveUnusedImportsCommand
+
+
+class RemoveUnusedImportsCommandTest(CodemodTest):
+    TRANSFORM = RemoveUnusedImportsCommand
+
+    def test_simple_case(self) -> None:
+        before = "import a, b\na()"
+        after = "import a\na()"
+        self.assertCodemod(before, after)
+
+    def test_double_import(self) -> None:
+        before = "import a\nimport a\na()"
+        self.assertCodemod(before, before)
+
+    def test_conditional_import(self) -> None:
+        before = """
+            if True:
+                import a
+            else:
+                import b as a
+            a()
+        """
+        self.assertCodemod(before, before)
+
+    def test_unused_in_conditional(self) -> None:
+        before = """
+            if False:
+                import a
+        """
+        after = """
+            if False:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_type_annotations(self) -> None:
+        before = """
+            import a
+            x: a = 1
+        """
+        self.assertCodemod(before, before)


### PR DESCRIPTION
## Test Plan

Ran on an earlier version of this file:

```
❯ python -m libcst.tool codemod remove_unused_imports.RemoveUnusedImportsCommand libcst/codemod/commands/remove_unused_imports.py -u                                                                      normal
Calculating full-repo metadata...
Executing codemod...
0.01s 0% complete, [calculating] estimated for 1 files to go...--- /home/zsol/libcst/libcst/codemod/commands/remove_unused_imports.py
+++ /home/zsol/libcst/libcst/codemod/commands/remove_unused_imports.py
@@ -3,16 +3,14 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 #
 # pyre-strict
 
-from typing import Type, Generator
-from libcst.codemod import Codemod, VisitorBasedCodemodCommand
+from libcst.codemod import VisitorBasedCodemodCommand
 
 from libcst.codemod.visitors import RemoveImportsVisitor
 from libcst import Import, ImportFrom
-import asyncio
 
 
 class RemoveUnusedImportsCommand(VisitorBasedCodemodCommand):
     DESCRIPTION: str = "Remove all imports that are not used in a file."
 
Finished codemodding 1 files!
 - Transformed 1 files successfully.
 - Skipped 0 files.
 - Failed to codemod 0 files.
 - 0 warnings were generated.
```