### PR TITLE
Add InsertStatementsVisitor

### DIFF
--- a/libcst/codemod/visitors/__init__.py
+++ b/libcst/codemod/visitors/__init__.py
@@ -7,8 +7,8 @@
 from libcst.codemod.visitors._add_imports import AddImportsVisitor
 from libcst.codemod.visitors._gather_exports import GatherExportsVisitor
 from libcst.codemod.visitors._gather_imports import GatherImportsVisitor
-from libcst.codemod.visitors._remove_imports import RemoveImportsVisitor
 from libcst.codemod.visitors._insert_statements import InsertStatementsVisitor
+from libcst.codemod.visitors._remove_imports import RemoveImportsVisitor
 
 
 __all__ = [

--- a/libcst/codemod/visitors/__init__.py
+++ b/libcst/codemod/visitors/__init__.py
@@ -8,6 +8,7 @@ from libcst.codemod.visitors._add_imports import AddImportsVisitor
 from libcst.codemod.visitors._gather_exports import GatherExportsVisitor
 from libcst.codemod.visitors._gather_imports import GatherImportsVisitor
 from libcst.codemod.visitors._remove_imports import RemoveImportsVisitor
+from libcst.codemod.visitors._insert_statements import InsertStatementsVisitor
 
 
 __all__ = [
@@ -15,4 +16,5 @@ __all__ = [
     "GatherImportsVisitor",
     "GatherExportsVisitor",
     "RemoveImportsVisitor",
+    "InsertStatementsVisitor",
 ]

--- a/libcst/codemod/visitors/_insert_statements.py
+++ b/libcst/codemod/visitors/_insert_statements.py
@@ -1,6 +1,12 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
-from typing import TYPE_CHECKING, List, Tuple, Type, Optional, Union, Dict, Sequence
+from typing import TYPE_CHECKING, List, Tuple, Type, Optional, Union, Dict, Sequence, NamedTuple
 import itertools
+from collections import namedtuple
 
 import libcst as cst
 from libcst.codemod._visitor import ContextAwareTransformer
@@ -10,31 +16,55 @@ from libcst._types import CSTNodeT
 from libcst._removal_sentinel import RemovalSentinel
 
 
-class InsertStatementsVisitor(ContextAwareTransformer):
+class InsertStatementsVisitorContext(NamedTuple):
+    """
+    Context for the InsertStatementsVisitor about which statements
+    have been requested to insert before/after the current one.
+    """
+
+    # Mapping from a statement to list of statements to insert before it
     stmts_before: Dict[cst.BaseStatement, List[cst.BaseStatement]]
+
+    # Mapping from a statement to list of statements to insert after it
     stmts_after: Dict[cst.BaseStatement, List[cst.BaseStatement]]
+
+    # List of statements to insert before the current one
     stmts_before_acc: List[cst.BaseStatement]
+
+    # List of statements to insert after the current one
     stmts_after_acc: List[cst.BaseStatement]
+
+
+class InsertStatementsVisitor(ContextAwareTransformer):
+    """
+    Allows :class:`~libcst.visitor.CSTTransformer` to insert multiple statements before and after the currently-visited statement.
+    """
+
+    CONTEXT_KEY = "InsertStatementsVisitor"
 
     def __init__(self, context: CodemodContext) -> None:
         super().__init__(context)
-        self.stmts_before = {}
-        self.stmts_after = {}
-        self.stmts_before_acc = []
-        self.stmts_after_acc = []
+        self.context.scratch[
+            InsertStatementsVisitor.CONTEXT_KEY] = InsertStatementsVisitorContext({}, {},
+                                                                                  [], [])
+
+    def _context(self) -> InsertStatementsVisitorContext:
+        return self.context.scratch[InsertStatementsVisitor.CONTEXT_KEY]
 
     def insert_statements_before_current(self, stmts: List[cst.BaseStatement]) -> None:
-        self.stmts_before_acc.extend(stmts)
+        self._context().stmts_before_acc.extend(stmts)
 
     def insert_statements_after_current(self, stmts: List[cst.BaseStatement]) -> None:
-        self.stmts_after_acc.extend(stmts)
+        self._context().stmts_after_acc.extend(stmts)
 
     def _build_body(self, body: Sequence[cst.BaseStatement]) -> List[cst.BaseStatement]:
+        stmts_before = self._context().stmts_before
+        stmts_after = self._context().stmts_after
         new_stmts = []
         for stmt in body:
-            new_stmts.extend(self.stmts_before.get(stmt, []))
+            new_stmts.extend(stmts_before.get(stmt, []))
             new_stmts.append(stmt)
-            new_stmts.extend(self.stmts_after.get(stmt, []))
+            new_stmts.extend(stmts_after.get(stmt, []))
         return new_stmts
 
     def leave_IndentedBlock(self, original_node: cst.IndentedBlock,
@@ -53,9 +83,10 @@ class InsertStatementsVisitor(ContextAwareTransformer):
                                   updated_node: cst.SimpleStatementLine
                                   ) -> Union[cst.BaseStatement, cst.RemovalSentinel]:
         final_node = super().leave_SimpleStatementLine(original_node, updated_node)
+        context = self._context()
         if isinstance(final_node, cst.BaseStatement):
-            self.stmts_before[final_node] = self.stmts_before_acc
-            self.stmts_after[final_node] = self.stmts_after_acc
-        self.stmts_before_acc = []
-        self.stmts_after_acc = []
+            context.stmts_before[final_node] = context.stmts_before_acc.copy()
+            context.stmts_after[final_node] = context.stmts_after_acc.copy()
+        context.stmts_before_acc.clear()
+        context.stmts_after_acc.clear()
         return final_node

--- a/libcst/codemod/visitors/_insert_statements.py
+++ b/libcst/codemod/visitors/_insert_statements.py
@@ -1,0 +1,61 @@
+# pyre-strict
+from typing import TYPE_CHECKING, List, Tuple, Type, Optional, Union, Dict, Sequence
+import itertools
+
+import libcst as cst
+from libcst.codemod._visitor import ContextAwareTransformer
+from libcst.codemod._context import CodemodContext
+from libcst._nodes.base import CSTNode
+from libcst._types import CSTNodeT
+from libcst._removal_sentinel import RemovalSentinel
+
+
+class InsertStatementsVisitor(ContextAwareTransformer):
+    stmts_before: Dict[cst.BaseStatement, List[cst.BaseStatement]]
+    stmts_after: Dict[cst.BaseStatement, List[cst.BaseStatement]]
+    stmts_before_acc: List[cst.BaseStatement]
+    stmts_after_acc: List[cst.BaseStatement]
+
+    def __init__(self, context: CodemodContext) -> None:
+        super().__init__(context)
+        self.stmts_before = {}
+        self.stmts_after = {}
+        self.stmts_before_acc = []
+        self.stmts_after_acc = []
+
+    def insert_statements_before_current(self, stmts: List[cst.BaseStatement]) -> None:
+        self.stmts_before_acc.extend(stmts)
+
+    def insert_statements_after_current(self, stmts: List[cst.BaseStatement]) -> None:
+        self.stmts_after_acc.extend(stmts)
+
+    def _build_body(self, body: Sequence[cst.BaseStatement]) -> List[cst.BaseStatement]:
+        new_stmts = []
+        for stmt in body:
+            new_stmts.extend(self.stmts_before.get(stmt, []))
+            new_stmts.append(stmt)
+            new_stmts.extend(self.stmts_after.get(stmt, []))
+        return new_stmts
+
+    def leave_IndentedBlock(self, original_node: cst.IndentedBlock,
+                            updated_node: cst.IndentedBlock) -> cst.BaseSuite:
+        final_node = super().leave_IndentedBlock(original_node, updated_node)
+        if isinstance(final_node, cst.IndentedBlock):
+            return final_node.with_changes(body=self._build_body(final_node.body))
+        return final_node
+
+    def leave_Module(self, original_node: cst.Module,
+                     updated_node: cst.Module) -> cst.Module:
+        updated_node = super().leave_Module(original_node, updated_node)
+        return updated_node.with_changes(body=self._build_body(updated_node.body))
+
+    def leave_SimpleStatementLine(self, original_node: cst.SimpleStatementLine,
+                                  updated_node: cst.SimpleStatementLine
+                                  ) -> Union[cst.BaseStatement, cst.RemovalSentinel]:
+        final_node = super().leave_SimpleStatementLine(original_node, updated_node)
+        if isinstance(final_node, cst.BaseStatement):
+            self.stmts_before[final_node] = self.stmts_before_acc
+            self.stmts_after[final_node] = self.stmts_after_acc
+        self.stmts_before_acc = []
+        self.stmts_after_acc = []
+        return final_node

--- a/libcst/codemod/visitors/tests/test_insert_statements.py
+++ b/libcst/codemod/visitors/tests/test_insert_statements.py
@@ -1,21 +1,29 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
 # pyre-strict
+from typing import Type
+
 import libcst as cst
 from libcst.codemod import CodemodContext, CodemodTest
 from libcst.codemod.visitors import InsertStatementsVisitor
-from libcst.testing.utils import UnitTest
-from typing import Type
 
 
 class InsertAssignAroundAssignVisitor(InsertStatementsVisitor):
-    def leave_Integer(self, original_node: cst.Integer,
-                      updated_node: cst.Integer) -> cst.Integer:
+    def leave_Integer(
+        self, original_node: cst.Integer, updated_node: cst.Integer
+    ) -> cst.Integer:
         self.insert_statements_before_current([cst.parse_statement("y = 1")])
         self.insert_statements_after_current([cst.parse_statement("z = 1")])
         return updated_node
 
 
 class TestInsertStatementsVisitor(CodemodTest):
-    def insert_statements(self, Visitor: Type[InsertStatementsVisitor], code: str) -> str:
+    def insert_statements(
+        self, Visitor: Type[InsertStatementsVisitor], code: str
+    ) -> str:
         transform_instance = Visitor(CodemodContext())
         input_tree = cst.parse_module(CodemodTest.make_fixture_data(code))
         return input_tree.visit(transform_instance).code

--- a/libcst/codemod/visitors/tests/test_insert_statements.py
+++ b/libcst/codemod/visitors/tests/test_insert_statements.py
@@ -1,0 +1,61 @@
+# pyre-strict
+import libcst as cst
+from libcst.codemod import CodemodContext, CodemodTest
+from libcst.codemod.visitors import InsertStatementsVisitor
+from libcst.testing.utils import UnitTest
+from typing import Type
+
+
+class InsertAssignAroundAssignVisitor(InsertStatementsVisitor):
+    def leave_Integer(self, original_node: cst.Integer,
+                      updated_node: cst.Integer) -> cst.Integer:
+        self.insert_statements_before_current([cst.parse_statement("y = 1")])
+        self.insert_statements_after_current([cst.parse_statement("z = 1")])
+        return updated_node
+
+
+class TestInsertStatementsVisitor(CodemodTest):
+    def insert_statements(self, Visitor: Type[InsertStatementsVisitor], code: str) -> str:
+        transform_instance = Visitor(CodemodContext())
+        input_tree = cst.parse_module(CodemodTest.make_fixture_data(code))
+        return input_tree.visit(transform_instance).code
+
+    def test_noop(self) -> None:
+        """
+        Should do nothing.
+        """
+
+        before = """
+            x = "a"
+        """
+
+        expected_after = """
+            x = "a"
+        """
+
+        actual_after = self.insert_statements(InsertAssignAroundAssignVisitor, before)
+        self.assertCodeEqual(expected_after, actual_after)
+
+    def test_insert_assign(self) -> None:
+        """
+        Should add assignments before and after the x = ...
+        """
+
+        before = """
+            x = 1
+            if True:
+                x = 1
+        """
+
+        expected_after = """
+            y = 1
+            x = 1
+            z = 1
+            if True:
+                y = 1
+                x = 1
+                z = 1
+        """
+
+        actual_after = self.insert_statements(InsertAssignAroundAssignVisitor, before)
+        self.assertCodeEqual(expected_after, actual_after)


### PR DESCRIPTION
## Summary

This PR adds a `CSTTransformer` mixin that allows sub-classes to use `insert_statements_before_current` and `insert_statements_after_current`, as discussed in #263. For example, this transformer:

```python
class InsertAssignAroundAssignVisitor(InsertStatementsVisitor):
    def leave_Integer(
        self, original_node: cst.Integer, updated_node: cst.Integer
    ) -> cst.Integer:
        self.insert_statements_before_current([cst.parse_statement("y = 1")])
        self.insert_statements_after_current([cst.parse_statement("z = 1")])
        return updated_node
```

Turns this code:

```python
x = 1
if True:
    x = 1  
```

Into this code:

```python
y = 1
x = 1
z = 1
if True:
    y = 1
    x = 1
    z = 1
```

This PR is **not** finalized. Specifically, my primary concern: in the [previous iteration of the idea](https://gist.github.com/willcrichton/e2ff206b2a0f76e33ee4d2f10c2169ed), I used `on_leave` with `isinstance(node, STATEMENT_TYPE)` to check whether to map the statement accumulator to `node`. However, @jimmylai suggested only using the specialize `leave_*` methods due to efficiency concerns. There are 8 different statements that inherit from `BaseCompoundStatement`, meaning I would need to implement the `leave` method for each of them, generating a lot of redundant code. Is that still worth it?

Beyond that, any comments on the design are welcome. Once we resolve the question above, I will add more unit tests.

## Test Plan

I have added unit tests to `_test_insert_statements.py`. 

