### PR TITLE
Use correct type for AugAssign and AnnAssign target

### DIFF
--- a/libcst/_nodes/statement.py
+++ b/libcst/_nodes/statement.py
@@ -1332,7 +1332,7 @@ class AnnAssign(BaseSmallStatement):
     """
 
     #: The target that is being annotated and possibly assigned to.
-    target: BaseExpression
+    target: BaseAssignTargetExpression
 
     #: The annotation for the target.
     annotation: Annotation
@@ -1393,7 +1393,7 @@ class AugAssign(BaseSmallStatement):
     """
 
     #: Target that is being operated on and assigned to.
-    target: BaseExpression
+    target: BaseAssignTargetExpression
 
     #: The augmented assignment operation being performed.
     operator: BaseAugOp

--- a/libcst/_nodes/tests/base.py
+++ b/libcst/_nodes/tests/base.py
@@ -95,6 +95,12 @@ class CSTNodeTest(UnitTest):
         with self.assertRaisesRegex(cst.CSTValidationError, expected_re):
             get_node()
 
+    def assert_invalid_types(
+        self, get_node: Callable[[], cst.CSTNode], expected_re: str
+    ) -> None:
+        with self.assertRaisesRegex(TypeError, expected_re):
+            get_node().validate_types_shallow()
+
     def __assert_codegen(
         self,
         node: cst.CSTNode,

--- a/libcst/_nodes/tests/test_assign.py
+++ b/libcst/_nodes/tests/test_assign.py
@@ -119,6 +119,28 @@ class AssignTest(CSTNodeTest):
     def test_invalid(self, **kwargs: Any) -> None:
         self.assert_invalid(**kwargs)
 
+    @data_provider(
+        (
+            {
+                "get_node": (
+                    lambda: cst.Assign(
+                        targets=[
+                            cst.BinaryOperation(
+                                left=cst.Name("x"),
+                                operator=cst.Add(),
+                                right=cst.Integer("1"),
+                            ),
+                        ],
+                        value=cst.Name("y"),
+                    )
+                ),
+                "expected_re": "Expected an instance of .*statement.AssignTarget.*",
+            },
+        )
+    )
+    def test_invalid_types(self, **kwargs: Any) -> None:
+        self.assert_invalid_types(**kwargs)
+
 
 class AnnAssignTest(CSTNodeTest):
     @data_provider(
@@ -284,6 +306,30 @@ class AnnAssignTest(CSTNodeTest):
     def test_invalid(self, **kwargs: Any) -> None:
         self.assert_invalid(**kwargs)
 
+    @data_provider(
+        (
+            {
+                "get_node": (
+                    lambda: cst.AnnAssign(
+                        target=cst.BinaryOperation(
+                            left=cst.Name("x"),
+                            operator=cst.Add(),
+                            right=cst.Integer("1"),
+                        ),
+                        annotation=cst.Annotation(cst.Name("int")),
+                        equal=cst.AssignEqual(),
+                        value=cst.Name("y"),
+                    )
+                ),
+                "expected_re": (
+                    "Expected an instance of .*BaseAssignTargetExpression.*"
+                ),
+            },
+        )
+    )
+    def test_invalid_types(self, **kwargs: Any) -> None:
+        self.assert_invalid_types(**kwargs)
+
 
 class AugAssignTest(CSTNodeTest):
     @data_provider(
@@ -362,3 +408,26 @@ class AugAssignTest(CSTNodeTest):
     )
     def test_valid(self, **kwargs: Any) -> None:
         self.validate_node(**kwargs)
+
+    @data_provider(
+        (
+            {
+                "get_node": (
+                    lambda: cst.AugAssign(
+                        target=cst.BinaryOperation(
+                            left=cst.Name("x"),
+                            operator=cst.Add(),
+                            right=cst.Integer("1"),
+                        ),
+                        operator=cst.Add(),
+                        value=cst.Name("y"),
+                    )
+                ),
+                "expected_re": (
+                    "Expected an instance of .*BaseAssignTargetExpression.*"
+                ),
+            },
+        )
+    )
+    def test_invalid_types(self, **kwargs: Any) -> None:
+        self.assert_invalid_types(**kwargs)

--- a/libcst/_nodes/tests/test_assign.py
+++ b/libcst/_nodes/tests/test_assign.py
@@ -124,6 +124,7 @@ class AssignTest(CSTNodeTest):
             {
                 "get_node": (
                     lambda: cst.Assign(
+                        # pyre-ignore: Incompatible parameter type [6]
                         targets=[
                             cst.BinaryOperation(
                                 left=cst.Name("x"),
@@ -311,6 +312,7 @@ class AnnAssignTest(CSTNodeTest):
             {
                 "get_node": (
                     lambda: cst.AnnAssign(
+                        # pyre-ignore: Incompatible parameter type [6]
                         target=cst.BinaryOperation(
                             left=cst.Name("x"),
                             operator=cst.Add(),
@@ -414,6 +416,7 @@ class AugAssignTest(CSTNodeTest):
             {
                 "get_node": (
                     lambda: cst.AugAssign(
+                        # pyre-ignore: Incompatible parameter type [6]
                         target=cst.BinaryOperation(
                             left=cst.Name("x"),
                             operator=cst.Add(),

--- a/libcst/matchers/__init__.py
+++ b/libcst/matchers/__init__.py
@@ -223,10 +223,10 @@ class And(BaseBooleanOp, BaseMatcherNode):
     ] = DoNotCare()
 
 
-BaseExpressionMatchType = Union[
-    "BaseExpression",
+BaseAssignTargetExpressionMatchType = Union[
+    "BaseAssignTargetExpression",
     MetadataMatchType,
-    MatchIfTrue[Callable[[cst.BaseExpression], bool]],
+    MatchIfTrue[Callable[[cst.BaseAssignTargetExpression], bool]],
 ]
 AnnotationMatchType = Union[
     "Annotation", MetadataMatchType, MatchIfTrue[Callable[[cst.Annotation], bool]]
@@ -248,10 +248,10 @@ SemicolonMatchType = Union[
 @dataclass(frozen=True, eq=False, unsafe_hash=False)
 class AnnAssign(BaseSmallStatement, BaseMatcherNode):
     target: Union[
-        BaseExpressionMatchType,
+        BaseAssignTargetExpressionMatchType,
         DoNotCareSentinel,
-        OneOf[BaseExpressionMatchType],
-        AllOf[BaseExpressionMatchType],
+        OneOf[BaseAssignTargetExpressionMatchType],
+        AllOf[BaseAssignTargetExpressionMatchType],
     ] = DoNotCare()
     annotation: Union[
         AnnotationMatchType,
@@ -283,6 +283,13 @@ class AnnAssign(BaseSmallStatement, BaseMatcherNode):
         OneOf[MetadataMatchType],
         AllOf[MetadataMatchType],
     ] = DoNotCare()
+
+
+BaseExpressionMatchType = Union[
+    "BaseExpression",
+    MetadataMatchType,
+    MatchIfTrue[Callable[[cst.BaseExpression], bool]],
+]
 
 
 @dataclass(frozen=True, eq=False, unsafe_hash=False)
@@ -597,13 +604,6 @@ class AssignEqual(BaseMatcherNode):
     ] = DoNotCare()
 
 
-BaseAssignTargetExpressionMatchType = Union[
-    "BaseAssignTargetExpression",
-    MetadataMatchType,
-    MatchIfTrue[Callable[[cst.BaseAssignTargetExpression], bool]],
-]
-
-
 @dataclass(frozen=True, eq=False, unsafe_hash=False)
 class AssignTarget(BaseMatcherNode):
     target: Union[
@@ -852,10 +852,10 @@ BaseAugOpMatchType = Union[
 @dataclass(frozen=True, eq=False, unsafe_hash=False)
 class AugAssign(BaseSmallStatement, BaseMatcherNode):
     target: Union[
-        BaseExpressionMatchType,
+        BaseAssignTargetExpressionMatchType,
         DoNotCareSentinel,
-        OneOf[BaseExpressionMatchType],
-        AllOf[BaseExpressionMatchType],
+        OneOf[BaseAssignTargetExpressionMatchType],
+        AllOf[BaseAssignTargetExpressionMatchType],
     ] = DoNotCare()
     operator: Union[
         BaseAugOpMatchType,


### PR DESCRIPTION
## Summary
Closes #391 

Changes to `libcst/matchers/__init__.py` performed by `tox -e codegen`

## Test Plan
I couldn't find any relevant tests to extend but would be happy to write one.
