### PR TITLE
[ScopeProvider] Expose more granular Assignments and Accesses for dotted imports

### DIFF
--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -141,12 +141,25 @@ There are four different type of scope in Python:
 :class:`~libcst.metadata.ComprehensionScope`.
 
 .. image:: _static/img/python_scopes.png
-   :alt: LibCST
+   :alt: Diagram showing how the above 4 scopes are nested in each other
    :width: 400
    :align: center
 
 LibCST allows you to inspect these scopes to see what local variables are
 assigned or accessed within.
+
+.. note::
+   Import statements bring new symbols into scope that are declared in other files.
+   As such, they are represented by :class:`~libcst.metadata.Assignment` for scope
+   analysis purposes. Dotted imports (e.g. ``import a.b.c``) generate multiple
+   :class:`~libcst.metadata.Assignment` objects — one for each module. When analyzing
+   references, only the most specific access is recorded.
+   
+   For example, the above ``import a.b.c`` statement generates three
+   :class:`~libcst.metadata.Assignment` objects: one for ``a``, one for ``a.b``, and
+   one for ``a.b.c``. A reference for ``a.b.c`` records an access only for the last
+   assignment, while a reference for ``a.d`` only records an access for the
+   :class:`~libcst.metadata.Assignment` representing ``a``.
 
 .. autoclass:: libcst.metadata.ScopeProvider
    :no-undoc-members:

--- a/libcst/codemod/commands/tests/test_remove_unused_imports.py
+++ b/libcst/codemod/commands/tests/test_remove_unused_imports.py
@@ -48,3 +48,32 @@ class RemoveUnusedImportsCommandTest(CodemodTest):
             x: a = 1
         """
         self.assertCodemod(before, before)
+
+    def test_dotted_imports(self) -> None:
+        before = """
+            import a.b, a.b.c
+            import e.f
+            import g.h
+            import x.y, x.y.z
+
+            def foo() -> None:
+                a.b
+                e.g
+                g.h.i
+                x.y.z
+        """
+
+        after = """
+            import a.b, a.b.c
+            import e.f
+            import g.h
+            import x.y.z
+
+            def foo() -> None:
+                a.b
+                e.g
+                g.h.i
+                x.y.z
+        """
+
+        self.assertCodemod(before, after)

--- a/libcst/codemod/visitors/tests/test_remove_imports.py
+++ b/libcst/codemod/visitors/tests/test_remove_imports.py
@@ -377,46 +377,6 @@ class TestRemoveImportsCodemod(CodemodTest):
             context_override=CodemodContext(full_module_name="a.b.foobar"),
         )
 
-    def test_remove_dotted_import(self) -> None:
-        before = """
-            import a.b, a.b.c
-            import e.f
-            import g.h
-            import x.y, x.y.z
-
-            def foo() -> None:
-                a.b
-                e.g
-                g.h.i
-                x.y.z
-        """
-
-        after = """
-            import a.b, a.b.c
-            import e.f
-            import g.h
-            import x.y.z
-
-            def foo() -> None:
-                a.b
-                e.g
-                g.h.i
-                x.y.z
-        """
-
-        self.assertCodemod(
-            before,
-            after,
-            [
-                ("a.b", None, None),
-                ("a.b.c", None, None),
-                ("e.f", None, None),
-                ("g.h", None, None),
-                ("x.y", None, None),
-                ("x.y.z", None, None),
-            ],
-        )
-
     def test_remove_import_complex(self) -> None:
         """
         Should remove complex module as import

--- a/libcst/codemod/visitors/tests/test_remove_imports.py
+++ b/libcst/codemod/visitors/tests/test_remove_imports.py
@@ -433,6 +433,7 @@ class TestRemoveImportsCodemod(CodemodTest):
             from d.e import f
             from h.i import j as k
             from l.m import n as o
+            from x import *
 
             def foo() -> None:
                 f()
@@ -442,6 +443,7 @@ class TestRemoveImportsCodemod(CodemodTest):
             from bar import qux
             from d.e import f
             from h.i import j as k
+            from x import *
 
             def foo() -> None:
                 f()

--- a/libcst/codemod/visitors/tests/test_remove_imports.py
+++ b/libcst/codemod/visitors/tests/test_remove_imports.py
@@ -387,21 +387,25 @@ class TestRemoveImportsCodemod(CodemodTest):
             import baz, qux
             import a.b
             import c.d
+            import x.y.z
             import e.f as g
             import h.i as j
 
             def foo() -> None:
                 c.d()
+                x.u
                 j()
         """
         after = """
             import bar
             import qux
             import c.d
