### PR TITLE
Codemod CLI multiprocessing simplification

### DIFF
--- a/libcst/codemod/_dummy_pool.py
+++ b/libcst/codemod/_dummy_pool.py
@@ -1,0 +1,35 @@
+from types import TracebackType
+from typing import Callable, Generator, Iterable, Optional, Type, TypeVar
+
+
+RetT = TypeVar("RetT")
+ArgT = TypeVar("ArgT")
+
+
+class DummyPool:
+    """
+    Synchronous dummy `multiprocessing.Pool` analogue.
+    """
+
+    def __init__(self, processes: Optional[int] = None) -> None:
+        pass
+
+    def imap_unordered(
+        self,
+        func: Callable[[ArgT], RetT],
+        iterable: Iterable[ArgT],
+        chunksize: Optional[int] = None,
+    ) -> Generator[RetT, None, None]:
+        for args in iterable:
+            yield func(args)
+
+    def __enter__(self) -> "DummyPool":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[Exception]],
+        exc: Optional[Exception],
+        tb: Optional[TracebackType],
+    ) -> None:
+        pass


### PR DESCRIPTION
## Summary

This PR refactors some of the codemod CLI internals to:

* use a simple "execution configuration" dataclass instead of passing a number of kwargs around
* use the default `multiprocessing.Pool()` instead of managing processes and queues by hand
* simplify the special-casing of a single file being processed by `parallel_exec_transform_with_prettyprint` to use a synchronous stub "multiprocessing" Pool instead

These changes pave the way to surfacing `_execute_transform()` (née `_parallel_exec_process_stub()`) as a public API, which would be useful for writing wrapper tools (like `django-codemod`, via which I came across LibCST in https://github.com/browniebroke/django-codemod/pull/233) that could opt-in to doing either parallel or serial codemod processing as they like.

## Test Plan

This is an internal change; no tests need editing.
