### PR TITLE
[RemoveUnusedImports] Support string type annotations

### DIFF
--- a/docs/source/codemods.rst
+++ b/docs/source/codemods.rst
@@ -146,12 +146,18 @@ LibCST additionally includes a library of transforms to reduce the need for boil
 inside codemods. As of now, the list includes the following helpers.
 
 .. autoclass:: libcst.codemod.visitors.GatherImportsVisitor
-  :exclude-members: visit_Import, visit_ImportFrom
+  :no-undoc-members:
 .. autoclass:: libcst.codemod.visitors.GatherExportsVisitor
-  :exclude-members: visit_AnnAssign, leave_AnnAssign, visit_Assign, leave_Assign, visit_List, leave_List, visit_Tuple, leave_Tuple, visit_Set, leave_Set, visit_Element
+  :no-undoc-members:
 .. autoclass:: libcst.codemod.visitors.AddImportsVisitor
-  :exclude-members: CONTEXT_KEY, visit_Module, leave_ImportFrom, leave_Module
+  :no-undoc-members:
 .. autoclass:: libcst.codemod.visitors.RemoveImportsVisitor
-  :exclude-members: CONTEXT_KEY, METADATA_DEPENDENCIES, visit_Module, leave_ImportFrom, leave_Import
+  :no-undoc-members:
 .. autoclass:: libcst.codemod.visitors.ApplyTypeAnnotationsVisitor
-  :exclude-members: CONTEXT_KEY, transform_module_impl, visit_ClassDef, visit_Comment, visit_FunctionDef, leave_Assign, leave_ClassDef, leave_FunctionDef, leave_ImportFrom, leave_Module
+  :no-undoc-members:
+.. autoclass:: libcst.codemod.visitors.GatherUnusedImportsVisitor
+  :no-undoc-members:
+.. autoclass:: libcst.codemod.visitors.GatherCommentsVisitor
+  :no-undoc-members:
+.. autoclass:: libcst.codemod.visitors.GatherNamesFromStringAnnotationsVisitor
+  :no-undoc-members:

--- a/libcst/codemod/commands/remove_unused_imports.py
+++ b/libcst/codemod/commands/remove_unused_imports.py
@@ -33,10 +33,7 @@ class RemoveUnusedImportsCommand(VisitorBasedCodemodCommand):
         "Note: only considers the file in isolation. "
     )
 
-    METADATA_DEPENDENCIES: Tuple[ProviderT] = (
-        PositionProvider,
-        *GatherCommentsVisitor.METADATA_DEPENDENCIES,
-    )
+    METADATA_DEPENDENCIES: Tuple[ProviderT] = (PositionProvider,)
 
     def __init__(self, context: CodemodContext) -> None:
         super().__init__(context)

--- a/libcst/codemod/commands/remove_unused_imports.py
+++ b/libcst/codemod/commands/remove_unused_imports.py
@@ -4,12 +4,14 @@
 # LICENSE file in the root directory of this source tree.
 #
 
+from typing import Union
+
 from libcst import Import, ImportFrom, Module
 from libcst.codemod import VisitorBasedCodemodCommand
-from libcst.codemod.visitors import RemoveImportsVisitor, GatherCommentsVisitor
+from libcst.codemod.visitors import GatherCommentsVisitor, RemoveImportsVisitor
 from libcst.helpers import get_absolute_module_for_import
 from libcst.metadata import PositionProvider
