### PR TITLE
Add NamedTuple to dataclass conversion codemod

### DIFF
--- a/libcst/codemod/commands/convert_namedtuple_to_dataclass.py
+++ b/libcst/codemod/commands/convert_namedtuple_to_dataclass.py
@@ -53,7 +53,7 @@ class ConvertNamedTupleToDataclassCommand(VisitorBasedCodemodCommand):
                 namedtuple_base = base_class
 
         # We still want to return the updated node in case some of its children have been modified
-        if not namedtuple_base:
+        if namedtuple_base is None:
             return updated_node
 
         AddImportsVisitor.add_needed_import(self.context, "dataclasses", "dataclass")

--- a/libcst/codemod/commands/convert_namedtuple_to_dataclass.py
+++ b/libcst/codemod/commands/convert_namedtuple_to_dataclass.py
@@ -29,7 +29,7 @@ class ConvertNamedTupleToDataclassCommand(VisitorBasedCodemodCommand):
     DESCRIPTION: str = "Convert NamedTuple class declarations to Python 3.7 dataclasses using the @dataclass decorator."
     METADATA_DEPENDENCIES: Sequence[ProviderT] = (QualifiedNameProvider,)
 
-    # The `NamedTuple` we are interested in
+    # The 'NamedTuple' we are interested in
     qualified_namedtuple: QualifiedName = QualifiedName(
         name="typing.NamedTuple", source=QualifiedNameSource.IMPORT
     )
@@ -42,7 +42,7 @@ class ConvertNamedTupleToDataclassCommand(VisitorBasedCodemodCommand):
 
         # Need to examine the original node's bases since they are directly tied to import metadata
         for base_class in original_node.bases:
-            # Compare the base class' qualified name against the expected typing.NamedTuple
+            # Compare the base class's qualified name against the expected typing.NamedTuple
             if not QualifiedNameProvider.has_name(
                 self, base_class.value, self.qualified_namedtuple
             ):

--- a/libcst/codemod/commands/convert_namedtuple_to_dataclass.py
+++ b/libcst/codemod/commands/convert_namedtuple_to_dataclass.py
@@ -41,7 +41,7 @@ class ConvertNamedTupleToDataclassCommand(VisitorBasedCodemodCommand):
             name=f"{self.MODULE}.{self.OBJECT}", source=QualifiedNameSource.IMPORT
         )
 
