### PR TITLE
fix: allow ParenthesizedWhitespace before params in FuncDef

### DIFF
--- a/libcst/_nodes/statement.py
+++ b/libcst/_nodes/statement.py
@@ -1561,7 +1561,7 @@ class FunctionDef(BaseCompoundStatement):
 
     #: Whitespace after the opening parenthesis for the parameters but before
     #: the first param itself.
-    whitespace_before_params: SimpleWhitespace = SimpleWhitespace.field("")
+    whitespace_before_params: BaseParenthesizableWhitespace = SimpleWhitespace.field("")
 
     #: Whitespace after the closing parenthesis or return annotation and before
     #: the colon.

--- a/libcst/_nodes/tests/test_funcdef.py
+++ b/libcst/_nodes/tests/test_funcdef.py
@@ -665,6 +665,22 @@ class FunctionDefCreationTest(CSTNodeTest):
                 "code": "* third",
                 "expected_position": CodeRange((1, 0), (1, 7)),
             },
+            {
+                "node": cst.FunctionDef(
+                    name=cst.Name(value="foo",),
+                    params=cst.Parameters(
+                        params=[cst.Param(name=cst.Name(value="param1",),),],
+                    ),
+                    body=cst.IndentedBlock(
+                        body=[cst.SimpleStatementLine(body=[cst.Pass(),],),],
+                    ),
+                    whitespace_before_params=cst.ParenthesizedWhitespace(
+                        last_line=cst.SimpleWhitespace(value="    ",),
+                    ),
+                ),
+                "code": "def foo(\n    param1):\n    pass\n",
+                "expected_position": CodeRange((1, 0), (3, 8)),
+            },
         )
     )
     def test_valid(self, **kwargs: Any) -> None:

--- a/libcst/matchers/__init__.py
+++ b/libcst/matchers/__init__.py
@@ -5799,10 +5799,10 @@ class FunctionDef(BaseCompoundStatement, BaseStatement, BaseMatcherNode):
         AllOf[SimpleWhitespaceMatchType],
     ] = DoNotCare()
     whitespace_before_params: Union[
-        SimpleWhitespaceMatchType,
+        BaseParenthesizableWhitespaceMatchType,
         DoNotCareSentinel,
-        OneOf[SimpleWhitespaceMatchType],
-        AllOf[SimpleWhitespaceMatchType],
+        OneOf[BaseParenthesizableWhitespaceMatchType],
+        AllOf[BaseParenthesizableWhitespaceMatchType],
     ] = DoNotCare()
     whitespace_before_colon: Union[
         SimpleWhitespaceMatchType,


### PR DESCRIPTION
## Summary
Fixes #303

## Test Plan
Unit Tests
