### PR TITLE
[scope] add scope for ImportAlias

### DIFF
--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -659,6 +659,7 @@ class ScopeVisitor(cst.CSTVisitor):
 
         # make sure node.names is Sequence[ImportAlias]
         for name in names:
+            self.provider.set_metadata(name, self.scope)
             asname = name.asname
             if asname is not None:
                 name_values = _gen_dotted_names(cst.ensure_type(asname.name, cst.Name))

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -140,6 +140,16 @@ class ScopeProviderTest(UnitTest):
             """
         )
         scope_of_module = scopes[m]
+
+        import_0 = cst.ensure_type(
+            cst.ensure_type(m.body[0], cst.SimpleStatementLine).body[0], cst.Import
+        )
+        self.assertEqual(scopes[import_0], scope_of_module)
+        import_aliases = import_0.names
+        if not isinstance(import_aliases, cst.ImportStar):
+            for alias in import_aliases:
+                self.assertEqual(scopes[alias], scope_of_module)
+
         for idx, in_scopes in enumerate(
             [["foo", "foo.bar"], ["fizzbuzz"], ["a", "a.b", "a.b.c"], ["g"],]
         ):
@@ -202,6 +212,16 @@ class ScopeProviderTest(UnitTest):
             """
         )
         scope_of_module = scopes[m]
+
+        import_from = cst.ensure_type(
+            cst.ensure_type(m.body[0], cst.SimpleStatementLine).body[0], cst.ImportFrom
+        )
+        self.assertEqual(scopes[import_from], scope_of_module)
+        import_aliases = import_from.names
+        if not isinstance(import_aliases, cst.ImportStar):
+            for alias in import_aliases:
+                self.assertEqual(scopes[alias], scope_of_module)
+
         for idx, in_scope in [(0, "a"), (0, "b_renamed"), (1, "c"), (2, "d")]:
             self.assertEqual(
                 len(scope_of_module[in_scope]), 1, f"{in_scope} should be in scope."


### PR DESCRIPTION
## Summary
Add scope for ImportAlias.
Import node and ImportFrom node already have scope object associated. Also add test cases for them.

## Test Plan
Updated unit test.