### PR TITLE
ApplyTypeAnnotationsVisitor: fix default value

### DIFF
--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -398,7 +398,10 @@ class ApplyTypeAnnotationsVisitor(ContextAwareTransformer):
         return annotations.parameters.with_changes(
             params=update_annotation(
                 updated_node.params.params, annotations.parameters.params
-            )
+            ),
+            kwonly_params=update_annotation(
+                updated_node.params.kwonly_params, annotations.parameters.kwonly_params
+            ),
         )
 
     def _insert_empty_line(

--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -402,6 +402,10 @@ class ApplyTypeAnnotationsVisitor(ContextAwareTransformer):
             kwonly_params=update_annotation(
                 updated_node.params.kwonly_params, annotations.parameters.kwonly_params
             ),
+            posonly_params=update_annotation(
+                updated_node.params.posonly_params,
+                annotations.parameters.posonly_params,
+            ),
         )
 
     def _insert_empty_line(

--- a/libcst/codemod/visitors/tests/test_apply_type_annotations.py
+++ b/libcst/codemod/visitors/tests/test_apply_type_annotations.py
@@ -4,7 +4,9 @@
 # LICENSE file in the root directory of this source tree.
 #
 
+import sys
 import textwrap
+import unittest
 from typing import Type
 
 from libcst import parse_module
@@ -625,6 +627,56 @@ class TestApplyAnnotationsVisitor(CodemodTest):
         )
     )
     def test_annotate_functions(self, stub: str, before: str, after: str) -> None:
+        context = CodemodContext()
+        ApplyTypeAnnotationsVisitor.store_stub_in_context(
+            context, parse_module(textwrap.dedent(stub.rstrip()))
+        )
+        self.assertCodemod(before, after, context_override=context)
+
+    @data_provider(
+        (
+            (
+                """
+                def foo(
+                    a: int, /, b: str, c: int = ..., *, d: str = ..., e: int, f: int = ...
+                ) -> int: ...
+                """,
+                """
+                def foo(
+                    a, /, b, c=5, *, d="a", e, f=10
+                ) -> int:
+                    return 1
+                """,
+                """
+                def foo(
+                    a: int, /, b: str, c: int=5, *, d: str="a", e: int, f: int=10
+                ) -> int:
+                    return 1
+                """,
+            ),
+            (
+                """
+                def foo(
+                    a: int, b: int = ..., /, c: int = ..., *, d: str = ..., e: int, f: int = ...
+                ) -> int: ...
+                """,
+                """
+                def foo(
+                    a, b = 5, /, c = 10, *, d = "a", e, f = 20
+                ) -> int:
+                    return 1
+                """,
+                """
+                def foo(
+                    a: int, b: int = 5, /, c: int = 10, *, d: str = "a", e: int, f: int = 20
+                ) -> int:
+                    return 1
+                """,
+            ),
+        )
+    )
+    @unittest.skipIf(sys.version_info < (3, 8), "Unsupported Python version")
+    def test_annotate_functions_py38(self, stub: str, before: str, after: str) -> None:
         context = CodemodContext()
         ApplyTypeAnnotationsVisitor.store_stub_in_context(
             context, parse_module(textwrap.dedent(stub.rstrip()))

--- a/libcst/codemod/visitors/tests/test_apply_type_annotations.py
+++ b/libcst/codemod/visitors/tests/test_apply_type_annotations.py
@@ -33,6 +33,25 @@ class TestApplyAnnotationsVisitor(CodemodTest):
             ),
             (
                 """
+                def foo(
+                    b: str, c: int = ..., *, d: str = ..., e: int, f: int = ...
+                ) -> int: ...
+                """,
+                """
+                def foo(
+                    b, c=5, *, d="a", e, f=10
+                ) -> int:
+                    return 1
+                """,
+                """
+                def foo(
+                    b: str, c: int=5, *, d: str="a", e: int, f: int=10
+                ) -> int:
+                    return 1
+                """,
+            ),
+            (
+                """
                 import bar
 
                 def foo() -> bar.Baz: ...


### PR DESCRIPTION
## Summary

ApplyTypeAnnotationsVisitor erases default values of positional-only and keyword-only args. See https://github.com/Instagram/MonkeyType/issues/198 for a repro

## Test Plan

Added tests for the relevant issues in test_apply_type_annotations.py