### PR TITLE
replace matchers with explicit visitation in gatherers

### DIFF
--- a/libcst/codemod/visitors/_gather_string_annotation_names.py
+++ b/libcst/codemod/visitors/_gather_string_annotation_names.py
@@ -28,15 +28,10 @@ class GatherNamesFromStringAnnotationsVisitor(ContextAwareVisitor):
     METADATA_DEPENDENCIES = (QualifiedNameProvider,)
 
     def __init__(
-        self, context: CodemodContext, typing_functions: Optional[Set[str]] = None
+        self, context: CodemodContext, typing_functions: Collection[str] = FUNCS_CONSIDERED_AS_STRING_ANNOTATIONS
     ) -> None:
         super().__init__(context)
-
-        self._typing_functions: Set[str] = (
-            typing_functions
-            if typing_functions is not None
-            else FUNCS_CONSIDERED_AS_STRING_ANNOTATIONS
-        )
+        self._typing_functions: Collection[str] = typing_functions
         self._annotation_stack: List[cst.CSTNode] = []
         #: The set of names collected from string literals.
         self.names: Set[str] = set()

--- a/libcst/codemod/visitors/_gather_string_annotation_names.py
+++ b/libcst/codemod/visitors/_gather_string_annotation_names.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Set, Union, cast
+from typing import List, Optional, Set, Union, cast
 
 import libcst as cst
 import libcst.matchers as m
@@ -35,14 +35,48 @@ class GatherNamesFromStringAnnotationsVisitor(ContextAwareVisitor):
 
     METADATA_DEPENDENCIES = (QualifiedNameProvider,)
 
-    def __init__(self, context: CodemodContext) -> None:
+    def __init__(
+        self, context: CodemodContext, typing_functions: Optional[Set[str]] = None
+    ) -> None:
         super().__init__(context)
 
+        self._typing_functions: Set[str] = (
+            typing_functions
+            if typing_functions is not None
+            else FUNCS_CONSIDERED_AS_STRING_ANNOTATIONS
+        )
+        self._annotation_stack: List[cst.CSTNode] = []
         #: The set of names collected from string literals.
         self.names: Set[str] = set()
 
-    @m.call_if_inside(ANNOTATION_MATCHER)
-    @m.visit(m.ConcatenatedString())
+    def visit_Annotation(self, node: cst.Annotation) -> bool:
+        self._annotation_stack.append(node)
+        return True
+
+    def leave_Annotation(self, original_node: cst.Annotation) -> None:
+        self._annotation_stack.pop()
+
+    def visit_Call(self, node: cst.Call) -> bool:
+        qnames = self.get_metadata(QualifiedNameProvider, node)
+        if any(qn.name in self._typing_functions for qn in qnames):
+            self._annotation_stack.append(node)
+            return True
+        return False
+
+    def leave_Call(self, original_node: cst.Call) -> None:
+        if self._annotation_stack != [] and self._annotation_stack[-1] == original_node:
+            self._annotation_stack.pop()
+
+    def visit_ConcatenatedString(self, node: cst.ConcatenatedString) -> bool:
+        if self._annotation_stack != []:
+            self.handle_any_string(node)
+        return False
+
+    def visit_SimpleString(self, node: cst.SimpleString) -> bool:
+        if self._annotation_stack != []:
+            self.handle_any_string(node)
+        return False
+
     def handle_any_string(
         self, node: Union[cst.SimpleString, cst.ConcatenatedString]
     ) -> None:
@@ -73,9 +107,3 @@ class GatherNamesFromStringAnnotationsVisitor(ContextAwareVisitor):
             )
         }
         self.names.update(names)
-
-    @m.call_if_inside(ANNOTATION_MATCHER)
-    @m.call_if_not_inside(m.ConcatenatedString())
-    @m.visit(m.SimpleString())
-    def handle_simple_string(self, node: cst.SimpleString) -> None:
-        self.handle_any_string(node)

--- a/libcst/codemod/visitors/_gather_string_annotation_names.py
+++ b/libcst/codemod/visitors/_gather_string_annotation_names.py
@@ -13,14 +13,6 @@ from libcst.metadata import MetadataWrapper, QualifiedNameProvider
 
 
 FUNCS_CONSIDERED_AS_STRING_ANNOTATIONS = {"typing.TypeVar"}
-ANNOTATION_MATCHER: m.BaseMatcherNode = m.Annotation() | m.Call(
-    metadata=m.MatchMetadataIfTrue(
-        QualifiedNameProvider,
-        lambda qualnames: any(
-            qn.name in FUNCS_CONSIDERED_AS_STRING_ANNOTATIONS for qn in qualnames
-        ),
-    )
-)
 
 
 class GatherNamesFromStringAnnotationsVisitor(ContextAwareVisitor):

--- a/libcst/codemod/visitors/_gather_string_annotation_names.py
+++ b/libcst/codemod/visitors/_gather_string_annotation_names.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import List, Optional, Set, Union, cast
+from typing import Collection, List, Set, Union, cast
 
 import libcst as cst
 import libcst.matchers as m
