### PR TITLE
ApplyTypeAnnotations: apply parameter annotations even if no return type is declared

### DIFF
--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -70,12 +70,16 @@ class TypeCollector(cst.CSTVisitor):
     def visit_FunctionDef(self, node: cst.FunctionDef) -> bool:
         self.qualifier.append(node.name.value)
         returns = node.returns
-        if returns is not None:
-            return_annotation = self._create_import_from_annotation(returns)
-            parameter_annotations = self._import_parameter_annotations(node.params)
-            self.function_annotations[".".join(self.qualifier)] = FunctionAnnotation(
-                parameters=parameter_annotations, returns=return_annotation
-            )
+        return_annotation = (
+            self._create_import_from_annotation(returns)
+            if returns is not None
+            else None
+        )
+        parameter_annotations = self._import_parameter_annotations(node.params)
+        self.function_annotations[".".join(self.qualifier)] = FunctionAnnotation(
+            parameters=parameter_annotations, returns=return_annotation
+        )
+
         # pyi files don't support inner functions, return False to stop the traversal.
         return False
 

--- a/libcst/codemod/visitors/tests/test_apply_type_annotations.py
+++ b/libcst/codemod/visitors/tests/test_apply_type_annotations.py
@@ -651,6 +651,24 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                 example: Dict[str, Type[foo.Example]] = { "test": foo() }
                 """,
             ),
+            (
+                """
+                from typing import Optional
+
+                class A:
+                    def foo(self, atticus, b: Optional[int] = None, c: bool = False): ...
+                """,
+                """
+                class A:
+                    def foo(self, atticus, b = None, c = False): ...
+                """,
+                """
+                from typing import Optional
+
+                class A:
+                    def foo(self, atticus, b: Optional[int] = None, c: bool = False): ...
+                """,
+            ),
         )
     )
     def test_annotate_functions(self, stub: str, before: str, after: str) -> None:


### PR DESCRIPTION
## Summary

Caught this bug while running codemods, the result was that stubs for functions with parameter annotations, but without return annotations would not be annotated.

## Test Plan

`python -m unittest -v libcst.codemod.visitors.tests.test_apply_type_annotations`