### PR TITLE
Ignore version markers from pyenv and common virtualenv names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ build/
 .coverage
 .hypothesis/
 .pyre_configuration
+.python-version

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ build/
 .hypothesis/
 .pyre_configuration
 .python-version
+.venv/
+venv/


### PR DESCRIPTION
## Summary

These are added when adding directory-based version preferences via `pyenv local`. Also, common practice is to put the virtualenvs in the root of the project, named either `venv/` or `.venv/`, so let's ignore those too.

