### PR TITLE
FullRepoManager `cache` property

### DIFF
--- a/libcst/metadata/full_repo_manager.py
+++ b/libcst/metadata/full_repo_manager.py
@@ -40,6 +40,16 @@ class FullRepoManager:
         self._providers = providers
         self._paths: List[str] = list(paths)
 
+    @property
+    def cache(self) -> Dict["ProviderT", Mapping[str, object]]:
+        """
+        The full repository cache data for all metadata providers passed in the ``providers`` parameter when
+        constructing :class:`~libcst.metadata.FullRepoManager`. Each provider is mapped to a mapping of path to cache.
+        """
+        # Make sure that the cache is available to us. If resolve_cache() was called manually then this is a noop.
+        self.resolve_cache()
+        return self._cache
+
     def resolve_cache(self) -> None:
         """
         Resolve cache for all providers that require it. Normally this is called by
@@ -81,27 +91,6 @@ class FullRepoManager:
             for _path, data in files.items()
             if _path == path
         }
-
-    def get_cache_for_provider(self, provider: "ProviderT") -> Mapping[str, object]:
-        """
-        Retrieve cache from a provider for all source files. The provider needs to appear in the ```providers```
-        parameters when constructing :class`~libcst.metadata.FullRepoManager`.
-
-        Returns a mapping of source file path to cache for source file.
-
-        .. code-block:: python
-
-            manager = FullRepoManager(".", {"a.py", "b.py"}, {TypeInferenceProvider})
-            type_inference_cache = manager.get_cache_for_provider(TypeInferenceProvider)
-        """
-        if provider not in self._providers:
-            raise Exception(
-                "The provider needs to be in the providers parameter when constructing FullRepoManager."
-            )
-        # Make sure that the cache is available to us. If the user called
-        # resolve_cache() manually then this is a noop.
-        self.resolve_cache()
-        return self._cache[provider]
 
     def get_metadata_wrapper_for_path(self, path: str) -> MetadataWrapper:
         """

--- a/libcst/metadata/full_repo_manager.py
+++ b/libcst/metadata/full_repo_manager.py
@@ -82,6 +82,27 @@ class FullRepoManager:
             if _path == path
         }
 
+    def get_cache_for_provider(self, provider: "ProviderT") -> Mapping[str, object]:
+        """
+        Retrieve cache from a provider for all source files. The provider needs to appear in the ```providers```
+        parameters when constructing :class`~libcst.metadata.FullRepoManager`.
+
+        Returns a mapping of source file path to cache for source file.
+
+        .. code-block:: python
+
+            manager = FullRepoManager(".", {"a.py", "b.py"}, {TypeInferenceProvider})
+            type_inference_cache = manager.get_cache_for_provider(TypeInferenceProvider)
+        """
+        if provider not in self._providers:
+            raise Exception(
+                "The provider needs to be in the providers parameter when constructing FullRepoManager."
+            )
+        # Make sure that the cache is available to us. If the user called
+        # resolve_cache() manually then this is a noop.
+        self.resolve_cache()
+        return self._cache[provider]
+
     def get_metadata_wrapper_for_path(self, path: str) -> MetadataWrapper:
         """
         Create a :class:`~libcst.metadata.MetadataWrapper` given a source file path.

--- a/libcst/metadata/tests/test_full_repo_manager.py
+++ b/libcst/metadata/tests/test_full_repo_manager.py
@@ -48,3 +48,15 @@ class FullRepoManagerTest(UnitTest):
             "The path needs to be in paths parameter when constructing FullRepoManager for efficient batch processing.",
         ):
             manager.get_metadata_wrapper_for_path(path)
+
+    @patch.object(TypeInferenceProvider, "gen_cache")
+    def test_get_cache_for_provider(self, gen_cache: Mock) -> None:
+        path_prefix = "tests/pyre/simple_class"
+        path = f"{path_prefix}.py"
+        mock_cache = {
+            path: json.loads((Path(REPO_ROOT_DIR) / f"{path_prefix}.json").read_text())
+        }
+        gen_cache.return_value = mock_cache
+        manager = FullRepoManager(REPO_ROOT_DIR, path, [TypeInferenceProvider])
+        type_inference_cache = manager.get_cache_for_provider(TypeInferenceProvider)
+        self.assertEqual(type_inference_cache, mock_cache)

--- a/libcst/metadata/tests/test_full_repo_manager.py
+++ b/libcst/metadata/tests/test_full_repo_manager.py
@@ -50,7 +50,7 @@ class FullRepoManagerTest(UnitTest):
             manager.get_metadata_wrapper_for_path(path)
 
     @patch.object(TypeInferenceProvider, "gen_cache")
-    def test_get_cache_for_provider(self, gen_cache: Mock) -> None:
+    def test_get_full_repo_cache(self, gen_cache: Mock) -> None:
         path_prefix = "tests/pyre/simple_class"
         path = f"{path_prefix}.py"
         mock_cache = {
@@ -58,5 +58,5 @@ class FullRepoManagerTest(UnitTest):
         }
         gen_cache.return_value = mock_cache
         manager = FullRepoManager(REPO_ROOT_DIR, path, [TypeInferenceProvider])
-        type_inference_cache = manager.get_cache_for_provider(TypeInferenceProvider)
-        self.assertEqual(type_inference_cache, mock_cache)
+        cache = manager.cache
+        self.assertEqual(cache, {TypeInferenceProvider: mock_cache})


### PR DESCRIPTION
## Summary
A need for the ability to fetch cache for all paths at once became evident in a use case requiring some optimizations.
The ability to access the private `_cache` property of `FullRepoManager` would be useful in a case like this.

## Test Plan
- Test case in `test_full_repo_manager`
- All tests pass