+            import x.y.z
             import h.i as j
 
             def foo() -> None:
                 c.d()
+                x.u
                 j()
         """
 
@@ -414,6 +418,7 @@ class TestRemoveImportsCodemod(CodemodTest):
                 ("c.d", None, None),
                 ("e.f", None, "g"),
                 ("h.i", None, "j"),
+                ("x.y.z", None, None),
             ],
         )
 

--- a/libcst/codemod/visitors/tests/test_remove_imports.py
+++ b/libcst/codemod/visitors/tests/test_remove_imports.py
@@ -377,6 +377,46 @@ class TestRemoveImportsCodemod(CodemodTest):
             context_override=CodemodContext(full_module_name="a.b.foobar"),
         )
 
+    def test_remove_dotted_import(self) -> None:
+        before = """
+            import a.b, a.b.c
+            import e.f
+            import g.h
+            import x.y, x.y.z
+
+            def foo() -> None:
+                a.b
+                e.g
+                g.h.i
+                x.y.z
+        """
+
+        after = """
+            import a.b, a.b.c
+            import e.f
+            import g.h
+            import x.y.z
+
+            def foo() -> None:
+                a.b
+                e.g
+                g.h.i
+                x.y.z
+        """
+
+        self.assertCodemod(
+            before,
+            after,
+            [
+                ("a.b", None, None),
+                ("a.b.c", None, None),
+                ("e.f", None, None),
+                ("g.h", None, None),
+                ("x.y", None, None),
+                ("x.y.z", None, None),
+            ],
+        )
+
     def test_remove_import_complex(self) -> None:
         """
         Should remove complex module as import

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -55,11 +55,14 @@ class Access:
                    ...
     """
 
-    #: The name node of the access. A name is an access when the expression context is
-    #: :attr:`ExpressionContext.LOAD`.
+    #: The node of the access. A name is an access when the expression context is
+    #: :attr:`ExpressionContext.LOAD`. This is usually the name node representing the
+    #: access, except for dotted imports, when it might be the attribute that
+    #: represents the most specific part of the imported symbol.
     node: Union[cst.Name, cst.Attribute]
 
-    #: The scope of the access. Note that a access could be in a child scope of its assignment.
+    #: The scope of the access. Note that a access could be in a child scope of its
+    #: assignment.
     scope: "Scope"
 
     __assignments: Set["BaseAssignment"]

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -810,9 +810,8 @@ class ScopeVisitor(cst.CSTVisitor):
         scope_name_accesses = defaultdict(set)
         for (access, enclosing_attribute) in self.__deferred_accesses:
             if enclosing_attribute is not None:
-                names = _gen_dotted_names(enclosing_attribute)
                 name = None
-                for name, node in names:
+                for name, node in _gen_dotted_names(enclosing_attribute):
                     if name in access.scope:
                         access.node = node
                         break

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -20,11 +20,14 @@ from typing import (
     MutableMapping,
     Optional,
     Set,
+    Tuple,
     Type,
     Union,
+    Iterable,
 )
 
 import libcst as cst
+from libcst import ensure_type
 from libcst._add_slots import add_slots
 from libcst._metadata_dependent import MetadataDependent
 from libcst.helpers import get_full_name_for_node
@@ -54,7 +57,7 @@ class Access:
 
     #: The name node of the access. A name is an access when the expression context is
     #: :attr:`ExpressionContext.LOAD`.
-    node: cst.Name
+    node: Union[cst.Name, cst.Attribute]
 
     #: The scope of the access. Note that a access could be in a child scope of its assignment.
     scope: "Scope"
@@ -584,12 +587,32 @@ class ComprehensionScope(LocalScope):
     pass
 
 
+# Generates dotted names from an Attribute or Name node:
+# Attribute(value=Name(value="a"), attr=Name(value="b")) -> ("a.b", "a")
+# each string has the corresponding CSTNode attached to it
+def _gen_dotted_names(
+    node: Union[cst.Attribute, cst.Name]
+) -> Iterable[Tuple[str, Union[cst.Attribute, cst.Name]]]:
+    if isinstance(node, cst.Name):
+        yield (node.value, node)
+    else:
+        value = node.value
+        if not isinstance(value, (cst.Attribute, cst.Name)):
+            raise ValueError(f"Unexpected name value in import: {value}")
+        name_values = iter(_gen_dotted_names(value))
+        (next_name, next_node) = next(name_values)
+        yield (f"{next_name}.{node.attr.value}", node)
+        yield (next_name, next_node)
+        yield from name_values
+
+
 class ScopeVisitor(cst.CSTVisitor):
     # since it's probably not useful. That can makes this visitor cleaner.
     def __init__(self, provider: "ScopeProvider") -> None:
         self.provider: ScopeProvider = provider
         self.scope: Scope = GlobalScope()
-        self.__deferred_accesses: List[Access] = []
+        self.__deferred_accesses: List[Tuple[Access, Optional[cst.Attribute]]] = []
+        self.__top_level_attribute: Optional[cst.Attribute] = None
 
     @contextmanager
     def _new_scope(
@@ -613,24 +636,18 @@ class ScopeVisitor(cst.CSTVisitor):
 
     def _visit_import_alike(self, node: Union[cst.Import, cst.ImportFrom]) -> bool:
         names = node.names
-        if not isinstance(names, cst.ImportStar):
-            # make sure node.names is Sequence[ImportAlias]
-            for name in names:
-                asname = name.asname
-                if asname is not None:
-                    name_value = cst.ensure_type(asname.name, cst.Name).value
-                else:
-                    name_node = name.name
-                    while isinstance(name_node, cst.Attribute):
-                        # the value of Attribute in import alike can only be either Name or Attribute
-                        name_node = name_node.value
-                    if isinstance(name_node, cst.Name):
-                        name_value = name_node.value
-                    else:
-                        raise Exception(
-                            f"Unexpected ImportAlias name value: {name_node}"
-                        )
+        if isinstance(names, cst.ImportStar):
+            return False
 
+        # make sure node.names is Sequence[ImportAlias]
+        for name in names:
+            asname = name.asname
+            if asname is not None:
+                name_values = _gen_dotted_names(cst.ensure_type(asname.name, cst.Name))
+            else:
+                name_values = _gen_dotted_names(name.name)
+
+            for name_value, _ in name_values:
                 self.scope.record_assignment(name_value, node)
         return False
 
@@ -641,7 +658,11 @@ class ScopeVisitor(cst.CSTVisitor):
         return self._visit_import_alike(node)
 
     def visit_Attribute(self, node: cst.Attribute) -> Optional[bool]:
+        if self.__top_level_attribute is None:
+            self.__top_level_attribute = node
         node.value.visit(self)  # explicitly not visiting attr
+        if self.__top_level_attribute is node:
+            self.__top_level_attribute = None
         return False
 
     def visit_Name(self, node: cst.Name) -> Optional[bool]:
@@ -651,8 +672,7 @@ class ScopeVisitor(cst.CSTVisitor):
             self.scope.record_assignment(node.value, node)
         elif context in (ExpressionContext.LOAD, ExpressionContext.DEL):
             access = Access(node, self.scope)
-            self.__deferred_accesses.append(access)
-            self.scope.record_access(node.value, access)
+            self.__deferred_accesses.append((access, self.__top_level_attribute))
 
     def visit_FunctionDef(self, node: cst.FunctionDef) -> Optional[bool]:
         self.scope.record_assignment(node.name.value, node)
@@ -788,10 +808,20 @@ class ScopeVisitor(cst.CSTVisitor):
         # In worst case, all accesses (m) and assignments (n) refer to the same name,
         # the time complexity is O(m x n), this optimizes it as O(m + n).
         scope_name_accesses = defaultdict(set)
-        for access in self.__deferred_accesses:
-            name = access.node.value
+        for (access, enclosing_attribute) in self.__deferred_accesses:
+            if enclosing_attribute is not None:
+                names = _gen_dotted_names(enclosing_attribute)
+                name = None
+                for name, node in names:
+                    if name in access.scope:
+                        access.node = node
+                        break
+                assert name is not None
+            else:
+                name = ensure_type(access.node, cst.Name).value
             scope_name_accesses[(access.scope, name)].add(access)
             access.record_assignments(access.scope[name])
+            access.scope.record_access(name, access)
 
         for (scope, name), accesses in scope_name_accesses.items():
             for assignment in scope[name]:

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -14,6 +14,7 @@ from enum import Enum, auto
 from typing import (
     Collection,
     Dict,
+    Iterable,
     Iterator,
     List,
     Mapping,
@@ -23,7 +24,6 @@ from typing import (
     Tuple,
     Type,
     Union,
-    Iterable,
 )
 
 import libcst as cst


### PR DESCRIPTION
## Summary
This PR adds extra `Assignment`s created by the `ScopeProvider` for dotted imports like `import a.b.c`. For such an import, there are now three assignments, keyed by `a`, `a.b`, and `a.b.c`. For accesses, only the most specific access is recorded and attached to the appropriate assignment.

## Test Plan

Added unit tests.

Fixes #281.
