### PR TITLE
[codemod] add integration test for show errors from formatter subprocess call

### DIFF
--- a/libcst/codemod/tests/codemod_formatter_error_input.py.txt
+++ b/libcst/codemod/tests/codemod_formatter_error_input.py.txt
@@ -1,0 +1,15 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# pyre-strict
+
+import subprocess  # noqa: F401
+from contextlib import AsyncExitStack
+
+
+def fun() -> None:
+    # this is an explicit syntax error to cause formatter error
+    async with AsyncExitStack() as stack:
+        stack

--- a/libcst/codemod/tests/test_codemod_cli.py
+++ b/libcst/codemod/tests/test_codemod_cli.py
@@ -1,0 +1,38 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# pyre-strict
+
+
+import subprocess
+import sys
+
+from libcst.testing.utils import UnitTest
+
+
+class TestCodemodCLI(UnitTest):
+    def test_codemod_formatter_error_input(self) -> None:
+        rlt = subprocess.run(
+            [
+                "python",
+                "-m",
+                "libcst.tool",
+                "codemod",
+                "remove_unused_imports.RemoveUnusedImportsCommand",
+                "libcst/codemod/tests/codemod_formatter_error_input.py.txt",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        version = sys.version_info
+        if version[0] == 3 and version[1] == 6:
+            self.assertIn(
+                "ParserSyntaxError: Syntax Error @ 14:11.", rlt.stderr.decode("utf-8"),
+            )
+        else:
+            self.assertIn(
+                "error: cannot format -: Cannot parse: 13:10:     async with AsyncExitStack() as stack:",
+                rlt.stderr.decode("utf-8"),
+            )


### PR DESCRIPTION
## Summary
Without the fix, it shows error like this and it's not useful to understand the cause.
```
Traceback (most recent call last):
  File "/Users/jimmylai/github/LibCST/libcst/codemod/_cli.py", line 334, in _parallel_exec_process_stub
    newcode = invoke_formatter(formatter_args, newcode)
  File "/Users/jimmylai/github/LibCST/libcst/codemod/_cli.py", line 63, in invoke_formatter
    encoding=None if work_with_bytes else "utf-8",
  File "/Users/jimmylai/anaconda3/lib/python3.7/subprocess.py", line 395, in check_output
    **kwargs).stdout
  File "/Users/jimmylai/anaconda3/lib/python3.7/subprocess.py", line 487, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/Users/jimmylai/github/libcst-env/bin/black', '-']' returned non-zero exit status 123.

Failed to codemod /Users/jimmylai/github/LibCST/libcst/codemod/tests/codemod_formatter_error_input.py
```

With the fix, it includes those detail to make debug easy.
```
Codemodding /Users/jimmylai/github/LibCST/libcst/codemod/tests/codemod_formatter_error_input.py
# Copyright (c) Facebook, Inc. and its affiliates.
#
# This source code is licensed under the MIT license found in the
# LICENSE file in the root directory of this source tree.
#
# pyre-strict

from contextlib import AsyncExitStack


def fun():
    # this is an explicit syntax error to cause formatter error
    async with AsyncExitStack() as stack:
        pass

error: cannot format -: Cannot parse: 13:10:     async with AsyncExitStack() as stack:
```

This is for fixing issue @lexprfuncall had.

## Test Plan
added test case.
