### PR TITLE
Literal could be imported from typing_extensions too

### DIFF
--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -739,7 +739,7 @@ class ScopeVisitor(cst.CSTVisitor):
 
     def visit_Subscript(self, node: cst.Subscript) -> Optional[bool]:
         if any(
-            qn.name == "typing.Literal"
+            qn.name in ("typing.Literal", "typing_extensions.Literal")
             for qn in self.scope.get_qualified_names_for(node.value)
         ):
             node.value.visit(self)


### PR DESCRIPTION
## Summary

`Literal` is some times imported from `typing_extensions`

## Test Plan
Run tests