-        # Need to iterate through the original node's bases since they are directly tied to import metadata
+        # Need to examine the original node's bases since they are directly tied to import metadata
         for base_class in original_node.bases:
             # Compare the base class's qualified named against the expected typing.NamedTuple
             if not QualifiedNameProvider.has_name(

--- a/libcst/codemod/commands/convert_namedtuple_to_dataclass.py
+++ b/libcst/codemod/commands/convert_namedtuple_to_dataclass.py
@@ -26,26 +26,25 @@ class ConvertNamedTupleToDataclassCommand(VisitorBasedCodemodCommand):
     NamedTuple-specific attributes and methods.
     """
 
-    DESCRIPTION: str = "Convert legacy NamedTuple class declarations to Python 3.7 dataclasses."
+    DESCRIPTION: str = "Convert NamedTuple class declarations to Python 3.7 dataclasses using the @dataclass decorator."
     METADATA_DEPENDENCIES: Sequence[ProviderT] = (QualifiedNameProvider,)
 
-    MODULE: str = "typing"
-    OBJECT: str = "NamedTuple"
+    # The `NamedTuple` we are interested in
+    qualified_namedtuple: QualifiedName = QualifiedName(
+        name="typing.NamedTuple", source=QualifiedNameSource.IMPORT
+    )
 
     def leave_ClassDef(
         self, original_node: cst.ClassDef, updated_node: cst.ClassDef
     ) -> cst.ClassDef:
         new_bases: List[cst.Arg] = []
         namedtuple_base: Optional[cst.Arg] = None
-        qualified_namedtuple: QualifiedName = QualifiedName(
-            name=f"{self.MODULE}.{self.OBJECT}", source=QualifiedNameSource.IMPORT
-        )
 
         # Need to examine the original node's bases since they are directly tied to import metadata
         for base_class in original_node.bases:
-            # Compare the base class's qualified named against the expected typing.NamedTuple
+            # Compare the base class' qualified name against the expected typing.NamedTuple
             if not QualifiedNameProvider.has_name(
-                self, base_class.value, qualified_namedtuple
+                self, base_class.value, self.qualified_namedtuple
             ):
                 # Keep all bases that are not of type typing.NamedTuple
                 new_bases.append(base_class)

--- a/libcst/codemod/commands/tests/test_convert_namedtuple_to_dataclass.py
+++ b/libcst/codemod/commands/tests/test_convert_namedtuple_to_dataclass.py
@@ -1,0 +1,179 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# pyre-strict
+from libcst.codemod import CodemodTest
+from libcst.codemod.commands.convert_namedtuple_to_dataclass import (
+    ConvertNamedTupleToDataclassCommand,
+)
+
+
+class ConvertNamedTupleToDataclassCommandTest(CodemodTest):
+
+    TRANSFORM = ConvertNamedTupleToDataclassCommand
+
+    def test_no_change(self) -> None:
+        """
+        Should result in no change as there are no children of NamedTuple.
+        """
+
+        before = """
+            @dataclass(frozen=True)
+            class Foo:
+                pass
+        """
+        after = """
+            @dataclass(frozen=True)
+            class Foo:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_change(self) -> None:
+        """
+        Should remove the NamedTuple import along with its use as a base class for Foo.
+        Should import dataclasses.dataclass and annotate Foo.
+        """
+
+        before = """
+            from typing import NamedTuple
+
+            class Foo(NamedTuple):
+                pass
+        """
+        after = """
+            from dataclasses import dataclass
+
+            @dataclass(frozen=True)
+            class Foo:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_with_decorator_already(self) -> None:
+        """
+        Should retain existing decorator.
+        """
+
+        before = """
+            from typing import NamedTuple
+
+            @other_decorator
+            class Foo(NamedTuple):
+                pass
+        """
+        after = """
+            from dataclasses import dataclass
+
+            @other_decorator
+            @dataclass(frozen=True)
+            class Foo:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_multiple_bases(self) -> None:
+        """
+        Should retain all existing bases other than NamedTuple.
+        """
+
+        before = """
+            from typing import NamedTuple
+
+            class Foo(NamedTuple, OtherBase, YetAnotherBase):
+                pass
+        """
+        after = """
+            from dataclasses import dataclass
+
+            @dataclass(frozen=True)
+            class Foo(OtherBase, YetAnotherBase):
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_nested_classes(self) -> None:
+        """
+        Should perform expected changes on inner classes.
+        """
+
+        before = """
+            from typing import NamedTuple
+
+            class OuterClass:
+                class InnerClass(NamedTuple):
+                    pass
+        """
+        after = """
+            from dataclasses import dataclass
+
+            class OuterClass:
+                @dataclass(frozen=True)
+                class InnerClass:
+                    pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_aliased_object_import(self) -> None:
+        """
+        Should detect aliased NamedTuple object import and base.
+        """
+
+        before = """
+            from typing import NamedTuple as nt
+
+            class Foo(nt):
+                pass
+        """
+        after = """
+            from dataclasses import dataclass
+
+            @dataclass(frozen=True)
+            class Foo:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_aliased_module_import(self) -> None:
+        """
+        Should detect aliased `typing` module import and base.
+        """
+
+        before = """
+            import typing as typ
+
+            class Foo(typ.NamedTuple):
+                pass
+        """
+        after = """
+            from dataclasses import dataclass
+
+            @dataclass(frozen=True)
+            class Foo:
+                pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_other_unused_imports_not_removed(self) -> None:
+        """
+        Should not remove any imports other than NamedTuple, even if they are also unused.
+        """
+
+        before = """
+            from typing import NamedTuple
+            import SomeUnusedImport
+
+            class Foo(NamedTuple):
+                pass
+        """
+        after = """
+            import SomeUnusedImport
+            from dataclasses import dataclass
+
+            @dataclass(frozen=True)
+            class Foo:
+                pass
+        """
+        self.assertCodemod(before, after)


### PR DESCRIPTION
## Summary
Conversion of a NamedTuple class declaration to Python 3.7 `dataclasses.dataclass` type as an annotation. Perform removal of unused NamedTuple import and add the import of `dataclasses.dataclass` if not already imported. 
## Test Plan
Updated test suite:
```
python -m unittest libcst.codemod.commands.tests.test_convert_namedtuple_to_dataclass
```
Run entire test suite:
```
tox test
```

