### PR TITLE
Fix syntax error in .pyre_configuration.example

### DIFF
--- a/.pyre_configuration.example
+++ b/.pyre_configuration.example
@@ -7,6 +7,6 @@
     ],
     "exclude": [
         ".*/\\.tox/.*"
-    ]
+    ],
     "strict": true
 }


### PR DESCRIPTION
## Summary

Missing a comma

## Test Plan

Try pyre with the example configuration
