### PR TITLE
[CI] add Fixit to tox -e lint

### DIFF
--- a/.fixit.config.yaml
+++ b/.fixit.config.yaml
@@ -1,0 +1,10 @@
+block_list_patterns:
+- '@generated'
+- '@nolint'
+block_list_rules: ["UseFstringRule", "CompareSingletonPrimitivesByIsRule"]
+fixture_dir: ./fixtures
+formatter: ["black", "-"]
+packages:
+- fixit.rules
+repo_root: libcst
+rule_config: {}

--- a/libcst/_parser/parso/pgen2/generator.py
+++ b/libcst/_parser/parso/pgen2/generator.py
@@ -321,8 +321,10 @@ def _calculate_tree_traversal(nonterminal_to_dfas):
                             ]
                         )
                         raise ValueError(
-                            "Rule %s is ambiguous; given a %s token, we "
-                            "can't determine if we should evaluate %s or %s."
+                            (
+                                "Rule %s is ambiguous; given a %s token, we "
+                                + "can't determine if we should evaluate %s or %s."
+                            )
                             % ((dfa_state.from_rule, transition) + tuple(choices))
                         )
                     transitions[transition] = DFAPlan(next_dfa, pushes)

--- a/libcst/_parser/parso/python/tokenize.py
+++ b/libcst/_parser/parso/python/tokenize.py
@@ -108,7 +108,7 @@ def _all_string_prefixes(
     if version_info < (3, 0) or version_info >= (3, 3):
         valid_string_prefixes.append("u")
 
-    result = set([""])
+    result = {""}
     if version_info >= (3, 6) and include_fstring:
         f = ["f", "fr"]
         if only_fstring:
@@ -326,7 +326,7 @@ class PythonToken(Token):
         )
 
 
-class FStringNode(object):
+class FStringNode:
     def __init__(self, quote):
         self.quote = quote
         self.parentheses_count = 0

--- a/libcst/_parser/parso/tests/test_utils.py
+++ b/libcst/_parser/parso/tests/test_utils.py
@@ -49,7 +49,7 @@ class ParsoUtilsTest(UnitTest):
     def test_python_bytes_to_unicode_unicode_text(self):
         source = (
             b"# vim: fileencoding=utf-8\n"
-            b"# \xe3\x81\x82\xe3\x81\x84\xe3\x81\x86\xe3\x81\x88\xe3\x81\x8a\n"
+            + b"# \xe3\x81\x82\xe3\x81\x84\xe3\x81\x86\xe3\x81\x88\xe3\x81\x8a\n"
         )
         actual = python_bytes_to_unicode(source)
         expected = source.decode("utf-8")

--- a/libcst/_parser/parso/utils.py
+++ b/libcst/_parser/parso/utils.py
@@ -184,8 +184,10 @@ def _parse_version(version: str) -> PythonVersionInfo:
     match = re.match(r"(\d+)(?:\.(\d+)(?:\.\d+)?)?$", version)
     if match is None:
         raise ValueError(
-            "The given version is not in the right format. "
-            'Use something like "3.2" or "3".'
+            (
+                "The given version is not in the right format. "
+                + 'Use something like "3.2" or "3".'
+            )
         )
 
     major = int(match.group(1))

