### PR TITLE
fix RemoveImportsVisitor crash when ImportAlias is inserted without comma

### DIFF
--- a/libcst/codemod/visitors/_remove_imports.py
+++ b/libcst/codemod/visitors/_remove_imports.py
@@ -374,12 +374,19 @@ class RemoveImportsVisitor(ContextAwareTransformer):
                 if len(names_to_keep) != 0:
                     # there is a previous import alias
                     prev = names_to_keep[-1]
-                    names_to_keep[-1] = prev.with_deep_changes(
-                        whitespace_after=_merge_whitespace_after(
-                            prev.comma.whitespace_after,
-                            comma.whitespace_after,
+                    if isinstance(prev.comma, cst.Comma):
+                        prev = prev.with_deep_changes(
+                            whitespace_after=_merge_whitespace_after(
+                                prev.comma.whitespace_after,
+                                comma.whitespace_after,
+                            )
                         )
-                    )
+                    else:
+                        # The previous alias didn't have a trailing comma. This can
+                        # occur if the alias was generated, instead of being parsed
+                        # from source.
+                        prev = prev.with_changes(comma=comma)
+                    names_to_keep[-1] = prev
                 else:
                     # No previous import alias, need to attach comment to `ImportFrom`.
                     # We can only do this if there was a leftparen on the import

--- a/libcst/codemod/visitors/_remove_imports.py
+++ b/libcst/codemod/visitors/_remove_imports.py
@@ -376,10 +376,11 @@ class RemoveImportsVisitor(ContextAwareTransformer):
                     prev = names_to_keep[-1]
                     if isinstance(prev.comma, cst.Comma):
                         prev = prev.with_deep_changes(
+                            prev.comma,
                             whitespace_after=_merge_whitespace_after(
                                 prev.comma.whitespace_after,
                                 comma.whitespace_after,
-                            )
+                            ),
                         )
                     else:
                         # The previous alias didn't have a trailing comma. This can

--- a/libcst/codemod/visitors/tests/test_remove_imports.py
+++ b/libcst/codemod/visitors/tests/test_remove_imports.py
@@ -80,6 +80,12 @@ class TestRemoveImportsCodemod(CodemodTest):
                 short,
                 this_stays_too
             )
+            from fourth import (
+                a,
+                # comment
+                b,
+                c
+            )
         """
         after = """
             from foo import (
@@ -92,6 +98,10 @@ class TestRemoveImportsCodemod(CodemodTest):
             from third import (
                 this_stays_too
             )
+            from fourth import (
+                a,
+                c
+            )
         """
         self.assertCodemod(
             before,
@@ -101,6 +111,7 @@ class TestRemoveImportsCodemod(CodemodTest):
                 ("loooong", "short", None),
                 ("loooong", "bar", None),
                 ("third", "short", None),
+                ("fourth", "b", None),
             ],
         )
 

--- a/libcst/codemod/visitors/tests/test_remove_imports.py
+++ b/libcst/codemod/visitors/tests/test_remove_imports.py
@@ -6,7 +6,7 @@
 import libcst as cst
 import libcst.matchers as m
 from libcst.codemod import CodemodContext, CodemodTest, VisitorBasedCodemodCommand
-from libcst.codemod.visitors import RemoveImportsVisitor, AddImportsVisitor
+from libcst.codemod.visitors import AddImportsVisitor, RemoveImportsVisitor
 from libcst.metadata import (
     QualifiedName,
     QualifiedNameProvider,


### PR DESCRIPTION
## Summary

The comment preserving logic introduced in #392 assumed that in an `ImportFrom` node, `ImportAlias`es have a `comma` property (except for the last one). That's only true if the `ImportFrom` node is parsed from actual source, but isn't necessarily true if it's constructed manually.

This PR adds a defensive check for the existence of a proper `Comma` node, and in case it doesn't exist (because it's a `MaybeSentinel`), the logic now just moves over the `Comma` node from the alias that's about to be removed.

## Test Plan

Added a test case that adds a new `ImportAlias` node manually (with `comma=MaybeSentinel.DEFAULT`), then removes the next alias.

