### PR TITLE
Support string annotations for type aliases

### DIFF
--- a/libcst/_parser/types/tests/test_config.py
+++ b/libcst/_parser/types/tests/test_config.py
@@ -12,7 +12,7 @@ from libcst.testing.utils import UnitTest, data_provider
 class TestConfig(UnitTest):
     @data_provider(
         {
-            "empty": (lambda: PartialParserConfig(),),
+            "empty": (PartialParserConfig,),
             "python_version_a": (lambda: PartialParserConfig(python_version="3.7"),),
             "python_version_b": (lambda: PartialParserConfig(python_version="3.7.1"),),
             "encoding": (lambda: PartialParserConfig(encoding="latin-1"),),

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -1018,8 +1018,8 @@ class ScopeProviderTest(UnitTest):
     def test_annotation_access(self) -> None:
         m, scopes = get_scope_metadata_provider(
             """
-                from typing import Literal, TypeVar
-                from a import A, B, C, D, E, F
+                from typing import Literal, NewType, Optional, TypeVar
+                from a import A, B, C, D, E, F, G, H
                 def x(a: A):
                     pass
                 def y(b: "B"):
@@ -1029,6 +1029,8 @@ class ScopeProviderTest(UnitTest):
                 DType = TypeVar("DType", bound=D)
                 EType = TypeVar("EType", bound="E")
                 FType = TypeVar("F")
+                GType = NewType("GType", "Optional[G]")
+                HType = Optional["H"]
             """
         )
         imp = ensure_type(
@@ -1067,6 +1069,18 @@ class ScopeProviderTest(UnitTest):
         assignment = list(scope["F"])[0]
         self.assertIsInstance(assignment, Assignment)
         self.assertEqual(len(assignment.references), 0)
+
+        assignment = list(scope["G"])[0]
+        self.assertIsInstance(assignment, Assignment)
+        self.assertEqual(len(assignment.references), 1)
+        references = list(assignment.references)
+        self.assertTrue(references[0].is_annotation)
+
+        assignment = list(scope["H"])[0]
+        self.assertIsInstance(assignment, Assignment)
+        self.assertEqual(len(assignment.references), 1)
+        references = list(assignment.references)
+        self.assertTrue(references[0].is_annotation)
 
     def test_node_of_scopes(self) -> None:
         m, scopes = get_scope_metadata_provider(

--- a/libcst/tests/test_type_enforce.py
+++ b/libcst/tests/test_type_enforce.py
@@ -53,6 +53,7 @@ class MyExampleClassWithMetaclass(metaclass=MyExampleMetaclass):
     pass
 
 
+# lint-ignore: NoNamedTupleRule
 class NamedTupleSubclass(NamedTuple):
     a: str
     b: int


### PR DESCRIPTION
## Summary

Add support for string annotations in type aliases.

## Test Plan

Run tests.

This will support things like:

```py
from typing import Dict, Union
from video import VideoType
VideoDict = Dict[str, Union[str, int, "VideoType"]]
```

And get a properly referenced `VideoType`.