### PR TITLE
Gathering exports in augmented assignment statements

### DIFF
--- a/libcst/codemod/visitors/tests/test_gather_exports.py
+++ b/libcst/codemod/visitors/tests/test_gather_exports.py
@@ -47,6 +47,18 @@ class TestGatherExportsVisitor(UnitTest):
         gatherer = self.gather_exports(code)
         self.assertEqual(gatherer.explicit_exported_objects, {"bar", "baz"})
 
+    def test_gather_exports_simple2(self) -> None:
+        code = """
+            from foo import bar
+            from biz import baz
+
+            __all__ = ["bar"]
+            __all__ += ["baz"]
+        """
+
+        gatherer = self.gather_exports(code)
+        self.assertEqual(gatherer.explicit_exported_objects, {"bar", "baz"})
+
     def test_gather_exports_simple_set(self) -> None:
         code = """
             from foo import bar


### PR DESCRIPTION
## Summary
Add support for gathering exports in `__all__` augmented assignments, such as:

```
import os
__all__ = []
__all__ += ["os"]
```

## Test Plan
Run existing tests