--- a/libcst/_parser/tests/test_detect_config.py
+++ b/libcst/_parser/tests/test_detect_config.py
@@ -284,7 +284,7 @@ class TestDetectConfig(UnitTest):
             "future_imports_in_mixed_position": {
                 "source": (
                     b"from __future__ import a, b\nimport os\n"
-                    b"from __future__ import c\n"
+                    + b"from __future__ import c\n"
                 ),
                 "partial": PartialParserConfig(python_version="3.7"),
                 "detect_trailing_newline": True,

--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -585,7 +585,7 @@ def parallel_exec_transform_with_prettyprint(  # noqa: C901
 
     # Ensure that we have no duplicates, otherwise we might get race conditions
     # on write.
-    files = sorted(list(set(os.path.abspath(f) for f in files)))
+    files = sorted(list({os.path.abspath(f) for f in files}))
     total = len(files)
     progress = Progress(enabled=not hide_progress, total=total)
 

--- a/libcst/codemod/commands/ensure_import_present.py
+++ b/libcst/codemod/commands/ensure_import_present.py
@@ -44,7 +44,7 @@ class EnsureImportPresentCommand(MagicArgsCodemodCommand):
             metavar="ALIAS",
             help=(
                 "Alias that will be used for the imported module or entity. If left "
-                "empty, no alias will be applied."
+                + "empty, no alias will be applied."
             ),
             type=str,
             default=None,

--- a/libcst/codemod/commands/remove_unused_imports.py
+++ b/libcst/codemod/commands/remove_unused_imports.py
@@ -30,7 +30,7 @@ class RemoveUnusedImportsCommand(VisitorBasedCodemodCommand):
 
     DESCRIPTION: str = (
         "Remove all imports that are not used in a file. "
-        "Note: only considers the file in isolation. "
+        + "Note: only considers the file in isolation. "
     )
 
     METADATA_DEPENDENCIES: Tuple[ProviderT] = (PositionProvider,)

--- a/libcst/codemod/visitors/tests/test_gather_unused_imports.py
+++ b/libcst/codemod/visitors/tests/test_gather_unused_imports.py
@@ -17,10 +17,10 @@ class TestGatherUnusedImportsVisitor(UnitTest):
         mod.resolve_many(GatherUnusedImportsVisitor.METADATA_DEPENDENCIES)
         instance = GatherUnusedImportsVisitor(CodemodContext(wrapper=mod))
         mod.visit(instance)
-        return set(
+        return {
             alias.evaluated_alias or alias.evaluated_name
             for alias, _ in instance.unused_imports
-        )
+        }
 
     def test_no_imports(self) -> None:
         imports = self.gather_imports(

--- a/libcst/matchers/_matcher_base.py
+++ b/libcst/matchers/_matcher_base.py
@@ -352,8 +352,10 @@ class _ExtractMatchingNode(Generic[_MatcherT]):
         # same node, or none of them. It makes more sense to move the SaveMatchedNode
         # up to wrap the AllOf.
         raise Exception(
-            "Cannot use AllOf with SavedMatchedNode children! Instead, you should "
-            "use SaveMatchedNode(AllOf(options...))."
+            (
+                "Cannot use AllOf with SavedMatchedNode children! Instead, you should "
+                + "use SaveMatchedNode(AllOf(options...))."
+            )
         )
 
     def __getattr__(self, key: str) -> object:
@@ -366,8 +368,10 @@ class _ExtractMatchingNode(Generic[_MatcherT]):
         # This doesn't make sense. We don't want to capture a node only if it
         # doesn't match, since this will never capture anything.
         raise Exception(
-            "Cannot invert a SaveMatchedNode. Instead you should wrap SaveMatchedNode "
-            "around your inversion itself"
+            (
+                "Cannot invert a SaveMatchedNode. Instead you should wrap SaveMatchedNode "
+                + "around your inversion itself"
+            )
         )
 
     def __repr__(self) -> str:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 black>=19.10b0
 codecov>=2.1.4
 coverage>=4.5.4
+fixit>=0.1.0
 flake8>=3.7.8
 hypothesis>=4.36.0
 hypothesmith>=0.0.4

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ commands =
     flake8 {posargs}
     isort --check-only {posargs:.}
     black --check {posargs:libcst/}
+    python3 -m fixit.cli.run_rules
 
 [testenv:docs]
 deps =
@@ -32,6 +33,7 @@ commands =
     flake8 {posargs}
     isort -q {posargs:.}
     black {posargs:libcst/}
+    python3 -m fixit.cli.apply_fix
 
 [testenv:coverage]
 deps =


### PR DESCRIPTION
## Summary
- add Fixit to tox -e lint
- run apply_fix except for UseFstringRule and CompareSingletonPrimitivesByIsRule.
  - UseFstringRule: f-string is only supported in Python 3.6. Use f-string requires drop the support of Python 3.5 which is probably ok. Leave as future work.
  - CompareSingletonPrimitivesByIsRule has an issue and the autofix was wrong. Will follow up in Fixit.

## Test Plan
CI builds