### PR TITLE
fix: correctly extract wildcard matchers

### DIFF
--- a/libcst/matchers/_matcher_base.py
+++ b/libcst/matchers/_matcher_base.py
@@ -15,6 +15,7 @@ from typing import (
     Generic,
     List,
     Mapping,
+    NamedTuple
     NoReturn,
     Optional,
     Pattern,
@@ -932,6 +933,11 @@ def SaveMatchedNode(matcher: _OtherNodeT, name: str) -> _OtherNodeT:
     return cast(_OtherNodeT, _ExtractMatchingNode(matcher, name))
 
 
+class _SequenceMatchesResult(NamedTuple):
+    sequence_capture: Optional[Dict[str, Union[libcst.CSTNode, Sequence[libcst.CSTNode]]]]
+    matched_nodes: Optional[Union[libcst.CSTNode, MaybeSentinel, Sequence[libcst.CSTNode]]]
+
+
 def _sequence_matches(  # noqa: C901
     nodes: Sequence[Union[MaybeSentinel, libcst.CSTNode]],
     matchers: Sequence[
@@ -944,30 +950,33 @@ def _sequence_matches(  # noqa: C901
         ]
     ],
     metadata_lookup: Callable[[meta.ProviderT, libcst.CSTNode], object],
-) -> Optional[Dict[str, Union[libcst.CSTNode, Sequence[libcst.CSTNode]]]]:
+) -> Tuple[
+    Optional[Dict[str, Union[libcst.CSTNode, Sequence[libcst.CSTNode]]]],
+    Optional[Union[libcst.CSTNode, MaybeSentinel, Sequence[libcst.CSTNode]]],
+]:
     if not nodes and not matchers:
-        # Base case, empty lists are alwatys matches
-        return {}
+        # Base case, empty lists are always matches
+        return {}, None
     if not nodes and matchers:
         # Base case, we have one or more matcher that wasn't matched
         return (
-            {}
+            ({}, [])
             if all(
                 (isinstance(m, AtLeastN) and m.n == 0) or isinstance(m, AtMostN)
                 for m in matchers
             )
-            else None
+            else (None, None)
         )
     if nodes and not matchers:
         # Base case, we have nodes left that don't match any matcher
-        return None
+        return None, None
 
     # Recursive case, nodes and matchers LHS matches
     node = nodes[0]
     matcher = matchers[0]
     if isinstance(matcher, DoNotCareSentinel):
         # We don't care about the value for this node.
-        return _sequence_matches(nodes[1:], matchers[1:], metadata_lookup)
+        return _sequence_matches(nodes[1:], matchers[1:], metadata_lookup)[0], node
     elif isinstance(matcher, _BaseWildcardNode):
         if isinstance(matcher, AtMostN):
             if matcher.n > 0:
@@ -977,18 +986,19 @@ def _sequence_matches(  # noqa: C901
                     nodes[0], matcher.matcher, metadata_lookup
                 )
                 if attribute_capture is not None:
-                    sequence_capture = _sequence_matches(
+                    sequence_capture, matched_nodes = _sequence_matches(
                         nodes[1:],
                         [AtMostN(matcher.matcher, n=matcher.n - 1), *matchers[1:]],
                         metadata_lookup,
                     )
                     if sequence_capture is not None:
-                        return {**attribute_capture, **sequence_capture}
+                        return (
+                            {**attribute_capture, **sequence_capture},
+                            (node, *matched_nodes),
+                        )
             # Finally, assume that this does not match the current node.
             # Consume the matcher but not the node.
-            sequence_capture = _sequence_matches(nodes, matchers[1:], metadata_lookup)
-            if sequence_capture is not None:
-                return sequence_capture
+            return _sequence_matches(nodes, matchers[1:], metadata_lookup)[0], ()
         elif isinstance(matcher, AtLeastN):
             if matcher.n > 0:
                 # Only match if we can consume one of the matches, since we still
@@ -997,13 +1007,17 @@ def _sequence_matches(  # noqa: C901
                     nodes[0], matcher.matcher, metadata_lookup
                 )
                 if attribute_capture is not None:
-                    sequence_capture = _sequence_matches(
+                    sequence_capture, matched_nodes = _sequence_matches(
                         nodes[1:],
                         [AtLeastN(matcher.matcher, n=matcher.n - 1), *matchers[1:]],
                         metadata_lookup,
                     )
                     if sequence_capture is not None:
-                        return {**attribute_capture, **sequence_capture}
+                        return (
+                            {**attribute_capture, **sequence_capture},
+                            (node, *matched_nodes),
+                        )
+                return None, None
             else:
                 # First, assume that this does match a node (greedy).
                 # Consume one node since it matched this matcher.
@@ -1011,45 +1025,49 @@ def _sequence_matches(  # noqa: C901
                     nodes[0], matcher.matcher, metadata_lookup
                 )
                 if attribute_capture is not None:
-                    sequence_capture = _sequence_matches(
+                    sequence_capture, matched_nodes = _sequence_matches(
                         nodes[1:], matchers, metadata_lookup
                     )
                     if sequence_capture is not None:
-                        return {**attribute_capture, **sequence_capture}
+                        return (
+                            {**attribute_capture, **sequence_capture},
+                            (node, *matched_nodes),
+                        )
                 # Now, assume that this does not match the current node.
                 # Consume the matcher but not the node.
-                sequence_capture = _sequence_matches(
-                    nodes, matchers[1:], metadata_lookup
-                )
-                if sequence_capture is not None:
-                    return sequence_capture
+                return _sequence_matches(nodes, matchers[1:], metadata_lookup)[0], ()
         else:
             # There are no other types of wildcard consumers, but we're making
             # pyre happy with that fact.
             raise Exception(f"Logic error unrecognized wildcard {type(matcher)}!")
     elif isinstance(matcher, _ExtractMatchingNode):
         # See if the raw matcher matches. If it does, capture the sequence we matched and store it.
-        sequence_capture = _sequence_matches(
+        sequence_capture, matched_nodes = _sequence_matches(
             nodes, [matcher.matcher, *matchers[1:]], metadata_lookup
         )
         if sequence_capture is not None:
-            return {
-                # Our own match capture comes first, since we wnat to allow the same
-                # name later in the sequence to override us.
-                matcher.name: nodes,
-                **sequence_capture,
-            }
-        return None
+            return (
+                {
+                    # Our own match capture comes first, since we wnat to allow the same
+                    # name later in the sequence to override us.
+                    matcher.name: matched_nodes,
+                    **sequence_capture,
+                },
+                matched_nodes,
+            )
+        return None, None
 
     match_capture = _matches(node, matcher, metadata_lookup)
     if match_capture is not None:
         # These values match directly
-        sequence_capture = _sequence_matches(nodes[1:], matchers[1:], metadata_lookup)
+        sequence_capture, _ = _sequence_matches(
+            nodes[1:], matchers[1:], metadata_lookup
+        )
         if sequence_capture is not None:
-            return {**match_capture, **sequence_capture}
+            return {**match_capture, **sequence_capture}, node
 
     # Failed recursive case, no match
-    return None
+    return None, None
 
 
 _AttributeValueT = Optional[Union[MaybeSentinel, libcst.CSTNode, str, bool]]
@@ -1110,7 +1128,7 @@ def _attribute_matches(  # noqa: C901
             for m in matcher.options:
                 if isinstance(m, collections.abc.Sequence):
                     # Should match the sequence of requested nodes
-                    sequence_capture = _sequence_matches(node, m, metadata_lookup)
+                    sequence_capture, _ = _sequence_matches(node, m, metadata_lookup)
                     if sequence_capture is not None:
                         return sequence_capture
                 elif isinstance(m, MatchIfTrue):
@@ -1121,7 +1139,7 @@ def _attribute_matches(  # noqa: C901
             for m in matcher.options:
                 if isinstance(m, collections.abc.Sequence):
                     # Should match the sequence of requested nodes
-                    sequence_capture = _sequence_matches(node, m, metadata_lookup)
+                    sequence_capture, _ = _sequence_matches(node, m, metadata_lookup)
                     if sequence_capture is None:
                         return None
                     all_captures = {**all_captures, **sequence_capture}
@@ -1150,7 +1168,7 @@ def _attribute_matches(  # noqa: C901
                     matcher,
                 ),
                 metadata_lookup,
-            )
+            )[0]
 
         # We exhausted our possibilities, there's no match
         return None

--- a/libcst/matchers/tests/test_extract.py
+++ b/libcst/matchers/tests/test_extract.py
@@ -404,3 +404,25 @@ class MatchersExtractTest(UnitTest):
             ),
         )
         self.assertIsNone(nodes)
+
+    def test_extract_sequence_multiple_wildcards(self) -> None:
+        expression = cst.parse_expression("1, 2, 3, 4")
+        nodes = m.extract(
+            expression,
+            m.Tuple(
+                elements=(
+                    m.SaveMatchedNode(m.ZeroOrMore(), "head"),
+                    m.SaveMatchedNode(m.Element(value=m.Integer(value="3")), "element"),
+                    m.SaveMatchedNode(m.ZeroOrMore(), "tail"),
+                )
+            ),
+        )
+        tuple_elements = cst.ensure_type(expression, cst.Tuple).elements
+        self.assertEqual(
+            nodes,
+            {
+                "head": tuple(tuple_elements[:2]),
+                "element": tuple_elements[2],
+                "tail": tuple(tuple_elements[3:]),
+            },
+        )


### PR DESCRIPTION
##  Summary
`SaveMatchedNodes` within sequences was not working as expected, the fixes in this PR are:
- Fixes #337 the returned matched sequence now reflect the original match and it's not extended until the end of the original sequence
- Fixes #338 a node matched without a wildcard is now returned as a node and not a sequence 

## Test Plan
Unit tests

