### PR TITLE
[codemod] show errors from formatter subprocess call

### DIFF
--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -58,7 +58,7 @@ def invoke_formatter(formatter_args: Sequence[str], code: AnyStr) -> AnyStr:
             formatter_args,
             env={},
             input=code,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.STDOUT,
             universal_newlines=not work_with_bytes,
             encoding=None if work_with_bytes else "utf-8",
         ),
@@ -70,6 +70,9 @@ def print_execution_result(result: TransformResult) -> None:
         print(f"WARNING: {warning}", file=sys.stderr)
 
     if isinstance(result, TransformFailure):
+        error = result.error
+        if isinstance(error, subprocess.CalledProcessError):
+            print(error.output.decode("utf-8"), file=sys.stderr)
         print(result.traceback_str, file=sys.stderr)
 
 


### PR DESCRIPTION
## Summary
When LibCST produces code with syntax error, the formatter raises exception but the error message was not useful. This surface the detailed error to make debug easier.

## Test Plan

