### PR TITLE
Include missing test data in install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,11 @@ setuptools.setup(
     url="https://github.com/Instagram/LibCST",
     license="MIT",
     packages=setuptools.find_packages(),
-    package_data={"libcst": ["py.typed"]},
+    package_data={
+        "libcst": ["py.typed"],
+        "libcst.tests.pyre": ["*"],
+        "libcst.codemod.tests": ["*"],
+    },
     test_suite="libcst",
     python_requires=">=3.6",
     install_requires=[


### PR DESCRIPTION
## Summary

#331 reports that tests fail in a certain environment; these messages could be more obvious but are because of missing files.

## Test Plan

The relevant files were not included in the manifest generated by `setup.py egg_info` before, and now are.