### PR TITLE
Handle non-import attribute accesses gracefully

### DIFF
--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -601,7 +601,8 @@ def _gen_dotted_names(
     else:
         value = node.value
         if not isinstance(value, (cst.Attribute, cst.Name)):
-            raise ValueError(f"Unexpected name value in import: {value}")
+            # this is not an import
+            return
         name_values = iter(_gen_dotted_names(value))
         (next_name, next_node) = next(name_values)
         yield (f"{next_name}.{node.attr.value}", node)
@@ -818,7 +819,8 @@ class ScopeVisitor(cst.CSTVisitor):
                     if name in access.scope:
                         access.node = node
                         break
-                assert name is not None
+                if name is None:
+                    continue
             else:
                 name = ensure_type(access.node, cst.Name).value
             scope_name_accesses[(access.scope, name)].add(access)

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -1064,6 +1064,13 @@ class ScopeProviderTest(UnitTest):
                     list(scope.parent._accesses.items()), before_parent_accesses
                 )
 
+    def test_attribute_of_function_call(self) -> None:
+        get_scope_metadata_provider("foo().bar")
+
+    def test_self(self) -> None:
+        with open(__file__) as f:
+            get_scope_metadata_provider(f.read())
+
     def test_get_qualified_names_for_is_read_only(self) -> None:
         m, scopes = get_scope_metadata_provider(
             """


### PR DESCRIPTION
## Summary
Scope analysis encounters attribute accesses that don't refer to imports. These attribute accesses can have arbitrary expressions in the `Attribute` node, which the import access analysis is not prepared for. Instead of blowing up with an exception, just skip these accesses (which was the previous behavior).

Note that for a case like `foo().bar`, this change only skips access analysis for the outer `Attribute` node, `foo` will still be analysed.

## Test Plan
Added two test cases.

Fixes #286 
