### PR TITLE
Work around Windows problem by using dummy pool for `jobs=1`

### DIFF
--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -614,7 +614,7 @@ def parallel_exec_transform_with_prettyprint(  # noqa: C901
         python_version=python_version,
     )
 
-    if total == 1:
+    if total == 1 or jobs == 1:
         # Simple case, we should not pay for process overhead.
         # Let's just use a dummy synchronous pool.
         jobs = 1


### PR DESCRIPTION
Per #435, any codemod which is implemented with a `lambda` cannot be run on more than one file at time.  That's because `pickle` limitations mean we can't use a process pool, and so this patch ensures that we *don't* use a process pool for `jobs=1` and thus enables a "just run serially" workaround.

This is also something of a performance optimisation, since starting a single process to do all the work is likely to take longer than just doing it in the current process.