### PR TITLE
Walrus operator's left hand side now has STORE expression context

### DIFF
--- a/libcst/metadata/expression_context_provider.py
+++ b/libcst/metadata/expression_context_provider.py
@@ -84,6 +84,13 @@ class ExpressionContextVisitor(cst.CSTVisitor):
         node.value.visit(self)
         return False
 
+    def visit_NamedExpr(self, node: cst.NamedExpr) -> bool:
+        node.target.visit(
+            ExpressionContextVisitor(self.provider, ExpressionContext.STORE)
+        )
+        node.value.visit(self)
+        return False
+
     def visit_Name(self, node: cst.Name) -> bool:
         self.provider.set_metadata(node, self.context)
         return False

--- a/libcst/metadata/tests/test_expression_context_provider.py
+++ b/libcst/metadata/tests/test_expression_context_provider.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 
 
-import sys
 from textwrap import dedent
 from typing import Dict, Optional, cast
 

--- a/libcst/metadata/tests/test_expression_context_provider.py
+++ b/libcst/metadata/tests/test_expression_context_provider.py
@@ -411,3 +411,19 @@ class ExpressionContextProviderTest(UnitTest):
                 },
             )
         )
+
+    def test_walrus(self) -> None:
+        code = """
+        if x := y:
+            pass
+        """
+        wrapper = MetadataWrapper(parse_module(dedent(code)))
+        wrapper.visit(
+            DependentVisitor(
+                test=self,
+                name_to_context={
+                    "x": ExpressionContext.STORE,
+                    "y": ExpressionContext.LOAD,
+                },
+            )
+        )

--- a/libcst/metadata/tests/test_expression_context_provider.py
+++ b/libcst/metadata/tests/test_expression_context_provider.py
@@ -414,13 +414,15 @@ class ExpressionContextProviderTest(UnitTest):
         )
 
     def test_walrus(self) -> None:
-        if sys.version_info < (3, 8):
-            self.skipTest("This python version does not support :=")
         code = """
         if x := y:
             pass
         """
-        wrapper = MetadataWrapper(parse_module(dedent(code)))
+        wrapper = MetadataWrapper(
+            parse_module(
+                dedent(code), config=cst.PartialParserConfig(python_version="3.8")
+            )
+        )
         wrapper.visit(
             DependentVisitor(
                 test=self,

--- a/libcst/metadata/tests/test_expression_context_provider.py
+++ b/libcst/metadata/tests/test_expression_context_provider.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
+import sys
 from textwrap import dedent
 from typing import Dict, Optional, cast
 
@@ -413,6 +414,8 @@ class ExpressionContextProviderTest(UnitTest):
         )
 
     def test_walrus(self) -> None:
+        if sys.version_info < (3, 8):
+            self.skipTest("This python version does not support :=")
         code = """
         if x := y:
             pass

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -1609,6 +1609,25 @@ class ScopeProviderTest(UnitTest):
                     ),
                 )
 
+    def test_walrus_accesses(self) -> None:
+        m, scopes = get_scope_metadata_provider(
+            """
+            if x := y:
+                y = 1
+                x
+            """
+        )
+        for scope in scopes.values():
+            for acc in scope.accesses:
+                self.assertEqual(
+                    len(acc.referents),
+                    1 if acc.node.value == "x" else 0,
+                    msg=(
+                        "Access for node has incorrect number of referents: "
+                        + f"{acc.node}"
+                    ),
+                )
+
     def test_cast(self) -> None:
         with self.assertRaises(cst.ParserSyntaxError):
             m, scopes = get_scope_metadata_provider(

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -1621,7 +1621,7 @@ class ScopeProviderTest(UnitTest):
             for acc in scope.accesses:
                 self.assertEqual(
                     len(acc.referents),
-                    1 if acc.node.value == "x" else 0,
+                    1 if getattr(acc.node, "value") == "x" else 0,
                     msg=(
                         "Access for node has incorrect number of referents: "
                         + f"{acc.node}"

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
+import sys
 from textwrap import dedent
 from typing import Mapping, Tuple, cast
 
@@ -24,7 +25,6 @@ from libcst.metadata.scope_provider import (
     _gen_dotted_names,
 )
 from libcst.testing.utils import UnitTest, data_provider
-import sys
 
 
 class DependentVisitor(cst.CSTVisitor):

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -24,6 +24,7 @@ from libcst.metadata.scope_provider import (
     _gen_dotted_names,
 )
 from libcst.testing.utils import UnitTest, data_provider
+import sys
 
 
 class DependentVisitor(cst.CSTVisitor):
@@ -1610,6 +1611,8 @@ class ScopeProviderTest(UnitTest):
                 )
 
     def test_walrus_accesses(self) -> None:
+        if sys.version_info < (3, 8):
+            self.skipTest("This python version doesn't support :=")
         m, scopes = get_scope_metadata_provider(
             """
             if x := y:


### PR DESCRIPTION
## Summary

This PR makes scope provider assign a `STORE` expression context to the left hand side of a walrus operator. So, in an `x := y` expression, `x` should have `ExpressionContext.STORE` as its expression context metadata.

## Test Plan

Added unit tests.
