### PR TITLE
Allow generator expressions in f-strings

### DIFF
--- a/libcst/_nodes/tests/test_atom.py
+++ b/libcst/_nodes/tests/test_atom.py
@@ -668,6 +668,35 @@ class AtomTest(CSTNodeTest):
                 "parser": parse_expression,
                 "expected_position": CodeRange((1, 1), (1, 4)),
             },
+            # Generator expression (doesn't make sense, but legal syntax)
+            {
+                "node": cst.FormattedString(
+                    start='f"',
+                    parts=[
+                        cst.FormattedStringExpression(
+                            expression=cst.GeneratorExp(
+                                elt=cst.Name(
+                                    value="x",
+                                ),
+                                for_in=cst.CompFor(
+                                    target=cst.Name(
+                                        value="x",
+                                    ),
+                                    iter=cst.Name(
+                                        value="y",
+                                    ),
+                                ),
+                                lpar=[],
+                                rpar=[],
+                            ),
+                        ),
+                    ],
+                    end='"',
+                ),
+                "code": 'f"{x for x in y}"',
+                "parser": parse_expression,
+                "expected_position": None,
+            },
             # Concatenated strings
             {
                 "node": cst.ConcatenatedString(

--- a/libcst/_parser/conversions/expression.py
+++ b/libcst/_parser/conversions/expression.py
@@ -1038,12 +1038,12 @@ def convert_fstring_equality(
 
 @with_production(
     "fstring_expr",
-    "'{' testlist [ fstring_equality ] [ fstring_conversion ] [ fstring_format_spec ] '}'",
+    "'{' testlist_comp_tuple [ fstring_equality ] [ fstring_conversion ] [ fstring_format_spec ] '}'",
     version=">=3.8",
 )
 @with_production(
     "fstring_expr",
-    "'{' testlist [ fstring_conversion ] [ fstring_format_spec ] '}'",
+    "'{' testlist_comp_tuple [ fstring_conversion ] [ fstring_format_spec ] '}'",
     version="<=3.7",
 )
 def convert_fstring_expr(


### PR DESCRIPTION
Fixes #388

## Summary

I'm kind of dogsciencing this, since there doesn't appear to be a formal grammar for f-strings. I tested a few other languages features and am pretty confident the only major feature that works in 3.8 that we didn't have was bare generator expressions.

## Test Plan

Includes new test, also tested on John's longer example.
