### PR TITLE
fix assignment/access ordering in comprehensions

### DIFF
--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -36,6 +36,8 @@ from libcst.metadata.expression_context_provider import (
 )
 
 
+# Comprehensions are handled separately in _visit_comp_alike due to
+# the complexity of the semantics
 _ASSIGNMENT_LIKE_NODES = (
     cst.AnnAssign,
     cst.AsName,
@@ -973,6 +975,8 @@ class ScopeVisitor(cst.CSTVisitor):
         self.provider.set_metadata(for_in, self.scope)
         with self._new_scope(ComprehensionScope, node):
             for_in.target.visit(self)
+            # Things from here on can refer to the target.
+            self.scope._assignment_count += 1
             for condition in for_in.ifs:
                 condition.visit(self)
             inner_for_in = for_in.inner_for_in

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
+from libcst._nodes.statement import Assign
 from textwrap import dedent
 from typing import Mapping, Tuple, cast
 
@@ -1509,9 +1510,10 @@ class ScopeProviderTest(UnitTest):
         # We record both assignments because it's impossible to know which one
         # the access refers to without running the program
         self.assertEqual(len(a_third_comp_access.referents), 2)
+        assert third_comp.for_in.inner_for_in is not None
         self.assertIn(
             third_comp.for_in.inner_for_in.target,
-            {ref.node for ref in a_third_comp_access.referents},
+            {ref.node for ref in a_third_comp_access.referents if isinstance(ref, Assignment)},
         )
 
         a_global = (

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 
 
-from libcst._nodes.statement import Assign
 from textwrap import dedent
 from typing import Mapping, Tuple, cast
 
@@ -1510,11 +1509,17 @@ class ScopeProviderTest(UnitTest):
         # We record both assignments because it's impossible to know which one
         # the access refers to without running the program
         self.assertEqual(len(a_third_comp_access.referents), 2)
-        assert third_comp.for_in.inner_for_in is not None
-        self.assertIn(
-            third_comp.for_in.inner_for_in.target,
-            {ref.node for ref in a_third_comp_access.referents if isinstance(ref, Assignment)},
-        )
+        inner_for_in = third_comp.for_in.inner_for_in
+        self.assertIsNotNone(inner_for_in)
+        if inner_for_in:
+            self.assertIn(
+                inner_for_in.target,
+                {
+                    ref.node
+                    for ref in a_third_comp_access.referents
+                    if isinstance(ref, Assignment)
+                },
+            )
 
         a_global = (
             cst.ensure_type(


### PR DESCRIPTION
## Summary
This change fixes attaching accesses to the right assignment in list comprehensions, so in
```
a = 1
[a for a in [1,2,3]]
```
The `a` at the beginning of the list comprehension is now attached to the `a` declared after `for` instead of the declaration on the first line.
## Test Plan
Added unit tests
