### PR TITLE
Handle scope ordering in For statements

### DIFF
--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -45,7 +45,6 @@ _ASSIGNMENT_LIKE_NODES = (
     cst.AugAssign,
     cst.ClassDef,
     cst.CompFor,
-    cst.For,
     cst.FunctionDef,
     cst.Global,
     cst.Import,

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -993,6 +993,14 @@ class ScopeVisitor(cst.CSTVisitor):
                 node.elt.visit(self)
         return False
 
+    def visit_For(self, node: cst.For) -> Optional[bool]:
+        node.target.visit(self)
+        self.scope._assignment_count += 1
+        for child in [node.iter, node.body, node.orelse, node.asynchronous]:
+            if child is not None:
+                child.visit(self)
+        return False
+
     def infer_accesses(self) -> None:
         # Aggregate access with the same name and batch add with set union as an optimization.
         # In worst case, all accesses (m) and assignments (n) refer to the same name,

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -1568,6 +1568,29 @@ class ScopeProviderTest(UnitTest):
         self.assertEqual(len(a_comp_assignment.references), 1)
         self.assertEqual(list(a_comp_assignment.references)[0].node, comp.elt)
 
+    def test_for_scope_ordering(self) -> None:
+        m, scopes = get_scope_metadata_provider(
+            """
+            def f():
+                for x in []:
+                    x
+            class X:
+                def f():
+                    for x in []:
+                        x
+            """
+        )
+        for scope in scopes.values():
+            for acc in scope.accesses:
+                self.assertEqual(
+                    len(acc.referents),
+                    1,
+                    msg=(
+                        "Access for node has incorrect number of referents: "
+                        + f"{acc.node}"
+                    ),
+                )
+
     def test_cast(self) -> None:
         with self.assertRaises(cst.ParserSyntaxError):
             m, scopes = get_scope_metadata_provider(


### PR DESCRIPTION
## Summary
When visiting `for ... in ... :` statements, the scope provider was incrementing the assignment counter _after_ the entire `For` statement was visited. This meant that all accesses to `For.target` in `For.body` were potentially attached to the wrong scope. The only exception to this was when the scope of the `For` statement was in the global scope, in which case the fallback logic accidentally saved us (because for the global scope, `scope.parent == scope`).

This PR fixes the bug by customizing the way `ScopeProvider` visits `For` statements, and increments the assignment counter directly after visiting `For.target`.

## Test Plan

Added a test case.

