### PR TITLE
[Pyre] Handle type subscripts when applying annotations.

### DIFF
--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -134,10 +134,7 @@ class TypeCollector(cst.CSTVisitor):
 
     def _handle_Subscript(self, node: cst.Subscript) -> cst.Subscript:
         slice = node.slice
-        if (
-            m.matches(node.value, m.Name())
-            and cst.ensure_type(node.value, cst.Name).value == "Type"
-        ):
+        if m.matches(node.value, m.Name(value="Type")):
             return node
         if isinstance(slice, list):
             new_slice = []
@@ -169,7 +166,7 @@ class TypeCollector(cst.CSTVisitor):
             return cst.Annotation(annotation=attr)
         if isinstance(annotation, cst.Subscript):
             value = annotation.value
-            if isinstance(value, cst.Name) and value.value == "Type":
+            if m.matches(value, m.Name(value="Type")):
                 return returns
             return cst.Annotation(annotation=self._handle_Subscript(annotation))
         else:

--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -8,12 +8,13 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import libcst as cst
+from libcst import matchers as m
 from libcst.codemod._context import CodemodContext
 from libcst.codemod._visitor import ContextAwareTransformer
 from libcst.codemod.visitors._add_imports import AddImportsVisitor
 from libcst.codemod.visitors._gather_imports import GatherImportsVisitor
 from libcst.helpers import get_full_name_for_node
-from libcst import matchers as m
+
 
 def _get_import_alias_names(import_aliases: Sequence[cst.ImportAlias]) -> Set[str]:
     import_names = set()
@@ -107,7 +108,6 @@ class TypeCollector(cst.CSTVisitor):
                     self.context, module_name, import_name
                 )
 
-
     def _add_annotation_to_imports(
         self, annotation: cst.Attribute
     ) -> Union[cst.Name, cst.Attribute]:
@@ -134,7 +134,10 @@ class TypeCollector(cst.CSTVisitor):
 
     def _handle_Subscript(self, node: cst.Subscript) -> cst.Subscript:
         slice = node.slice
-        if m.matches(node.value, m.Name()) and cst.ensure_type(node.value, cst.Name).value == 'Type':
+        if (
+            m.matches(node.value, m.Name())
+            and cst.ensure_type(node.value, cst.Name).value == "Type"
+        ):
             return node
         if isinstance(slice, list):
             new_slice = []

--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -13,7 +13,7 @@ from libcst.codemod._visitor import ContextAwareTransformer
 from libcst.codemod.visitors._add_imports import AddImportsVisitor
 from libcst.codemod.visitors._gather_imports import GatherImportsVisitor
 from libcst.helpers import get_full_name_for_node
-
+from libcst import matchers as m
 
 def _get_import_alias_names(import_aliases: Sequence[cst.ImportAlias]) -> Set[str]:
     import_names = set()
@@ -107,6 +107,7 @@ class TypeCollector(cst.CSTVisitor):
                     self.context, module_name, import_name
                 )
 
+
     def _add_annotation_to_imports(
         self, annotation: cst.Attribute
     ) -> Union[cst.Name, cst.Attribute]:
@@ -133,6 +134,8 @@ class TypeCollector(cst.CSTVisitor):
 
     def _handle_Subscript(self, node: cst.Subscript) -> cst.Subscript:
         slice = node.slice
+        if m.matches(node.value, m.Name()) and cst.ensure_type(node.value, cst.Name).value == 'Type':
+            return node
         if isinstance(slice, list):
             new_slice = []
             for item in slice:

--- a/libcst/codemod/visitors/tests/test_apply_type_annotations.py
+++ b/libcst/codemod/visitors/tests/test_apply_type_annotations.py
@@ -650,8 +650,7 @@ class TestApplyAnnotationsVisitor(CodemodTest):
 
                 example: Dict[str, Type[foo.Example]] = { "test": foo() }
                 """,
-            )
-
+            ),
         )
     )
     def test_annotate_functions(self, stub: str, before: str, after: str) -> None:

--- a/libcst/codemod/visitors/tests/test_apply_type_annotations.py
+++ b/libcst/codemod/visitors/tests/test_apply_type_annotations.py
@@ -624,6 +624,34 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                   return []
                 """,
             ),
+            (
+                """
+                from typing import Dict
+
+                example: Dict[str, Type[foo.Example]] = ...
+                """,
+                """
+                from typing import Type
+
+                def foo() -> Type[foo.Example]:
+                    class Example:
+                        pass
+                    return Example
+
+                example = { "test": foo() }
+                """,
+                """
+                from typing import Dict, Type
+
+                def foo() -> Type[foo.Example]:
+                    class Example:
+                        pass
+                    return Example
+
+                example: Dict[str, Type[foo.Example]] = { "test": foo() }
+                """,
+            )
+
         )
     )
     def test_annotate_functions(self, stub: str, before: str, after: str) -> None:


### PR DESCRIPTION
## Summary
Just as we special case "Type" when applying annotations here: https://github.com/Instagram/LibCST/blob/master/libcst/codemod/visitors/_apply_type_annotations.py#L166
We need to do the same in Subscripts

## Test Plan

python -m unittest -v libcst.codemod.visitors.tests.test_apply_type_annotations