### PR TITLE
Improve handling of raw fstrings (#462)

### DIFF
--- a/libcst/_nodes/tests/test_atom.py
+++ b/libcst/_nodes/tests/test_atom.py
@@ -683,6 +683,20 @@ class AtomTest(CSTNodeTest):
                 "parser": parse_expression,
                 "expected_position": None,
             },
+            {
+                "node": cst.FormattedString(
+                    parts=(
+                        cst.FormattedStringText("\\"),
+                        cst.FormattedStringExpression(
+                            cst.Name(value="a"),
+                        ),
+                    ),
+                    start='fr"',
+                ),
+                "code": 'fr"\\{a}"',
+                "parser": parse_expression,
+                "expected_position": None,
+            },
             # Validate parens
             {
                 "node": cst.FormattedString(


### PR DESCRIPTION
## Summary

Fixes the reported issue by reverting to the regex used before 02fc4401bc3313f0db109d86d1b84c6b35abba5a when raw.

I am not 100% sure checking just top of stack is enough, however.  I wish there was a conformance suite for f-strings.

## Test Plan

Includes new test case