### PR TITLE
[scope] keep track of assignment/access ordering

### DIFF
--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -1310,3 +1310,51 @@ class ScopeProviderTest(UnitTest):
             )
         }
         self.assertEqual(names, {"a.b.c", "a.b", "a"})
+
+    def test_ordering(self) -> None:
+        m, scopes = get_scope_metadata_provider(
+            """
+            from a import b
+            class X:
+                x = b
+                b = b
+                y = b
+            """
+        )
+        global_scope = scopes[m]
+        import_stmt = ensure_type(
+            ensure_type(m.body[0], cst.SimpleStatementLine).body[0], cst.ImportFrom
+        )
+        first_assignment = list(global_scope.assignments)[0]
+        assert isinstance(first_assignment, cst.metadata.Assignment)
+        self.assertEqual(first_assignment.node, import_stmt)
+        global_refs = list(first_assignment.references)
+        self.assertEqual(len(global_refs), 2)
+        class_def = ensure_type(m.body[1], cst.ClassDef)
+        x = ensure_type(
+            ensure_type(class_def.body.body[0], cst.SimpleStatementLine).body[0],
+            cst.Assign,
+        )
+        self.assertEqual(x.value, global_refs[0].node)
+        class_b = ensure_type(
+            ensure_type(class_def.body.body[1], cst.SimpleStatementLine).body[0],
+            cst.Assign,
+        )
+        self.assertEqual(class_b.value, global_refs[1].node)
+
+        class_accesses = list(scopes[x].accesses)
+        self.assertEqual(len(class_accesses), 3)
+        self.assertIn(
+            class_b.targets[0].target,
+            [
+                ref.node
+                for acc in class_accesses
+                for ref in acc.referents
+                if isinstance(ref, Assignment)
+            ],
+        )
+        y = ensure_type(
+            ensure_type(class_def.body.body[2], cst.SimpleStatementLine).body[0],
+            cst.Assign,
+        )
+        self.assertIn(y.value, [access.node for access in class_accesses])


### PR DESCRIPTION
## Summary
This PR makes sure references are never attached to assignments that are declared later than the access (but still in the same scope). It does so by keeping track of the relative ordering of accesses to assignments, through the inclusion of an `__index` member in both. The idea is to increment the index every time an assignment "happens" in a scope. This is a bit tricky because for `a = b`, the right hand side cannot refer to variables on the left side even if the left side is visited first.

Fixes #326 

## Test Plan

Added extensive test case for a variable shadowing in a class/global scope scenario.

