### PR TITLE
Correct handling of walrus operator in function args

### DIFF
--- a/libcst/_nodes/tests/test_namedexpr.py
+++ b/libcst/_nodes/tests/test_namedexpr.py
@@ -101,6 +101,71 @@ class NamedExprTest(CSTNodeTest):
                 "parser": _parse_statement_force_38,
                 "expected_position": None,
             },
+            # Function args
+            {
+                "node": cst.Call(
+                    func=cst.Name(value="f"),
+                    args=[
+                        cst.Arg(
+                            value=cst.NamedExpr(
+                                target=cst.Name(value="y"),
+                                value=cst.Integer(value="1"),
+                                whitespace_before_walrus=cst.SimpleWhitespace(""),
+                                whitespace_after_walrus=cst.SimpleWhitespace(""),
+                            )
+                        ),
+                    ],
+                ),
+                "code": "f(y:=1)",
+                "parser": _parse_expression_force_38,
+                "expected_position": None,
+            },
+            # Whitespace handling on args is fragile
+            {
+                "node": cst.Call(
+                    func=cst.Name(value="f"),
+                    args=[
+                        cst.Arg(
+                            value=cst.Name(value="x"),
+                            comma=cst.Comma(
+                                whitespace_after=cst.SimpleWhitespace("  ")
+                            ),
+                        ),
+                        cst.Arg(
+                            value=cst.NamedExpr(
+                                target=cst.Name(value="y"),
+                                value=cst.Integer(value="1"),
+                                whitespace_before_walrus=cst.SimpleWhitespace("   "),
+                                whitespace_after_walrus=cst.SimpleWhitespace("    "),
+                            ),
+                            whitespace_after_arg=cst.SimpleWhitespace("     "),
+                        ),
+                    ],
+                ),
+                "code": "f(x,  y   :=    1     )",
+                "parser": _parse_expression_force_38,
+                "expected_position": None,
+            },
+            {
+                "node": cst.Call(
+                    func=cst.Name(value="f"),
+                    args=[
+                        cst.Arg(
+                            value=cst.NamedExpr(
+                                target=cst.Name(value="y"),
+                                value=cst.Integer(value="1"),
+                                whitespace_before_walrus=cst.SimpleWhitespace("   "),
+                                whitespace_after_walrus=cst.SimpleWhitespace("    "),
+                            ),
+                            whitespace_after_arg=cst.SimpleWhitespace("     "),
+                        ),
+                    ],
+                    whitespace_before_args=cst.SimpleWhitespace("  "),
+                ),
+                "code": "f(  y   :=    1     )",
+                "parser": _parse_expression_force_38,
+                "expected_position": None,
+            },
         )
     )
     def test_valid(self, **kwargs: Any) -> None:

--- a/libcst/_parser/conversions/expression.py
+++ b/libcst/_parser/conversions/expression.py
@@ -1441,8 +1441,16 @@ def convert_arg_assign_comp_for(
         elt, for_in = children
         return Arg(value=GeneratorExp(elt.value, for_in, lpar=(), rpar=()))
     else:
-        # "key = value" assignment argument
         lhs, equal, rhs = children
+        # "key := value" assignment; positional
+        if equal.string == ":=":
+            val = convert_namedexpr_test(config, children)
+            if not isinstance(val, WithLeadingWhitespace):
+                raise Exception(
+                    f"convert_namedexpr_test returned {val!r}, not WithLeadingWhitespace"
+                )
+            return Arg(value=val.value)
+        # "key = value" assignment; keyword argument
         return Arg(
             keyword=lhs.value,
             equal=AssignEqual(


### PR DESCRIPTION
## Summary

Previous behavior treated it as identical to equal, making a kwarg; it should
instead be a positional arg.  Includes several tests to make sure that
whitespace handling is correct.

Fixes #416

## Test Plan

Includes new tests that were failing before.  I had some trouble ensuring the whitespace ended up in the right spot during development, so this includes a few probably unnecessary tests out of a general distrust that I did it right.
