### PR TITLE
Fix stderr being plugged into codemod-ed file

### DIFF
--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -58,7 +58,6 @@ def invoke_formatter(formatter_args: Sequence[str], code: AnyStr) -> AnyStr:
             formatter_args,
             env={},
             input=code,
-            stderr=subprocess.STDOUT,
             universal_newlines=not work_with_bytes,
             encoding=None if work_with_bytes else "utf-8",
         ),


### PR DESCRIPTION
## Summary
- When running a codemod on a file, the output success message of `black` ended up embedded in the file itself. See image below:
![image](https://user-images.githubusercontent.com/22413721/84198930-4e9b0f80-aa72-11ea-88c2-dd6c91ed6eb2.png)

- Tried to set the `-q` flag [here](https://github.com/Instagram/LibCST/blob/master/libcst/tool.py#L295) to quiet the output but that ended up completely erasing the test file
- Removing the line of code in `libcst/codemod/_cli.py` did the trick. The file still gets reformatted and the `black` output message still ends up in the terminal. See image below:
![image](https://user-images.githubusercontent.com/22413721/84199222-c5d0a380-aa72-11ea-8fde-c9647b8685bc.png)


## Test Plan
- Tested a test file `z.py` with various existing codemod commands
- Tested with `--no-format` flag to ensure that when it's on, `black` is not called at all
