### PR TITLE
Insert imports after module docstring

### DIFF
--- a/libcst/codemod/visitors/tests/test_add_imports.py
+++ b/libcst/codemod/visitors/tests/test_add_imports.py
@@ -637,3 +637,24 @@ class TestAddImportsCodemod(CodemodTest):
             [("a", "f", None), ("a", "g", "y"), ("a", "c", None), ("a", "d", "x")],
             context_override=CodemodContext(full_module_name="a.b.foobar"),
         )
+
+    def test_import_in_docstring_module(self) -> None:
+        """
+        The import should be added after module docstring.
+        """
+        before = """
+            '''Docstring.'''
+            import typing
+        """
+        after = """
+            '''Docstring.'''
+            from __future__ import annotations
+            import typing
+        """
+
+        self.assertCodemod(
+            before,
+            after,
+            [("__future__", "annotations", None)],
+            context_override=CodemodContext(full_module_name="a.b.foobar"),
+        )


### PR DESCRIPTION
## Summary
Module docstring was reordered wrongly.

```
'''Docstring.'''
import typing
```

Became

```
from __future__ import annotations
'''Docstring.'''
import typing
```

Instead of
```
'''Docstring.'''
from __future__ import annotations
import typing
```

## Test Plan
Added a test case.
