### PR TITLE
Don't allow out of order accesses in the global scope

### DIFF
--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -124,7 +124,7 @@ class Access:
             for assignment in assignments
             if assignment.scope != self.scope or assignment._index < self.__index
         }
-        if not previous_assignments and assignments:
+        if not previous_assignments and assignments and self.scope.parent != self.scope:
             previous_assignments = self.scope.parent[name]
         self.__assignments |= previous_assignments
 

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -1591,6 +1591,24 @@ class ScopeProviderTest(UnitTest):
                     ),
                 )
 
+    def test_no_out_of_order_references_in_global_scope(self) -> None:
+        m, scopes = get_scope_metadata_provider(
+            """
+            x = y
+            y = 1
+            """
+        )
+        for scope in scopes.values():
+            for acc in scope.accesses:
+                self.assertEqual(
+                    len(acc.referents),
+                    0,
+                    msg=(
+                        "Access for node has incorrect number of referents: "
+                        + f"{acc.node}"
+                    ),
+                )
+
     def test_cast(self) -> None:
         with self.assertRaises(cst.ParserSyntaxError):
             m, scopes = get_scope_metadata_provider(


### PR DESCRIPTION
## Summary

While investigating #430 I realized that scope provider might attach accesses to assignments AFTER the access in the global scope. This PR fixes that bug.

## Test Plan

Added test case and verified it fails before this PR.