@@ -28,7 +28,9 @@ class GatherNamesFromStringAnnotationsVisitor(ContextAwareVisitor):
     METADATA_DEPENDENCIES = (QualifiedNameProvider,)
 
     def __init__(
-        self, context: CodemodContext, typing_functions: Collection[str] = FUNCS_CONSIDERED_AS_STRING_ANNOTATIONS
+        self,
+        context: CodemodContext,
+        typing_functions: Collection[str] = FUNCS_CONSIDERED_AS_STRING_ANNOTATIONS,
     ) -> None:
         super().__init__(context)
         self._typing_functions: Collection[str] = typing_functions

--- a/libcst/codemod/visitors/_gather_string_annotation_names.py
+++ b/libcst/codemod/visitors/_gather_string_annotation_names.py
@@ -56,16 +56,16 @@ class GatherNamesFromStringAnnotationsVisitor(ContextAwareVisitor):
         return False
 
     def leave_Call(self, original_node: cst.Call) -> None:
-        if self._annotation_stack != [] and self._annotation_stack[-1] == original_node:
+        if self._annotation_stack and self._annotation_stack[-1] == original_node:
             self._annotation_stack.pop()
 
     def visit_ConcatenatedString(self, node: cst.ConcatenatedString) -> bool:
-        if self._annotation_stack != []:
+        if self._annotation_stack:
             self.handle_any_string(node)
         return False
 
     def visit_SimpleString(self, node: cst.SimpleString) -> bool:
-        if self._annotation_stack != []:
+        if self._annotation_stack:
             self.handle_any_string(node)
         return False
 

--- a/libcst/codemod/visitors/_gather_unused_imports.py
+++ b/libcst/codemod/visitors/_gather_unused_imports.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-from typing import Iterable, Optional, Set, Tuple, Union
+from typing import Collection, Iterable, Set, Tuple, Union
 
 import libcst as cst
 from libcst.codemod._context import CodemodContext
@@ -16,6 +16,8 @@ from libcst.codemod.visitors._gather_string_annotation_names import (
 from libcst.metadata import ProviderT, ScopeProvider
 from libcst.metadata.scope_provider import _gen_dotted_names
 
+
+MODULES_IGNORED_BY_DEFAULT = {"__future__"}
 
 class GatherUnusedImportsVisitor(ContextAwareVisitor):
     """
@@ -39,14 +41,12 @@ class GatherUnusedImportsVisitor(ContextAwareVisitor):
     def __init__(
         self,
         context: CodemodContext,
-        ignored_modules: Optional[Set[str]] = None,
-        typing_functions: Optional[Set[str]] = None,
+        ignored_modules: Collection[str] = MODULES_IGNORED_BY_DEFAULT,
+        typing_functions: Collection[str] = set(),
     ) -> None:
         super().__init__(context)
 
-        self._ignored_modules: Set[str] = (
-            ignored_modules if ignored_modules is not None else {"__future__"}
-        )
+        self._ignored_modules: Set[str] = ignored_modules
         self._typing_functions = typing_functions
         self._string_annotation_names: Set[str] = set()
         self._exported_names: Set[str] = set()

--- a/libcst/codemod/visitors/_gather_unused_imports.py
+++ b/libcst/codemod/visitors/_gather_unused_imports.py
@@ -11,6 +11,7 @@ from libcst.codemod._context import CodemodContext
 from libcst.codemod._visitor import ContextAwareVisitor
 from libcst.codemod.visitors._gather_exports import GatherExportsVisitor
 from libcst.codemod.visitors._gather_string_annotation_names import (
+    FUNCS_CONSIDERED_AS_STRING_ANNOTATIONS,
     GatherNamesFromStringAnnotationsVisitor,
 )
 from libcst.metadata import ProviderT, ScopeProvider
@@ -43,7 +44,7 @@ class GatherUnusedImportsVisitor(ContextAwareVisitor):
         self,
         context: CodemodContext,
         ignored_modules: Collection[str] = MODULES_IGNORED_BY_DEFAULT,
-        typing_functions: Collection[str] = set(),
+        typing_functions: Collection[str] = FUNCS_CONSIDERED_AS_STRING_ANNOTATIONS,
     ) -> None:
         super().__init__(context)
 

--- a/libcst/codemod/visitors/_gather_unused_imports.py
+++ b/libcst/codemod/visitors/_gather_unused_imports.py
@@ -19,6 +19,7 @@ from libcst.metadata.scope_provider import _gen_dotted_names
 
 MODULES_IGNORED_BY_DEFAULT = {"__future__"}
 
+
 class GatherUnusedImportsVisitor(ContextAwareVisitor):
     """
     Collects all imports from a module not directly used in the same module.
@@ -46,7 +47,7 @@ class GatherUnusedImportsVisitor(ContextAwareVisitor):
     ) -> None:
         super().__init__(context)
 
-        self._ignored_modules: Set[str] = ignored_modules
+        self._ignored_modules: Collection[str] = ignored_modules
         self._typing_functions = typing_functions
         self._string_annotation_names: Set[str] = set()
         self._exported_names: Set[str] = set()


### PR DESCRIPTION
## Summary
These gatherer visitors are supposed to be reusable, but the matchers make them
* unnecessarily slow
* hard to configure

So this PR eliminates the matchers and uses a more standard visitor API.

## Test Plan

Existing tests
