### PR TITLE
[metadata] update return type of ParentNodeProvider to be CSTNode

### DIFF
--- a/libcst/metadata/parent_node_provider.py
+++ b/libcst/metadata/parent_node_provider.py
@@ -21,6 +21,6 @@ class ParentNodeVisitor(cst.CSTVisitor):
         super().on_leave(original_node)
 
 
-class ParentNodeProvider(BatchableMetadataProvider[Optional[cst.CSTNode]]):
+class ParentNodeProvider(BatchableMetadataProvider[cst.CSTNode]):
     def visit_Module(self, node: cst.Module) -> Optional[bool]:
         node.visit(ParentNodeVisitor(self))


### PR DESCRIPTION
## Summary
@Kronuz called out that the return type of `ParentNodeProvider` should NOT be an `Optional`.

That's true because the `original_node` set as metadata is always a `CSTNode`.
https://github.com/Instagram/LibCST/blob/c023fa7c4caff3fd2b3946080f9a58b539b10363/libcst/metadata/parent_node_provider.py#L18-L21

## Test Plan
Existing tests.
