### PR TITLE
[scope] Visit concatenated f-strings

### DIFF
--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -590,7 +590,7 @@ def parallel_exec_transform_with_prettyprint(  # noqa: C901
     progress = Progress(enabled=not hide_progress, total=total)
 
     # Grab number of cores if we need to
-    jobs: int = jobs or cpu_count()
+    jobs: int = jobs if jobs is not None else cpu_count()
 
     if jobs < 1:
         raise Exception("Must have at least one job to process!")
@@ -598,7 +598,7 @@ def parallel_exec_transform_with_prettyprint(  # noqa: C901
     if total == 0:
         return ParallelTransformResult(successes=0, failures=0, skips=0, warnings=0)
 
-    if repo_root:
+    if repo_root is not None:
         # Make sure if there is a root that we have the absolute path to it.
         repo_root = os.path.abspath(repo_root)
         # Spin up a full repo metadata manager so that we can provide metadata

--- a/libcst/codemod/commands/convert_format_to_fstring.py
+++ b/libcst/codemod/commands/convert_format_to_fstring.py
@@ -295,7 +295,7 @@ class ConvertFormatStringCommand(VisitorBasedCodemodCommand):
                         spec_format_spec,
                         spec_conversion,
                     ) in format_spec_tokens:
-                        if spec_format_spec:
+                        if spec_format_spec is not None:
                             # This shouldn't be possible, we don't allow it in the spec!
                             raise Exception("Logic error!")
                         if spec_literal_text:

--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -20,7 +20,7 @@ def _get_import_alias_names(import_aliases: Sequence[cst.ImportAlias]) -> Set[st
     import_names = set()
     for imported_name in import_aliases:
         asname = imported_name.asname
-        if asname:
+        if asname is not None:
             import_names.add(get_full_name_for_node(asname.name))
         else:
             import_names.add(get_full_name_for_node(imported_name.name))
@@ -242,7 +242,9 @@ class ApplyTypeAnnotationsVisitor(ContextAwareTransformer):
         super().__init__(context)
         # Qualifier for storing the canonical name of the current function.
         self.qualifier: List[str] = []
-        self.annotations: Annotations = annotations or Annotations()
+        self.annotations: Annotations = (
+            Annotations() if annotations is None else annotations
+        )
         self.toplevel_annotations: Dict[str, cst.Annotation] = {}
         self.visited_classes: Set[str] = set()
         self.overwrite_existing_annotations = overwrite_existing_annotations
@@ -297,7 +299,7 @@ class ApplyTypeAnnotationsVisitor(ContextAwareTransformer):
         context_contents = self.context.scratch.get(
             ApplyTypeAnnotationsVisitor.CONTEXT_KEY
         )
-        if context_contents:
+        if context_contents is not None:
             stub, overwrite_existing_annotations = context_contents
             self.overwrite_existing_annotations = (
                 self.overwrite_existing_annotations or overwrite_existing_annotations

--- a/libcst/helpers/_statement.py
+++ b/libcst/helpers/_statement.py
@@ -31,7 +31,7 @@ def get_absolute_module_for_import(
         return None
     base_module = ".".join(modules[:-num_dots])
     # Finally, if the module name was supplied, append it to the end.
-    if module_name:
+    if module_name is not None:
         # If we went all the way to the top, the base module should be empty, so we
         # should return the relative bit as absolute. Otherwise, combine the base
         # module and module name using a dot separator.

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -733,12 +733,12 @@ class ScopeVisitor(cst.CSTVisitor):
         return False
 
     def visit_ConcatenatedString(self, node: cst.ConcatenatedString) -> Optional[bool]:
-        self._handle_string_annotation(node)
-        return False
+        return not self._handle_string_annotation(node)
 
     def _handle_string_annotation(
         self, node: Union[cst.SimpleString, cst.ConcatenatedString]
-    ) -> None:
+    ) -> bool:
+        """Returns whether it successfully handled the string annotation"""
         if (
             self.__in_type_hint or self.__in_annotation
         ) and not self.__in_ignored_subscript:
@@ -746,6 +746,8 @@ class ScopeVisitor(cst.CSTVisitor):
             if value:
                 mod = cst.parse_module(value)
                 mod.visit(self)
+                return True
+        return False
 
     def visit_Subscript(self, node: cst.Subscript) -> Optional[bool]:
         qnames = self.scope.get_qualified_names_for(node.value)

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -111,6 +111,25 @@ class ScopeProviderTest(UnitTest):
         wrapper = MetadataWrapper(cst.parse_module("def a():\n    from b import c\n\n"))
         wrapper.visit(DependentVisitor())
 
+    def test_fstring_accesses(self) -> None:
+        m, scopes = get_scope_metadata_provider(
+            """
+            from a import b
+            f"{b}" "hello"
+            """
+        )
+        global_scope = scopes[m]
+        self.assertIsInstance(global_scope, GlobalScope)
+        global_accesses = list(global_scope.accesses)
+        self.assertEqual(len(global_accesses), 1)
+        import_node = ensure_type(
+            ensure_type(m.body[0], cst.SimpleStatementLine).body[0], cst.ImportFrom
+        )
+        b_referent = list(global_accesses[0].referents)[0]
+        self.assertIsInstance(b_referent, Assignment)
+        assert isinstance(b_referent, Assignment)  # for the typechecker's eyes
+        self.assertEqual(b_referent.node, import_node)
+
     @data_provider((("any",), ("True",), ("Exception",), ("__name__",)))
     def test_builtins(self, builtin: str) -> None:
         m, scopes = get_scope_metadata_provider(

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -127,8 +127,8 @@ class ScopeProviderTest(UnitTest):
         )
         b_referent = list(global_accesses[0].referents)[0]
         self.assertIsInstance(b_referent, Assignment)
-        assert isinstance(b_referent, Assignment)  # for the typechecker's eyes
-        self.assertEqual(b_referent.node, import_node)
+        if isinstance(b_referent, Assignment):  # for the typechecker's eyes
+            self.assertEqual(b_referent.node, import_node)
 
     @data_provider((("any",), ("True",), ("Exception",), ("__name__",)))
     def test_builtins(self, builtin: str) -> None:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,12 @@
-black>=19.10b0
+black==20.8b1
 codecov>=2.1.4
 coverage>=4.5.4
-fixit>=0.1.0
+fixit==0.1.1
 flake8>=3.7.8
 hypothesis>=4.36.0
 hypothesmith>=0.0.4
 git+https://github.com/jimmylai/sphinx.git@slots_type_annotation
-isort>=4.3.20
+isort==5.5.3
 jupyter>=1.0.0
 nbsphinx>=0.4.2
 pyre-check==0.0.41


### PR DESCRIPTION
## Summary

This PR makes sure scope analysis visits nodes under a `ConcatenatedString`. This is important because `ConcatenatedString`s may contain `FormattedString`s which can contain further expressions. We only need to go deeper if the concatenated string is not part of a type annotation though (those can't contain f-strings).

Fixes #410.

## Test Plan

Added unit test.
