### PR TITLE
Added maxsplit value in QualifiedName retrieval

### DIFF
--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -248,7 +248,7 @@ class _NameUtil:
                         if eval_alias is not None:
                             as_name = eval_alias
                     if full_name.startswith(as_name):
-                        remaining_name = full_name.split(as_name)[1].lstrip(".")
+                        remaining_name = full_name.split(as_name, 1)[1].lstrip(".")
                         results.add(
                             QualifiedName(
                                 f"{real_name}.{remaining_name}"


### PR DESCRIPTION
## Summary
When working on another branch, noticed:
```
import a

foo = a.bar
```
The qualified name of `a.bar` would get returned as `QualifiedName(name="a.b",...)`

## Test Plan
- All tests still pass`tox`
- Check QualifiedName for `a.bar` is returned as "a.bar"

