### PR TITLE
[release] Bump LibCST to new release 0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # 0.3.6 - 2020-05-27
 
 ## Added
-- Added `ConvertNamedTupleToDataclassCommand` to convert `NamedTuple` class declarations to Python 3.7 `dataclasses` using the `@dataclass(frozen=True)` decorator. [#299](https://github.com/Instagram/LibCST/pull/299)
+ - Added `ConvertNamedTupleToDataclassCommand` to convert `NamedTuple` class declarations to Python 3.7 `dataclasses` using the `@dataclass(frozen=True)` decorator. [#299](https://github.com/Instagram/LibCST/pull/299)
+
+## Fixed
+ - Fixed typo in file name `libcst/codemod/commands/convert_percent_format_to_fstring.py`. [#301] (https://github.com/Instagram/LibCST/pull/301)
+ - Fixed `StopIteration` exception during scope analysis matching on import names. [#302](https://github.com/Instagram/LibCST/pull/302)
 
 # 0.3.5 - 2020-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.3.6 - 2020-05-27
+
+## Added
+- Added `ConvertNamedTupleToDataclassCommand` to convert `NamedTuple` class declarations to Python 3.7 `dataclasses` using the `@dataclass(frozen=True)` decorator. [#299](https://github.com/Instagram/LibCST/pull/299)
+
 # 0.3.5 - 2020-05-12
 
 ## Updated
@@ -32,7 +37,7 @@
 # 0.3.3 - 2020-03-05
 
 ## Added
- - `ByteSpanPositionProvider` provides start offset and length of CSTNode as metadata. 
+ - `ByteSpanPositionProvider` provides start offset and length of CSTNode as metadata.
  - `get_docstring` helper provides docstring from `Module`, `ClassDef` and `FunctionDef` node types.
 
 ## Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
  - Added `ConvertNamedTupleToDataclassCommand` to convert `NamedTuple` class declarations to Python 3.7 `dataclasses` using the `@dataclass(frozen=True)` decorator. [#299](https://github.com/Instagram/LibCST/pull/299)
 
 ## Fixed
- - Fixed typo in file name `libcst/codemod/commands/convert_percent_format_to_fstring.py`. [#301] (https://github.com/Instagram/LibCST/pull/301)
+ - Fixed typo in file name `libcst/codemod/commands/convert_percent_format_to_fstring.py`. [#301](https://github.com/Instagram/LibCST/pull/301)
  - Fixed `StopIteration` exception during scope analysis matching on import names. [#302](https://github.com/Instagram/LibCST/pull/302)
 
 # 0.3.5 - 2020-05-12

--- a/libcst/_version.py
+++ b/libcst/_version.py
@@ -4,4 +4,4 @@
 # LICENSE file in the root directory of this source tree.
 
 
-LIBCST_VERSION: str = "0.3.5"
+LIBCST_VERSION: str = "0.3.6"


### PR DESCRIPTION
## Summary
Bump to new version for `ConvertNamedTupleToDataclassCommand` codemod command

