### PR TITLE
Bump to version 0.3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.3.13 - 2020-10-12
+
+## Fixed
+- Use correct type for AugAssign and AnnAssign target [#396](https://github.com/Instagram/LibCST/pull/396)
+- Support string annotations for type aliases [#401](https://github.com/Instagram/LibCST/pull/401)
+
 # 0.3.12 - 2020-10-01
 
 ## Fixed

--- a/libcst/_version.py
+++ b/libcst/_version.py
@@ -4,4 +4,4 @@
 # LICENSE file in the root directory of this source tree.
 
 
-LIBCST_VERSION: str = "0.3.12"
+LIBCST_VERSION: str = "0.3.13"


### PR DESCRIPTION
## Summary

Bump to version 0.3.13

## Fixed

- Use correct type for AugAssign and AnnAssign target [#396](https://github.com/Instagram/LibCST/pull/396)
- Support string annotations for type aliases [#401](https://github.com/Instagram/LibCST/pull/401)