### PR TITLE
fix is_annotation for types used in classdef base and assign value

### DIFF
--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -725,7 +725,7 @@ class ScopeVisitor(cst.CSTVisitor):
     def visit_Assign_value(self, node: cst.Assign) -> None:
         self.__ignore_annotation += 1
 
-    def leave_Assign_value(self, original_node: cst.Assign) -> None:
+    def leave_Assign_value(self, node: cst.Assign) -> None:
         self.__ignore_annotation -= 1
 
     def visit_SimpleString(self, node: cst.SimpleString) -> Optional[bool]:
@@ -833,7 +833,7 @@ class ScopeVisitor(cst.CSTVisitor):
     def visit_ClassDef_bases(self, node: cst.ClassDef) -> None:
         self.__ignore_annotation += 1
 
-    def leave_ClassDef_bases(self, original_node: cst.ClassDef) -> None:
+    def leave_ClassDef_bases(self, node: cst.ClassDef) -> None:
         self.__ignore_annotation -= 1
 
     def visit_Global(self, node: cst.Global) -> Optional[bool]:

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -1019,7 +1019,7 @@ class ScopeProviderTest(UnitTest):
         m, scopes = get_scope_metadata_provider(
             """
                 from typing import Literal, NewType, Optional, TypeVar
-                from a import A, B, C, D, E, F, G, H
+                from a import A, B, C, D, E, F, G, H, I, J
                 def x(a: A):
                     pass
                 def y(b: "B"):
@@ -1031,6 +1031,10 @@ class ScopeProviderTest(UnitTest):
                 FType = TypeVar("F")
                 GType = NewType("GType", "Optional[G]")
                 HType = Optional["H"]
+                alias = Callable[..., I]
+
+                class Test(Generic[J]):
+                    pass
             """
         )
         imp = ensure_type(
@@ -1058,13 +1062,11 @@ class ScopeProviderTest(UnitTest):
         self.assertIsInstance(assignment, Assignment)
         self.assertEqual(len(assignment.references), 1)
         references = list(assignment.references)
-        self.assertTrue(references[0].is_annotation)
+        self.assertFalse(references[0].is_annotation)
 
         assignment = list(scope["E"])[0]
         self.assertIsInstance(assignment, Assignment)
-        self.assertEqual(len(assignment.references), 1)
-        references = list(assignment.references)
-        self.assertTrue(references[0].is_annotation)
+        self.assertEqual(len(assignment.references), 0)
 
         assignment = list(scope["F"])[0]
         self.assertIsInstance(assignment, Assignment)
@@ -1072,15 +1074,23 @@ class ScopeProviderTest(UnitTest):
 
         assignment = list(scope["G"])[0]
         self.assertIsInstance(assignment, Assignment)
-        self.assertEqual(len(assignment.references), 1)
-        references = list(assignment.references)
-        self.assertTrue(references[0].is_annotation)
+        self.assertEqual(len(assignment.references), 0)
 
         assignment = list(scope["H"])[0]
         self.assertIsInstance(assignment, Assignment)
+        self.assertEqual(len(assignment.references), 0)
+
+        assignment = list(scope["I"])[0]
+        self.assertIsInstance(assignment, Assignment)
         self.assertEqual(len(assignment.references), 1)
         references = list(assignment.references)
-        self.assertTrue(references[0].is_annotation)
+        self.assertFalse(references[0].is_annotation)
+
+        assignment = list(scope["J"])[0]
+        self.assertIsInstance(assignment, Assignment)
+        self.assertEqual(len(assignment.references), 1)
+        references = list(assignment.references)
+        self.assertFalse(references[0].is_annotation)
 
     def test_node_of_scopes(self) -> None:
         m, scopes = get_scope_metadata_provider(

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -1018,7 +1018,7 @@ class ScopeProviderTest(UnitTest):
     def test_annotation_access(self) -> None:
         m, scopes = get_scope_metadata_provider(
             """
-                from typing import Literal, NewType, Optional, TypeVar
+                from typing import Literal, NewType, Optional, TypeVar, Callable
                 from a import A, B, C, D, E, F, G, H, I, J
                 def x(a: A):
                     pass
@@ -1031,7 +1031,7 @@ class ScopeProviderTest(UnitTest):
                 FType = TypeVar("F")
                 GType = NewType("GType", "Optional[G]")
                 HType = Optional["H"]
-                alias = Callable[..., I]
+                IType = Callable[..., I]
 
                 class Test(Generic[J]):
                     pass
@@ -1063,12 +1063,14 @@ class ScopeProviderTest(UnitTest):
         self.assertEqual(len(assignment.references), 1)
         references = list(assignment.references)
         self.assertFalse(references[0].is_annotation)
+        self.assertTrue(references[0].is_type_hint)
 
         assignment = list(scope["E"])[0]
         self.assertIsInstance(assignment, Assignment)
         self.assertEqual(len(assignment.references), 1)
         references = list(assignment.references)
         self.assertFalse(references[0].is_annotation)
+        self.assertTrue(references[0].is_type_hint)
 
         assignment = list(scope["F"])[0]
         self.assertIsInstance(assignment, Assignment)
@@ -1079,12 +1081,14 @@ class ScopeProviderTest(UnitTest):
         self.assertEqual(len(assignment.references), 1)
         references = list(assignment.references)
         self.assertFalse(references[0].is_annotation)
+        self.assertTrue(references[0].is_type_hint)
 
         assignment = list(scope["H"])[0]
         self.assertIsInstance(assignment, Assignment)
         self.assertEqual(len(assignment.references), 1)
         references = list(assignment.references)
         self.assertFalse(references[0].is_annotation)
+        self.assertTrue(references[0].is_type_hint)
 
         assignment = list(scope["I"])[0]
         self.assertIsInstance(assignment, Assignment)

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -1066,7 +1066,9 @@ class ScopeProviderTest(UnitTest):
 
         assignment = list(scope["E"])[0]
         self.assertIsInstance(assignment, Assignment)
-        self.assertEqual(len(assignment.references), 0)
+        self.assertEqual(len(assignment.references), 1)
+        references = list(assignment.references)
+        self.assertFalse(references[0].is_annotation)
 
         assignment = list(scope["F"])[0]
         self.assertIsInstance(assignment, Assignment)
@@ -1074,11 +1076,15 @@ class ScopeProviderTest(UnitTest):
 
         assignment = list(scope["G"])[0]
         self.assertIsInstance(assignment, Assignment)
-        self.assertEqual(len(assignment.references), 0)
+        self.assertEqual(len(assignment.references), 1)
+        references = list(assignment.references)
+        self.assertFalse(references[0].is_annotation)
 
         assignment = list(scope["H"])[0]
         self.assertIsInstance(assignment, Assignment)
-        self.assertEqual(len(assignment.references), 0)
+        self.assertEqual(len(assignment.references), 1)
+        references = list(assignment.references)
+        self.assertFalse(references[0].is_annotation)
 
         assignment = list(scope["I"])[0]
         self.assertIsInstance(assignment, Assignment)


### PR DESCRIPTION
## Summary
fix is_annotation for types used in classdef base and assign value
discussion
## Test Plan
tox -e py37
tox -e autofix
