### PR TITLE
Optional args for tox commands

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,32 +6,32 @@ deps =
     -rrequirements.txt
     -rrequirements-dev.txt
 commands =
-    python -m unittest
+    python -m unittest {posargs}
 
 [testenv:lint]
 deps =
     -rrequirements.txt
     -rrequirements-dev.txt
 commands =
-    flake8
-    isort --check-only
-    black --check libcst/
+    flake8 {posargs}
+    isort --check-only -rc {posargs:.}
+    black --check {posargs:libcst/}
 
 [testenv:docs]
-deps = 
+deps =
     -rrequirements.txt
     -rrequirements-dev.txt
 commands =
-    sphinx-build docs/source/ docs/build/
+    sphinx-build {posargs:docs/source/ docs/build/}
 
 [testenv:autofix]
 deps =
     -rrequirements.txt
     -rrequirements-dev.txt
 commands =
-    flake8
-    isort -y -q
-    black libcst/
+    flake8 {posargs}
+    isort -y -q -rc {posargs:.}
+    black {posargs:libcst/}
 
 [testenv:coverage]
 deps =


### PR DESCRIPTION
## Summary
To provide a developer with the ability to run `tox` commands on specific directories or files during local development. 

## Test Plan
### `tox -e lint`:
- run on a directory:
```
tox -e lint libcst/tests
```
- run on a file:
```
tox -e lint libcst/_typed_visitor_base.py
```
- run with no args:
(make sure all 246 files checked)
```
tox -e lint
```

### `tox -e autofix`:
- run on a directory:
```
tox -e autofix libcst/tests
```
- run on a file:
```
tox -e autofix libcst/_typed_visitor_base.py
```
- run with no args:
(make sure all 246 files checked)
```
tox -e autofix
```

### `tox -e py<version>` for unittests:
- run specific test case:
```
tox -e py<version> libcst.tests.test_batched_visitor
```
- run with no args:
(make sure all 1727 tests run)
```
tox -e py<version>
```