### PR TITLE
Add FullyQualifiedNameProvider

### DIFF
--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -199,9 +199,17 @@ We don't call it `fully qualified name <https://en.wikipedia.org/wiki/Fully_qual
 because the name refers to the current module which doesn't consider the hierarchy of
 code repository.
 
+For fully qualified names, there's :class:`~libcst.metadata.FullyQualifiedNameProvider`
+which is similar to the above but takes the current module's location (relative to some
+python root folder, usually the repository's root) into account.
+
+
 .. autoclass:: libcst.metadata.QualifiedNameSource
 .. autoclass:: libcst.metadata.QualifiedName
 .. autoclass:: libcst.metadata.QualifiedNameProvider
+   :no-undoc-members:
+   
+.. autoclass:: libcst.metadata.FullyQualifiedNameProvider
    :no-undoc-members:
 
 Parent Node Metadata

--- a/libcst/codemod/_codemod.py
+++ b/libcst/codemod/_codemod.py
@@ -78,7 +78,7 @@ class Codemod(MetadataDependent, ABC):
         oldwrapper = self.context.wrapper
         metadata_manager = self.context.metadata_manager
         filename = self.context.filename
-        if metadata_manager and filename:
+        if metadata_manager is not None and filename:
             # We can look up full-repo metadata for this codemod!
             cache = metadata_manager.get_cache_for_path(filename)
             wrapper = MetadataWrapper(module, cache=cache)

--- a/libcst/metadata/__init__.py
+++ b/libcst/metadata/__init__.py
@@ -16,7 +16,10 @@ from libcst.metadata.expression_context_provider import (
     ExpressionContextProvider,
 )
 from libcst.metadata.full_repo_manager import FullRepoManager
-from libcst.metadata.name_provider import QualifiedNameProvider
+from libcst.metadata.name_provider import (
+    FullyQualifiedNameProvider,
+    QualifiedNameProvider,
+)
 from libcst.metadata.parent_node_provider import ParentNodeProvider
 from libcst.metadata.position_provider import (
     PositionProvider,
@@ -74,6 +77,7 @@ __all__ = [
     "BatchableMetadataProvider",
     "VisitorMetadataProvider",
     "QualifiedNameProvider",
+    "FullyQualifiedNameProvider",
     "ProviderT",
     "Assignments",
     "Accesses",

--- a/libcst/metadata/full_repo_manager.py
+++ b/libcst/metadata/full_repo_manager.py
@@ -29,8 +29,9 @@ class FullRepoManager:
         metadata provider like :class:`~libcst.metadata.TypeInferenceProvider`.
 
         :param paths: a collection of paths to access full repository data.
-        :param providers: a collection of metadata provider classes require accessing full repository
-            data, currently supports :class:`~libcst.metadata.TypeInferenceProvider`.
+        :param providers: a collection of metadata provider classes require accessing full repository data, currently supports
+        :class:`~libcst.metadata.TypeInferenceProvider` and
+        :class:`~libcst.metadata.FullyQualifiedNameProvider`.
         :param timeout: number of seconds. Raises `TimeoutExpired <https://docs.python.org/3/library/subprocess.html#subprocess.TimeoutExpired>`_
             when timeout.
         """


### PR DESCRIPTION
## Summary
This new provider resolves names to their fully qualified versions, and is capable of dealing with relative imports, addressing the same issue as #461.

Closes #460, closes #282.
This PR depends on #464 
## Test Plan
Added unit tests.

