### PR TITLE
Fix StopIteration exception during scope analysis

### DIFF
--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -1109,6 +1109,11 @@ class ScopeProviderTest(UnitTest):
     def test_attribute_of_function_call(self) -> None:
         get_scope_metadata_provider("foo().bar")
 
+    def test_attribute_of_subscript_called(self) -> None:
+        m, scopes = get_scope_metadata_provider("foo[0].bar.baz()")
+        scope = scopes[m]
+        self.assertIn("foo", scope.accesses)
+
     def test_self(self) -> None:
         with open(__file__) as f:
             get_scope_metadata_provider(f.read())


### PR DESCRIPTION
## Summary

During scope analysis all attribute accesses are collected for matching on
import names. The matching code (specifically `_gen_dotted_names`) was not
prepared for all types of expressions. In particular, complex expressions like
`foo[0].bar.baz()` caused a `StopIteration` exception when `_gen_dotted_names`
calls itself recursively. The nested call doesn't yield any values, and so
calling `next()` on it raises.

This commit fixes these types of errors.

## Test Plan

Added test case
