### PR TITLE
Update Scope.get_qualified_names_for to resolve relative imports

### DIFF
--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -939,6 +939,23 @@ class ScopeProviderTest(UnitTest):
             },
         )
 
+    def test_get_qualified_names_for_relative(self) -> None:
+        m, scopes = get_scope_metadata_provider(
+            """
+            from .. import a
+            a()
+            """
+        )
+        scope_of_module = scopes[m]
+        a_call = ensure_type(
+            ensure_type(m.body[1], cst.SimpleStatementLine).body[0], cst.Expr
+        ).value
+        self.assertIsInstance(scope_of_module, GlobalScope)
+        self.assertEqual(
+            scope_of_module.get_qualified_names_for(a_call, 'x.y.z'),
+            {QualifiedName("x.a", QualifiedNameSource.IMPORT)},
+        )
+
     def test_assignments_and_accesses(self) -> None:
         m, scopes = get_scope_metadata_provider(
             """


### PR DESCRIPTION
## Summary
This is an attempt to fix issue #460.

Unfortunately I'm not sure how to expose this fix to `libcst.metadata.QualifiedNameProvider`, which would be very useful in my opinion.  As far as I can tell, metadata providers can not be parameterized, nor do they have access to the `libcst.MetadataWrapper`. It might be an idea to add an optional `full_module_name`  as a field on the `libcst.MetadataWrapper` so that we can do this relative import resolution automatically.

## Test Plan

```
>>> import libcst as cst
>>> wrapper = cst.MetadataWrapper(cst.parse_module("from . import a\na()"))
>>> scopes = wrapper.resolve(cst.metadata.ScopeProvider)
>>> scope_of_module = scopes[wrapper.module]
>>> a_call = wrapper.module.body[1].body[0].value
>>> scope_of_module.get_qualified_names_for(a_call, "x.y.z")
{QualifiedName(name='x.y.a', source=<QualifiedNameSource.IMPORT: 1>)}
```