-from typing import Union
+
 
 DEFAULT_SUPPRESS_COMMENT_REGEX = (
     r".*\W(noqa|lint-ignore: ?unused-import|lint-ignore: ?F401)(\W.*)?$"

--- a/libcst/codemod/commands/remove_unused_imports.py
+++ b/libcst/codemod/commands/remove_unused_imports.py
@@ -4,9 +4,16 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-from libcst import Import, ImportFrom
+from libcst import Import, ImportFrom, Module
 from libcst.codemod import VisitorBasedCodemodCommand
-from libcst.codemod.visitors import RemoveImportsVisitor
+from libcst.codemod.visitors import RemoveImportsVisitor, GatherCommentsVisitor
+from libcst.helpers import get_absolute_module_for_import
+from libcst.metadata import PositionProvider
+from typing import Union
+
+DEFAULT_SUPPRESS_COMMENT_REGEX = (
+    r".*\W(noqa|lint-ignore: ?unused-import|lint-ignore: ?F401)(\W.*)?$"
+)
 
 
 class RemoveUnusedImportsCommand(VisitorBasedCodemodCommand):
@@ -17,21 +24,60 @@ class RemoveUnusedImportsCommand(VisitorBasedCodemodCommand):
     to track cross-references between them. If a symbol is imported in a file
     but otherwise unused in it, that import will be removed even if it is being
     referenced from another file.
-
-    It currently doesn't keep track of string type annotations, so an import
-    for `MyType` used only in `def f() -> "MyType"` will be removed.
     """
 
     DESCRIPTION: str = (
         "Remove all imports that are not used in a file. "
         "Note: only considers the file in isolation. "
-        "Note: does not account for usages in string type annotations. "
     )
 
+    METADATA_DEPENDENCIES = (
+        PositionProvider,
+        *GatherCommentsVisitor.METADATA_DEPENDENCIES,
+    )
+
+    def visit_Module(self, node: Module) -> bool:
+        comment_visitor = GatherCommentsVisitor(
+            self.context, DEFAULT_SUPPRESS_COMMENT_REGEX
+        )
+        node.visit(comment_visitor)
+        self._ignored_lines = set(comment_visitor.comments.keys())
+        return True
+
     def visit_Import(self, node: Import) -> bool:
-        RemoveImportsVisitor.remove_unused_import_by_node(self.context, node)
+        self._handle_import(node)
         return False
 
     def visit_ImportFrom(self, node: ImportFrom) -> bool:
-        RemoveImportsVisitor.remove_unused_import_by_node(self.context, node)
+        self._handle_import(node)
         return False
+
+    def _handle_import(self, node: Union[Import, ImportFrom]) -> None:
+        node_start = self.get_metadata(PositionProvider, node).start.line
+        if node_start in self._ignored_lines:
+            return
+
+        for alias in node.names:
+            position = self.get_metadata(PositionProvider, alias)
+            lines = set(range(position.start.line, position.end.line + 1))
+            if lines.isdisjoint(self._ignored_lines):
+                if isinstance(node, Import):
+                    RemoveImportsVisitor.remove_unused_import(
+                        self.context,
+                        module=alias.evaluated_name,
+                        asname=alias.evaluated_alias,
+                    )
+                else:
+                    module_name = get_absolute_module_for_import(
+                        self.context.full_module_name, node
+                    )
+                    if module_name is None:
+                        raise ValueError(
+                            f"Couldn't get absolute module name for {alias.evaluated_name}"
+                        )
+                    RemoveImportsVisitor.remove_unused_import(
+                        self.context,
+                        module=module_name,
+                        obj=alias.evaluated_name,
+                        asname=alias.evaluated_alias,
+                    )

--- a/libcst/codemod/commands/tests/test_remove_unused_imports.py
+++ b/libcst/codemod/commands/tests/test_remove_unused_imports.py
@@ -90,3 +90,33 @@ class RemoveUnusedImportsCommandTest(CodemodTest):
             a(b, 'look at these ugly quotes')
         """
         self.assertCodemod(before, before)
+
+    def test_suppression_on_first_line_of_multiline_import_refers_to_whole_block(
+        self,
+    ) -> None:
+        before = """
+            from a import (  # lint-ignore: unused-import
+                b,
+                c,
+            )
+        """
+        self.assertCodemod(before, before)
+
+    def test_suppression(self) -> None:
+        before = """
+            # noqa
+            import a, b
+            import c
+            from x import (
+                y,
+                z,  # noqa
+            )
+        """
+        after = """
+            # noqa
+            import a, b
+            from x import (
+                z,  # noqa
+            )
+        """
+        self.assertCodemod(before, after)

--- a/libcst/codemod/tests/codemod_formatter_error_input.py.txt
+++ b/libcst/codemod/tests/codemod_formatter_error_input.py.txt
@@ -5,7 +5,7 @@
 #
 # pyre-strict
 
-import subprocess  # noqa: F401
+import subprocess
 from contextlib import AsyncExitStack
 
 

--- a/libcst/codemod/visitors/__init__.py
+++ b/libcst/codemod/visitors/__init__.py
@@ -5,15 +5,23 @@
 #
 from libcst.codemod.visitors._add_imports import AddImportsVisitor
 from libcst.codemod.visitors._apply_type_annotations import ApplyTypeAnnotationsVisitor
+from libcst.codemod.visitors._gather_comments import GatherCommentsVisitor
 from libcst.codemod.visitors._gather_exports import GatherExportsVisitor
 from libcst.codemod.visitors._gather_imports import GatherImportsVisitor
+from libcst.codemod.visitors._gather_string_annotation_names import (
+    GatherNamesFromStringAnnotationsVisitor,
+)
+from libcst.codemod.visitors._gather_unused_imports import GatherUnusedImportsVisitor
 from libcst.codemod.visitors._remove_imports import RemoveImportsVisitor
 
 
 __all__ = [
     "AddImportsVisitor",
-    "GatherImportsVisitor",
-    "GatherExportsVisitor",
     "ApplyTypeAnnotationsVisitor",
+    "GatherCommentsVisitor",
+    "GatherExportsVisitor",
+    "GatherImportsVisitor",
+    "GatherNamesFromStringAnnotationsVisitor",
+    "GatherUnusedImportsVisitor",
     "RemoveImportsVisitor",
 ]

--- a/libcst/codemod/visitors/_gather_comments.py
+++ b/libcst/codemod/visitors/_gather_comments.py
@@ -14,11 +14,25 @@ from libcst.metadata import PositionProvider
 
 
 class GatherCommentsVisitor(ContextAwareVisitor):
+    """
+    Collects all comments matching a certain regex and their line numbers.
+    This visitor is useful for capturing special-purpose comments, for example
+    ``noqa`` style lint suppression annotations.
+
+    Standalone comments are assumed to affect the line following them, and
+    inline ones are recorded with the line they are on.
+
+    After visiting a CST, matching comments are collected in the ``comments``
+    attribute.
+    """
+
     METADATA_DEPENDENCIES = (PositionProvider,)
 
     def __init__(self, context: CodemodContext, comment_regex: str) -> None:
         super().__init__(context)
 
+        #: Dictionary of comments found in the CST. Keys are line numbers,
+        #: values are comment nodes.
         self.comments: Dict[int, cst.Comment] = {}
 
         self._comment_matcher: Pattern[str] = re.compile(comment_regex)

--- a/libcst/codemod/visitors/_gather_comments.py
+++ b/libcst/codemod/visitors/_gather_comments.py
@@ -1,0 +1,36 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import re
+from typing import Dict, Union
+
+import libcst as cst
+import libcst.matchers as m
+from libcst.codemod._context import CodemodContext
+from libcst.codemod._visitor import ContextAwareVisitor
+from libcst.metadata import PositionProvider
+
+
+class GatherCommentsVisitor(ContextAwareVisitor):
+    METADATA_DEPENDENCIES = (PositionProvider,)
+
+    def __init__(self, context: CodemodContext, comment_regex: str) -> None:
+        super().__init__(context)
+
+        self.comments: Dict[int, cst.Comment] = {}
+
+        self._comment_matcher = re.compile(comment_regex)
+
+    @m.visit(m.EmptyLine(comment=m.DoesNotMatch(None)))
+    @m.visit(m.TrailingWhitespace(comment=m.DoesNotMatch(None)))
+    def visit_comment(self, node: Union[cst.EmptyLine, cst.TrailingWhitespace]) -> None:
+        assert node.comment is not None  # hello, type checker
+        if not self._comment_matcher.match(node.comment.value):
+            return
+        line = self.get_metadata(PositionProvider, node.comment).start.line
+        if isinstance(node, cst.EmptyLine):
+            # Standalone comments refer to the next line
+            line += 1
+        self.comments[line] = node.comment

--- a/libcst/codemod/visitors/_gather_string_annotation_names.py
+++ b/libcst/codemod/visitors/_gather_string_annotation_names.py
@@ -3,13 +3,14 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Union, Set, cast
+from typing import Set, Union, cast
 
 import libcst as cst
 import libcst.matchers as m
 from libcst.codemod._context import CodemodContext
 from libcst.codemod._visitor import ContextAwareVisitor
 from libcst.metadata import QualifiedNameProvider
+
 
 FUNCS_CONSIDERED_AS_STRING_ANNOTATIONS = {"typing.TypeVar"}
 ANNOTATION_MATCHER = m.Annotation() | m.Call(

--- a/libcst/codemod/visitors/_gather_string_annotation_names.py
+++ b/libcst/codemod/visitors/_gather_string_annotation_names.py
@@ -13,7 +13,7 @@ from libcst.metadata import QualifiedNameProvider
 
 
 FUNCS_CONSIDERED_AS_STRING_ANNOTATIONS = {"typing.TypeVar"}
-ANNOTATION_MATCHER = m.Annotation() | m.Call(
+ANNOTATION_MATCHER: m.BaseMatcherNode = m.Annotation() | m.Call(
     metadata=m.MatchMetadataIfTrue(
         QualifiedNameProvider,
         lambda qualnames: any(

--- a/libcst/codemod/visitors/_gather_string_annotation_names.py
+++ b/libcst/codemod/visitors/_gather_string_annotation_names.py
@@ -24,11 +24,21 @@ ANNOTATION_MATCHER: m.BaseMatcherNode = m.Annotation() | m.Call(
 
 
 class GatherNamesFromStringAnnotationsVisitor(ContextAwareVisitor):
+    """
+    Collects all names from string literals used for typing purposes.
+    This includes annotations like ``foo: "SomeType"``, and parameters to
+    special functions related to typing (currently only `typing.TypeVar`).
+
+    After visiting, a set of all found names will be available on the ``names``
+    attribute of this visitor.
+    """
+
     METADATA_DEPENDENCIES = (QualifiedNameProvider,)
 
     def __init__(self, context: CodemodContext) -> None:
         super().__init__(context)
 
+        #: The set of names collected from string literals.
         self.names: Set[str] = set()
 
     @m.call_if_inside(ANNOTATION_MATCHER)

--- a/libcst/codemod/visitors/_gather_string_annotation_names.py
+++ b/libcst/codemod/visitors/_gather_string_annotation_names.py
@@ -1,0 +1,65 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Union, Set, cast
+
+import libcst as cst
+import libcst.matchers as m
+from libcst.codemod._context import CodemodContext
+from libcst.codemod._visitor import ContextAwareVisitor
+from libcst.metadata import QualifiedNameProvider
+
+FUNCS_CONSIDERED_AS_STRING_ANNOTATIONS = {"typing.TypeVar"}
+ANNOTATION_MATCHER = m.Annotation() | m.Call(
+    metadata=m.MatchMetadataIfTrue(
+        QualifiedNameProvider,
+        lambda qualnames: any(
+            qn.name in FUNCS_CONSIDERED_AS_STRING_ANNOTATIONS for qn in qualnames
+        ),
+    )
+)
+
+
+class GatherNamesFromStringAnnotationsVisitor(ContextAwareVisitor):
+    METADATA_DEPENDENCIES = (QualifiedNameProvider,)
+
+    def __init__(self, context: CodemodContext) -> None:
+        super().__init__(context)
+
+        self.names: Set[str] = set()
+
+    @m.call_if_inside(ANNOTATION_MATCHER)
+    @m.visit(m.ConcatenatedString())
+    def handle_any_string(
+        self, node: Union[cst.SimpleString, cst.ConcatenatedString]
+    ) -> None:
+        value = node.evaluated_value
+        if value is None:
+            return
+        mod = cst.parse_module(value)
+        extracted_nodes = m.extractall(
+            mod,
+            m.Name(value=m.SaveMatchedNode(m.DoNotCare(), "name"))
+            | m.SaveMatchedNode(m.Attribute(), "attribute"),
+        )
+        # This captures a bit more than necessary. For attributes, we capture the inner
+        # Name twice.
+        names = {
+            cast(str, values["name"]) for values in extracted_nodes if "name" in values
+        } | {
+            name
+            for values in extracted_nodes
+            if "attribute" in values
+            for name, _ in cst.metadata.scope_provider._gen_dotted_names(
+                cast(cst.Attribute, values["attribute"])
+            )
+        }
+        self.names.update(names)
+
+    @m.call_if_inside(ANNOTATION_MATCHER)
+    @m.call_if_not_inside(m.ConcatenatedString())
+    @m.visit(m.SimpleString())
+    def handle_simple_string(self, node: cst.SimpleString) -> None:
+        self.handle_any_string(node)

--- a/libcst/codemod/visitors/_gather_unused_imports.py
+++ b/libcst/codemod/visitors/_gather_unused_imports.py
@@ -20,7 +20,6 @@ from libcst.metadata.scope_provider import _gen_dotted_names
 
 class GatherUnusedImportsVisitor(ContextAwareVisitor):
 
-    SUPPRESS_COMMENT_REGEX_CONTEXT_KEY = f"GatherUnusedImportsVisitor.suppress_regex"
     METADATA_DEPENDENCIES: Tuple[ProviderT] = (
         *GatherNamesFromStringAnnotationsVisitor.METADATA_DEPENDENCIES,
         ScopeProvider,

--- a/libcst/codemod/visitors/_gather_unused_imports.py
+++ b/libcst/codemod/visitors/_gather_unused_imports.py
@@ -14,14 +14,14 @@ from libcst.codemod.visitors._gather_exports import GatherExportsVisitor
 from libcst.codemod.visitors._gather_string_annotation_names import (
     GatherNamesFromStringAnnotationsVisitor,
 )
-from libcst.metadata import ScopeProvider
+from libcst.metadata import ProviderT, ScopeProvider
 from libcst.metadata.scope_provider import _gen_dotted_names
 
 
 class GatherUnusedImportsVisitor(ContextAwareVisitor):
 
     SUPPRESS_COMMENT_REGEX_CONTEXT_KEY = f"GatherUnusedImportsVisitor.suppress_regex"
-    METADATA_DEPENDENCIES = (
+    METADATA_DEPENDENCIES: Tuple[ProviderT] = (
         *GatherNamesFromStringAnnotationsVisitor.METADATA_DEPENDENCIES,
         ScopeProvider,
     )
@@ -52,9 +52,10 @@ class GatherUnusedImportsVisitor(ContextAwareVisitor):
         )
     )
     def handle_import(self, node: Union[cst.Import, cst.ImportFrom]) -> None:
-        assert not isinstance(node.names, cst.ImportStar)  # hello, type checker
+        names = node.names
+        assert not isinstance(names, cst.ImportStar)  # hello, type checker
 
-        for alias in node.names:
+        for alias in names:
             self.unused_imports.add((alias, node))
 
     def leave_Module(self, original_node: cst.Module) -> None:

--- a/libcst/codemod/visitors/_gather_unused_imports.py
+++ b/libcst/codemod/visitors/_gather_unused_imports.py
@@ -1,0 +1,121 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+from typing import Dict, List, Optional, Sequence, Set, Tuple, Union, Iterable
+
+import libcst as cst
+import libcst.matchers as m
+from libcst.codemod._context import CodemodContext
+from libcst.codemod._visitor import ContextAwareVisitor
+from libcst.metadata import QualifiedNameProvider, ScopeProvider, PositionProvider
+from libcst.codemod.visitors._gather_exports import GatherExportsVisitor
+from libcst.codemod.visitors._gather_comments import GatherCommentsVisitor
+from libcst.codemod.visitors._gather_string_annotation_names import (
+    GatherNamesFromStringAnnotationsVisitor,
+)
+from libcst.metadata.scope_provider import _gen_dotted_names
+
+
+DEFAULT_SUPPRESS_COMMENT_REGEX = (
+    r".*\W(lint-ignore: ?unused-import|noqa|lint-ignore: ?F401)(\W.*)?$"
+)
+
+
+class GatherUnusedImportsVisitor(ContextAwareVisitor):
+
+    SUPPRESS_COMMENT_REGEX_CONTEXT_KEY = f"GatherUnusedImportsVisitor.suppress_regex"
+    METADATA_DEPENDENCIES = (
+        *GatherCommentsVisitor.METADATA_DEPENDENCIES,
+        *GatherNamesFromStringAnnotationsVisitor.METADATA_DEPENDENCIES,
+        PositionProvider,
+        ScopeProvider,
+    )
+
+    def __init__(self, context: CodemodContext) -> None:
+        super().__init__(context)
+
+        self._string_annotation_names: Set[str] = set()
+        self._ignored_lines: Set[int] = set()
+        self._exported_names: Set[str] = set()
+        self.unused_imports: Set[
+            Tuple[cst.ImportAlias, Union[cst.Import, cst.ImportFrom]]
+        ] = set()
+
+    def visit_Module(self, node: cst.Module) -> bool:
+        export_collector = GatherExportsVisitor(self.context)
+        node.visit(export_collector)
+        self._exported_names = export_collector.explicit_exported_objects
+        comment_visitor = GatherCommentsVisitor(
+            self.context,
+            self.context.scratch.get(
+                self.SUPPRESS_COMMENT_REGEX_CONTEXT_KEY, DEFAULT_SUPPRESS_COMMENT_REGEX,
+            ),
+        )
+        node.visit(comment_visitor)
+        self._ignored_lines = set(comment_visitor.comments.keys())
+        annotation_visitor = GatherNamesFromStringAnnotationsVisitor(self.context)
+        node.visit(annotation_visitor)
+        self._string_annotation_names = annotation_visitor.names
+        return True
+
+    @m.visit(
+        m.Import()
+        | m.ImportFrom(
+            module=m.DoesNotMatch(m.Name("__future__")),
+            names=m.DoesNotMatch(m.ImportStar()),
+        )
+    )
+    def handle_import(self, node: Union[cst.Import, cst.ImportFrom]) -> None:
+        assert not isinstance(node.names, cst.ImportStar)  # hello, type checker
+
+        node_start = self.get_metadata(PositionProvider, node).start.line
+        if node_start in self._ignored_lines:
+            return
+
+        for alias in node.names:
+            position = self.get_metadata(PositionProvider, alias)
+            lines = set(range(position.start.line, position.end.line + 1))
+            if lines.isdisjoint(self._ignored_lines):
+                self.unused_imports.add((alias, node))
+
+    def leave_Module(self, original_node: cst.Module) -> None:
+        self.unused_imports = self.filter_unused_imports(self.unused_imports)
+
+    def filter_unused_imports(
+        self,
+        candidates: Iterable[Tuple[cst.ImportAlias, Union[cst.Import, cst.ImportFrom]]],
+    ) -> Set[Tuple[cst.ImportAlias, Union[cst.Import, cst.ImportFrom]]]:
+        unused_imports = set()
+        for (alias, parent) in candidates:
+            scope = self.get_metadata(ScopeProvider, parent)
+            if scope is None:
+                continue
+            if not self.is_in_use(scope, alias):
+                unused_imports.add((alias, parent))
+        return unused_imports
+
+    def is_in_use(self, scope: cst.metadata.Scope, alias: cst.ImportAlias) -> bool:
+        asname = alias.asname
+        names = _gen_dotted_names(
+            cst.ensure_type(asname.name, cst.Name) if asname is not None else alias.name
+        )
+
+        for name_or_alias, _ in names:
+            if (
+                name_or_alias in self._exported_names
+                or name_or_alias in self._string_annotation_names
+            ):
+                return True
+
+            for assignment in scope[name_or_alias]:
+                if (
+                    isinstance(assignment, cst.metadata.Assignment)
+                    and isinstance(assignment.node, (cst.ImportFrom, cst.Import))
+                    and len(assignment.references) > 0
+                ):
+                    return True
+        return False
+

--- a/libcst/codemod/visitors/_gather_unused_imports.py
+++ b/libcst/codemod/visitors/_gather_unused_imports.py
@@ -4,17 +4,17 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-from typing import Set, Tuple, Union, Iterable
+from typing import Iterable, Set, Tuple, Union
 
 import libcst as cst
 import libcst.matchers as m
 from libcst.codemod._context import CodemodContext
 from libcst.codemod._visitor import ContextAwareVisitor
-from libcst.metadata import ScopeProvider
 from libcst.codemod.visitors._gather_exports import GatherExportsVisitor
 from libcst.codemod.visitors._gather_string_annotation_names import (
     GatherNamesFromStringAnnotationsVisitor,
 )
+from libcst.metadata import ScopeProvider
 from libcst.metadata.scope_provider import _gen_dotted_names
 
 
@@ -94,4 +94,3 @@ class GatherUnusedImportsVisitor(ContextAwareVisitor):
                 ):
                     return True
         return False
-

--- a/libcst/codemod/visitors/_remove_imports.py
+++ b/libcst/codemod/visitors/_remove_imports.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional, Sequence, Set, Tuple, Union
 import libcst as cst
 from libcst.codemod._context import CodemodContext
 from libcst.codemod._visitor import ContextAwareTransformer, ContextAwareVisitor
-from libcst.codemod.visitors._gather_exports import GatherExportsVisitor
+from libcst.codemod.visitors._gather_unused_imports import GatherUnusedImportsVisitor
 from libcst.helpers import get_absolute_module_for_import, get_full_name_for_node
 from libcst.metadata import Assignment, Scope, ScopeProvider
 from libcst.metadata.scope_provider import _gen_dotted_names
@@ -173,7 +173,7 @@ class RemoveImportsVisitor(ContextAwareTransformer):
     """
 
     CONTEXT_KEY = "RemoveImportsVisitor"
-    METADATA_DEPENDENCIES = (ScopeProvider,)
+    METADATA_DEPENDENCIES = (*GatherUnusedImportsVisitor.METADATA_DEPENDENCIES,)
 
     @staticmethod
     def _get_imports_from_context(
@@ -279,48 +279,24 @@ class RemoveImportsVisitor(ContextAwareTransformer):
             module: alias for module, obj, alias in all_unused_imports if obj is None
         }
         self.unused_obj_imports: Dict[str, Set[Tuple[str, Optional[str]]]] = {}
-        self.exported_objects: Set[str] = set()
         for module, obj, alias in all_unused_imports:
             if obj is None:
                 continue
             if module not in self.unused_obj_imports:
                 self.unused_obj_imports[module] = set()
             self.unused_obj_imports[module].add((obj, alias))
+        self._unused_imports: Dict[
+            cst.ImportAlias, Union[cst.Import, cst.ImportFrom]
+        ] = {}
 
     def visit_Module(self, node: cst.Module) -> None:
-        object_visitor = GatherExportsVisitor(self.context)
-        node.visit(object_visitor)
-        self.exported_objects = object_visitor.explicit_exported_objects
-
-    def _is_in_use(self, scope: Scope, alias: cst.ImportAlias) -> bool:
-        # Grab the string name of this alias from the point of view of this module.
-        asname = alias.asname
-        names = _gen_dotted_names(
-            cst.ensure_type(asname.name, cst.Name) if asname is not None else alias.name
-        )
-
-        for name_or_alias, _ in names:
-            if name_or_alias in self.exported_objects:
-                return True
-
-            for assignment in scope[name_or_alias]:
-                if (
-                    isinstance(assignment, Assignment)
-                    and isinstance(assignment.node, (cst.ImportFrom, cst.Import))
-                    and len(assignment.references) > 0
-                ):
-                    return True
-        return False
+        visitor = GatherUnusedImportsVisitor(self.context)
+        node.visit(visitor)
+        self._unused_imports = {k: v for (k, v) in visitor.unused_imports}
 
     def leave_Import(
         self, original_node: cst.Import, updated_node: cst.Import
     ) -> Union[cst.Import, cst.RemovalSentinel]:
-        # Grab the scope for this import. If we don't have scope, we can't determine
-        # whether this import is unused so it is unsafe to remove.
-        scope = self.get_metadata(ScopeProvider, original_node, None)
-        if scope is None:
-            return updated_node
-
         names_to_keep = []
         for import_alias in original_node.names:
             if import_alias.evaluated_name not in self.unused_module_imports:
@@ -339,7 +315,7 @@ class RemoveImportsVisitor(ContextAwareTransformer):
 
             # Now that we know we want to remove this module, figure out if
             # there are any live references to it.
-            if self._is_in_use(scope, import_alias):
+            if import_alias not in self._unused_imports:
                 names_to_keep.append(import_alias)
                 continue
 
@@ -363,13 +339,6 @@ class RemoveImportsVisitor(ContextAwareTransformer):
     def leave_ImportFrom(
         self, original_node: cst.ImportFrom, updated_node: cst.ImportFrom
     ) -> Union[cst.ImportFrom, cst.RemovalSentinel]:
-        # Grab the scope for this import. If we don't have scope, we can't determine
-        # whether this import is unused so it is unsafe to remove.
-        scope = self.get_metadata(ScopeProvider, original_node, None)
-        if scope is None:
-            return updated_node
-
-        # Make sure we have anything to do with this node.
         names = original_node.names
         if isinstance(names, cst.ImportStar):
             # This is a star import, so we won't remove it.
@@ -400,7 +369,7 @@ class RemoveImportsVisitor(ContextAwareTransformer):
 
             # Now that we know we want to remove this object, figure out if
             # there are any live references to it.
-            if self._is_in_use(scope, import_alias):
+            if import_alias not in self._unused_imports:
                 names_to_keep.append(import_alias)
                 continue
 

--- a/libcst/codemod/visitors/_remove_imports.py
+++ b/libcst/codemod/visitors/_remove_imports.py
@@ -10,7 +10,7 @@ from libcst.codemod._context import CodemodContext
 from libcst.codemod._visitor import ContextAwareTransformer, ContextAwareVisitor
 from libcst.codemod.visitors._gather_unused_imports import GatherUnusedImportsVisitor
 from libcst.helpers import get_absolute_module_for_import, get_full_name_for_node
-from libcst.metadata import Assignment, ScopeProvider
+from libcst.metadata import Assignment, ProviderT, ScopeProvider
 
 
 class RemovedNodeVisitor(ContextAwareVisitor):
@@ -172,7 +172,9 @@ class RemoveImportsVisitor(ContextAwareTransformer):
     """
 
     CONTEXT_KEY = "RemoveImportsVisitor"
-    METADATA_DEPENDENCIES = (*GatherUnusedImportsVisitor.METADATA_DEPENDENCIES,)
+    METADATA_DEPENDENCIES: Tuple[ProviderT] = (
+        *GatherUnusedImportsVisitor.METADATA_DEPENDENCIES,
+    )
 
     @staticmethod
     def _get_imports_from_context(

--- a/libcst/codemod/visitors/_remove_imports.py
+++ b/libcst/codemod/visitors/_remove_imports.py
@@ -10,8 +10,7 @@ from libcst.codemod._context import CodemodContext
 from libcst.codemod._visitor import ContextAwareTransformer, ContextAwareVisitor
 from libcst.codemod.visitors._gather_unused_imports import GatherUnusedImportsVisitor
 from libcst.helpers import get_absolute_module_for_import, get_full_name_for_node
-from libcst.metadata import Assignment, Scope, ScopeProvider
-from libcst.metadata.scope_provider import _gen_dotted_names
+from libcst.metadata import Assignment, ScopeProvider
 
 
 class RemovedNodeVisitor(ContextAwareVisitor):

--- a/libcst/codemod/visitors/_remove_imports.py
+++ b/libcst/codemod/visitors/_remove_imports.py
@@ -118,7 +118,7 @@ class RemoveImportsVisitor(ContextAwareTransformer):
     object appears in an ``__any__`` list.
 
     This is one of the transforms that is available automatically to you when running
-    a codemod. To use it in this manner, importi
+    a codemod. To use it in this manner, import
     :class:`~libcst.codemod.visitors.RemoveImportsVisitor` and then call the static
     :meth:`~libcst.codemod.visitors.RemoveImportsVisitor.remove_unused_import` method,
     giving it the current context (found as ``self.context`` for all subclasses of

--- a/libcst/codemod/visitors/tests/test_gather_comments.py
+++ b/libcst/codemod/visitors/tests/test_gather_comments.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 #
-from libcst import parse_module, MetadataWrapper, Comment
+from libcst import Comment, MetadataWrapper, parse_module
 from libcst.codemod import CodemodContext, CodemodTest
 from libcst.codemod.visitors import GatherCommentsVisitor
 from libcst.testing.utils import UnitTest

--- a/libcst/codemod/visitors/tests/test_gather_comments.py
+++ b/libcst/codemod/visitors/tests/test_gather_comments.py
@@ -1,0 +1,46 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from libcst import parse_module, MetadataWrapper, Comment
+from libcst.codemod import CodemodContext, CodemodTest
+from libcst.codemod.visitors import GatherCommentsVisitor
+from libcst.testing.utils import UnitTest
+
+
+class TestGatherCommentsVisitor(UnitTest):
+    def gather_comments(self, code: str) -> GatherCommentsVisitor:
+        mod = MetadataWrapper(parse_module(CodemodTest.make_fixture_data(code)))
+        mod.resolve_many(GatherCommentsVisitor.METADATA_DEPENDENCIES)
+        instance = GatherCommentsVisitor(
+            CodemodContext(wrapper=mod), r".*\Wnoqa(\W.*)?$"
+        )
+        mod.visit(instance)
+        return instance
+
+    def test_no_comments(self) -> None:
+        visitor = self.gather_comments(
+            """
+            def foo() -> None:
+                pass
+            """
+        )
+        self.assertEqual(visitor.comments, {})
+
+    def test_noqa_comments(self) -> None:
+        visitor = self.gather_comments(
+            """
+            import a.b.c # noqa
+            import d  # somethingelse
+            # noqa
+            def foo() -> None:
+                pass
+
+            """
+        )
+        self.assertEqual(visitor.comments.keys(), {1, 4})
+        self.assertTrue(isinstance(visitor.comments[1], Comment))
+        self.assertEqual(visitor.comments[1].value, "# noqa")
+        self.assertTrue(isinstance(visitor.comments[4], Comment))
+        self.assertEqual(visitor.comments[4].value, "# noqa")

--- a/libcst/codemod/visitors/tests/test_gather_string_annotation_names.py
+++ b/libcst/codemod/visitors/tests/test_gather_string_annotation_names.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 #
-from libcst import parse_module, MetadataWrapper
+from libcst import MetadataWrapper, parse_module
 from libcst.codemod import CodemodContext, CodemodTest
 from libcst.codemod.visitors import GatherNamesFromStringAnnotationsVisitor
 from libcst.testing.utils import UnitTest

--- a/libcst/codemod/visitors/tests/test_gather_string_annotation_names.py
+++ b/libcst/codemod/visitors/tests/test_gather_string_annotation_names.py
@@ -1,0 +1,71 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from libcst import parse_module, MetadataWrapper
+from libcst.codemod import CodemodContext, CodemodTest
+from libcst.codemod.visitors import GatherNamesFromStringAnnotationsVisitor
+from libcst.testing.utils import UnitTest
+
+
+class TestGatherNamesFromStringAnnotationsVisitor(UnitTest):
+    def gather_names(self, code: str) -> GatherNamesFromStringAnnotationsVisitor:
+        mod = MetadataWrapper(parse_module(CodemodTest.make_fixture_data(code)))
+        mod.resolve_many(GatherNamesFromStringAnnotationsVisitor.METADATA_DEPENDENCIES)
+        instance = GatherNamesFromStringAnnotationsVisitor(CodemodContext(wrapper=mod))
+        mod.visit(instance)
+        return instance
+
+    def test_no_annotations(self) -> None:
+        visitor = self.gather_names(
+            """
+            def foo() -> None:
+                pass
+            """
+        )
+        self.assertEqual(visitor.names, set())
+
+    def test_simple_string_annotations(self) -> None:
+        visitor = self.gather_names(
+            """
+            def foo() -> "None":
+                pass
+            """
+        )
+        self.assertEqual(visitor.names, {"None"})
+
+    def test_concatenated_string_annotations(self) -> None:
+        visitor = self.gather_names(
+            """
+            def foo() -> "No" "ne":
+                pass
+            """
+        )
+        self.assertEqual(visitor.names, {"None"})
+
+    def test_typevars(self) -> None:
+        visitor = self.gather_names(
+            """
+            from typing import TypeVar as SneakyBastard
+            V = SneakyBastard("V", bound="int")
+            """
+        )
+        self.assertEqual(visitor.names, {"V", "int"})
+
+    def test_complex(self) -> None:
+        visitor = self.gather_names(
+            """
+            from typing import TypeVar, TYPE_CHECKING
+            if TYPE_CHECKING:
+                from a import Container, Item
+            def foo(a: "A") -> "Item":
+                pass
+            A = TypeVar("A", bound="Container[Item]")
+            class X:
+                var: "ThisIsExpensiveToImport"  # noqa
+            """
+        )
+        self.assertEqual(
+            visitor.names, {"A", "Item", "Container", "ThisIsExpensiveToImport"}
+        )

--- a/libcst/codemod/visitors/tests/test_gather_string_annotation_names.py
+++ b/libcst/codemod/visitors/tests/test_gather_string_annotation_names.py
@@ -69,3 +69,14 @@ class TestGatherNamesFromStringAnnotationsVisitor(UnitTest):
         self.assertEqual(
             visitor.names, {"A", "Item", "Container", "ThisIsExpensiveToImport"}
         )
+
+    def test_dotted_names(self) -> None:
+        visitor = self.gather_names(
+            """
+            a: "api.http_exceptions.HttpException"
+            """
+        )
+        self.assertEqual(
+            visitor.names,
+            {"api", "api.http_exceptions", "api.http_exceptions.HttpException"},
+        )

--- a/libcst/codemod/visitors/tests/test_gather_unused_imports.py
+++ b/libcst/codemod/visitors/tests/test_gather_unused_imports.py
@@ -3,12 +3,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 #
-from libcst import parse_module, MetadataWrapper
+from typing import Set
+
+from libcst import MetadataWrapper, parse_module
 from libcst.codemod import CodemodContext, CodemodTest
 from libcst.codemod.visitors import GatherUnusedImportsVisitor
 from libcst.testing.utils import UnitTest
-
-from typing import Set
 
 
 class TestGatherUnusedImportsVisitor(UnitTest):
@@ -126,4 +126,3 @@ class TestGatherUnusedImportsVisitor(UnitTest):
             """
         )
         self.assertEqual(imports, set())
-

--- a/libcst/codemod/visitors/tests/test_gather_unused_imports.py
+++ b/libcst/codemod/visitors/tests/test_gather_unused_imports.py
@@ -95,20 +95,6 @@ class TestGatherUnusedImportsVisitor(UnitTest):
         )
         self.assertEqual(imports, set())
 
-    def test_suppression(self) -> None:
-        imports = self.gather_imports(
-            """
-            # noqa
-            import a, b
-            import c
-            from x import (
-                y,  # noqa
-                z,
-            )
-            """
-        )
-        self.assertEqual(imports, {"c", "z"})
-
     def test_string_annotation(self) -> None:
         imports = self.gather_imports(
             """
@@ -141,15 +127,3 @@ class TestGatherUnusedImportsVisitor(UnitTest):
         )
         self.assertEqual(imports, set())
 
-    def test_suppression_on_first_line_of_multiline_import_refers_to_whole_block(
-        self,
-    ) -> None:
-        imports = self.gather_imports(
-            """
-            from a import (  # lint-ignore: unused-import
-                b,
-                c,
-            )
-            """
-        )
-        self.assertEqual(imports, set())

--- a/libcst/codemod/visitors/tests/test_gather_unused_imports.py
+++ b/libcst/codemod/visitors/tests/test_gather_unused_imports.py
@@ -1,0 +1,155 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from libcst import parse_module, MetadataWrapper
+from libcst.codemod import CodemodContext, CodemodTest
+from libcst.codemod.visitors import GatherUnusedImportsVisitor
+from libcst.testing.utils import UnitTest
+
+from typing import Set
+
+
+class TestGatherUnusedImportsVisitor(UnitTest):
+    def gather_imports(self, code: str) -> Set[str]:
+        mod = MetadataWrapper(parse_module(CodemodTest.make_fixture_data(code)))
+        mod.resolve_many(GatherUnusedImportsVisitor.METADATA_DEPENDENCIES)
+        instance = GatherUnusedImportsVisitor(CodemodContext(wrapper=mod))
+        mod.visit(instance)
+        return set(
+            alias.evaluated_alias or alias.evaluated_name
+            for alias, _ in instance.unused_imports
+        )
+
+    def test_no_imports(self) -> None:
+        imports = self.gather_imports(
+            """
+            foo = 1
+            """
+        )
+        self.assertEqual(imports, set())
+
+    def test_dotted_imports(self) -> None:
+        imports = self.gather_imports(
+            """
+            import a.b.c, d
+            import x.y
+            a.b(d)
+            """
+        )
+        self.assertEqual(imports, {"x.y"})
+
+    def test_alias(self) -> None:
+        imports = self.gather_imports(
+            """
+            from bar import baz as baz_alias
+            import bar as bar_alias
+            bar_alias()
+            """
+        )
+        self.assertEqual(imports, {"baz_alias"})
+
+    def test_import_complex(self) -> None:
+        imports = self.gather_imports(
+            """
+            import bar
+            import baz, qux
+            import a.b
+            import c.d
+            import x.y.z
+            import e.f as g
+            import h.i as j
+
+            def foo() -> None:
+                c.d(qux)
+                x.u
+                j()
+            """
+        )
+        self.assertEqual(imports, {"bar", "baz", "a.b", "g"})
+
+    def test_import_from_complex(self) -> None:
+        imports = self.gather_imports(
+            """
+            from bar import qux, quux
+            from a.b import c
+            from d.e import f
+            from h.i import j as k
+            from l.m import n as o
+            from x import *
+
+            def foo() -> None:
+                f(qux)
+                k()
+            """
+        )
+        self.assertEqual(imports, {"quux", "c", "o"})
+
+    def test_exports(self) -> None:
+        imports = self.gather_imports(
+            """
+            import a
+            __all__ = ["a"]
+            """
+        )
+        self.assertEqual(imports, set())
+
+    def test_suppression(self) -> None:
+        imports = self.gather_imports(
+            """
+            # noqa
+            import a, b
+            import c
+            from x import (
+                y,  # noqa
+                z,
+            )
+            """
+        )
+        self.assertEqual(imports, {"c", "z"})
+
+    def test_string_annotation(self) -> None:
+        imports = self.gather_imports(
+            """
+            from a import b
+            from c import d
+            import m, n.blah
+            foo: "b[int]"
+            bar: List["d"]
+            quux: List["m.blah"]
+            alma: List["n.blah"]
+            """
+        )
+        self.assertEqual(imports, set())
+
+    def test_typevars(self) -> None:
+        imports = self.gather_imports(
+            """
+            from typing import TypeVar as Sneaky
+            from a import b
+            t = Sneaky("t", bound="b")
+            """
+        )
+        self.assertEqual(imports, set())
+
+    def test_future(self) -> None:
+        imports = self.gather_imports(
+            """
+            from __future__ import cool_feature
+            """
+        )
+        self.assertEqual(imports, set())
+
+    def test_suppression_on_first_line_of_multiline_import_refers_to_whole_block(
+        self,
+    ) -> None:
+        imports = self.gather_imports(
+            """
+            from a import (  # lint-ignore: unused-import
+                b,
+                c,
+            )
+            """
+        )
+        self.assertEqual(imports, set())


### PR DESCRIPTION
## Summary
This PR adds support for detecting imports being used by string type
annotations, as well as imports suppressed by comments.

It breaks up the existing visitor into multiple smaller, single-purpose
visitors, and composes them together.

TODO:

- [x] add docstrings
- [x] document behavioral changes to `RemoveImportsVisitor`


## Test Plan
existing and new tests
