### PR TITLE
[ExpressionContextProvider] Make subscript values have a LOAD context

### DIFF
--- a/libcst/codemod/commands/tests/test_remove_unused_imports.py
+++ b/libcst/codemod/commands/tests/test_remove_unused_imports.py
@@ -76,3 +76,10 @@ class RemoveUnusedImportsCommandTest(CodemodTest):
         """
 
         self.assertCodemod(before, after)
+
+    def test_access_in_assignment(self) -> None:
+        before = """
+            from a import b
+            b(0)[x] = False
+        """
+        self.assertCodemod(before, before)

--- a/libcst/metadata/expression_context_provider.py
+++ b/libcst/metadata/expression_context_provider.py
@@ -133,7 +133,9 @@ class ExpressionContextVisitor(cst.CSTVisitor):
 
     def visit_Subscript(self, node: cst.Subscript) -> bool:
         self.provider.set_metadata(node, self.context)
-        node.value.visit(self)
+        node.value.visit(
+            ExpressionContextVisitor(self.provider, ExpressionContext.LOAD)
+        )
         slice = node.slice
         if isinstance(slice, Sequence):
             for sli in slice:


### PR DESCRIPTION
Fixes #318.

## Summary

This brings LibCST in line with the built in ast module.

## Test Plan

Changed/added tests + manually verified the following file is not touched by the remove unused imports codemod:
```
from a import b
b[0] = False
```

```
python -m libcst.tool codemod remove_unused_imports.RemoveUnusedImportsCommand test.py -u
```

