### PR TITLE
Fixes code generation issue after removing type annotation of assignments by a custom CSTTransformer

### DIFF
--- a/libcst/_nodes/statement.py
+++ b/libcst/_nodes/statement.py
@@ -1367,7 +1367,8 @@ class AnnAssign(BaseSmallStatement):
     ) -> None:
         with state.record_syntactic_position(self):
             self.target._codegen(state)
-            self.annotation._codegen(state, default_indicator=":")
+            if self.annotation is not None:
+                self.annotation._codegen(state, default_indicator=":")
             equal = self.equal
             if equal is MaybeSentinel.DEFAULT and self.value is not None:
                 state.add_token(" = ")


### PR DESCRIPTION
## Summary
I have fixed the issue of ` _codegen_impl` method of class `AnnAssign` when the type annotation of assignments is removed by a custom `CSTTransformer`. 

The following minimal code example shows how to reproduce the code generation issue:

```python
import libcst

class AnnAssignAnnotationRemover(libcst.CSTTransformer):

    def leave_AnnAssign(self, original_node, updated_node):
        return updated_node.with_changes(annotation=None) if original_node.annotation is not None else updated_node

parsed_expr = libcst.parse_module("x: int = 2")
v_ann_assign = AnnAssignAnnotationRemover()
v_ann_assign = parsed_expr.visit(v_ann_assign)

print(v_ann_assign.code)
```

Also, this is the traceback of the exception:
```
Traceback (most recent call last):
  File "/Users/amir/test_LibCST.py", line 12, in <module>
    print(v_ann_assign.code)
  File "/Users/amir/projects/LibCST/libcst/_nodes/module.py", line 118, in code
    return self.code_for_node(self)
  File "/Users/amir/projects/LibCST/libcst/_nodes/module.py", line 138, in code_for_node
    node._codegen(state)
  File "/Users/amir/projects/LibCST/libcst/_nodes/base.py", line 298, in _codegen
    self._codegen_impl(state, **kwargs)
  File "/Users/amir/projects/LibCST/libcst/_nodes/module.py", line 101, in _codegen_impl
    stmt._codegen(state)
  File "/Users/amir/projects/LibCST/libcst/_nodes/base.py", line 298, in _codegen
    self._codegen_impl(state, **kwargs)
  File "/Users/amir/projects/LibCST/libcst/_nodes/statement.py", line 439, in _codegen_impl
    _BaseSimpleStatement._codegen_impl(self, state)
  File "/Users/amir/projects/LibCST/libcst/_nodes/statement.py", line 385, in _codegen_impl
    stmt._codegen(state, default_semicolon=(idx != laststmt))
  File "/Users/amir/projects/LibCST/libcst/_nodes/base.py", line 298, in _codegen
    self._codegen_impl(state, **kwargs)
  File "/Users/amir/projects/LibCST/libcst/_nodes/statement.py", line 1370, in _codegen_impl
    self.annotation._codegen(state, default_indicator=":")
AttributeError: 'NoneType' object has no attribute '_codegen'
```

This issue does not exist for `Param` and `FunctionDef`.

## Test Plan
None yet!
The test suite successfully passes by `tox test`.
