### PR TITLE
Add Github Actions and derive version from git tags

### DIFF
--- a/.github/workflows/.pyre_configuration
+++ b/.github/workflows/.pyre_configuration
@@ -1,0 +1,9 @@
+{
+    "source_directories": [
+        "."
+    ],
+    "search_path": [
+        "stubs", "~/cache/tox/pyre/lib/python3.8/site-packages/"
+    ],
+    "strict": true
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,88 @@
+name: Python CI
+
+on: [push, pull_request]
+
+env:
+  PIP_CACHE_DIR: ~/cache/pip
+
+jobs:
+  tox:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: [3.6, 3.7, 3.8]
+        environment: [test]
+        include:
+          - os: ubuntu-latest
+            python-version: 3.8
+            environment: lint
+          - os: ubuntu-latest
+            python-version: 3.8
+            environment: docs
+          - os: ubuntu-latest
+            python-version: 3.8
+            environment: coverage
+          - os: ubuntu-latest
+            python-version: 3.8
+            environment: pyre
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: pip cache
+      uses: actions/cache@v2
+      id:   cache
+      with:
+        path: '~/cache'
+        key: pip-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.environment }}-${{ hashFiles('tox.ini', 'requirements.txt', 'requirements-dev.txt', 'setup.py') }}
+        restore-keys: |
+          pip-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.environment }}-
+          pip-${{ matrix.os }}-${{ matrix.python-version }}-
+          pip-${{ matrix.os }}-
+    - name: install tox
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions -r requirements.txt -r requirements-dev.txt
+    - name: run tox
+      run: tox --workdir ~/cache/tox -e ${{ matrix.environment }}
+    - name: Archive Docs
+      if: matrix.environment == 'docs'
+      uses: actions/upload-artifact@v2
+      with:
+        name: sphinx-docs
+        path: docs/build
+    - name: Archive Coverage
+      if: matrix.environment == 'coverage'
+      uses: actions/upload-artifact@v2
+      with:
+        name: coverage
+        path: coverage.xml
+
+# Build python package
+  build:
+    needs: tox
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.pyc
 *.pyo
 *.egg-info/
+.eggs/
 .pyre/
 __pycache__/
 .tox/

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ docs/build/
 dist/
 docs/source/.ipynb_checkpoints/
 build/
+libcst/_version.py
 .coverage
 .hypothesis/
 .pyre_configuration

--- a/libcst/__init__.py
+++ b/libcst/__init__.py
@@ -191,6 +191,12 @@ from libcst._parser.types.config import (
 )
 from libcst._removal_sentinel import RemovalSentinel, RemoveFromParent
 from libcst._visitors import CSTNodeT, CSTTransformer, CSTVisitor, CSTVisitorT
+
+
+try:
+    from libcst._version import version as LIBCST_VERSION
+except ImportError:
+    LIBCST_VERSION = "unknown"
 from libcst.helpers import (  # from libcst import ensure_type is deprecated, will be removed in 0.4.0
     ensure_type,
 )
@@ -200,11 +206,6 @@ from libcst.metadata.base_provider import (
     VisitorMetadataProvider,
 )
 from libcst.metadata.wrapper import MetadataWrapper
-
-try:
-    from libcst._version import version as LIBCST_VERSION
-except ImportError:
-    LIBCST_VERSION = "unknown"
 
 
 __all__ = [

--- a/libcst/__init__.py
+++ b/libcst/__init__.py
@@ -190,7 +190,6 @@ from libcst._parser.types.config import (
     PartialParserConfig,
 )
 from libcst._removal_sentinel import RemovalSentinel, RemoveFromParent
-from libcst._version import LIBCST_VERSION
 from libcst._visitors import CSTNodeT, CSTTransformer, CSTVisitor, CSTVisitorT
 from libcst.helpers import (  # from libcst import ensure_type is deprecated, will be removed in 0.4.0
     ensure_type,
@@ -201,6 +200,11 @@ from libcst.metadata.base_provider import (
     VisitorMetadataProvider,
 )
 from libcst.metadata.wrapper import MetadataWrapper
+
+try:
+    from libcst._version import version as LIBCST_VERSION
+except ImportError:
+    LIBCST_VERSION = "unknown"
 
 
 __all__ = [

--- a/libcst/_version.py
+++ b/libcst/_version.py
@@ -1,7 +1,0 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
-#
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
-
-
-LIBCST_VERSION: str = "0.3.20"

--- a/libcst/tool.py
+++ b/libcst/tool.py
@@ -801,7 +801,7 @@ def main(proc_name: str, cli_args: List[str]) -> int:
         "--version",
         help="Print current version of LibCST toolset.",
         action="version",
-        version=f"LibCST version {LIBCST_VERSION}",
+        version=f"LibCST version {LIBCST_VERSION}",  # pyre-ignore[16] pyre bug?
     )
     parser.add_argument(
         "action",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,4 @@ pyre-check==0.0.41
 sphinx-rtd-theme>=0.4.3
 prompt-toolkit>=2.0.9
 tox>=3.18.1
+setuptools_scm>=6.0.1

--- a/setup.py
+++ b/setup.py
@@ -4,16 +4,10 @@
 # LICENSE file in the root directory of this source tree.
 
 
-import importlib.util
 from os import path
-from typing import TYPE_CHECKING
 
 import setuptools
 
-
-if TYPE_CHECKING:
-    from importlib.machinery import ModuleSpec
-    from types import ModuleType
 
 # Grab the readme so that our package stays in sync with github.
 this_directory: str = path.abspath(path.dirname(__file__))
@@ -22,7 +16,7 @@ with open(path.join(this_directory, "README.rst"), encoding="utf-8") as f:
 
 setuptools.setup(
     use_scm_version={
-        'write_to': 'libcst/_version.py',
+        "write_to": "libcst/_version.py",
     },
     name="libcst",
     description="A concrete syntax tree with AST-like properties for Python 3.5, 3.6, 3.7 and 3.8 programs.",
@@ -38,10 +32,14 @@ setuptools.setup(
     },
     test_suite="libcst",
     python_requires=">=3.6",
-    setup_requires=['setuptools_scm'],
+    setup_requires=["setuptools_scm"],
     install_requires=[dep.strip() for dep in open("requirements.txt").readlines()],
     extras_require={
-        "dev": [dep.strip() for dep in open("requirements-dev.txt").readlines() if "=" in dep],
+        "dev": [
+            dep.strip()
+            for dep in open("requirements-dev.txt").readlines()
+            if "=" in dep
+        ],
     },
     classifiers=[
         "License :: OSI Approved :: MIT License",

--- a/setup.py
+++ b/setup.py
@@ -20,22 +20,14 @@ this_directory: str = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, "README.rst"), encoding="utf-8") as f:
     long_description = f.read()
 
-# Grab the version constant so that libcst.tool stays in sync with this package.
-spec: "ModuleSpec" = importlib.util.spec_from_file_location(
-    "version", path.join(this_directory, "libcst/_version.py")
-)
-version: "ModuleType" = importlib.util.module_from_spec(spec)
-# pyre-ignore Pyre doesn't know about importlib entirely.
-spec.loader.exec_module(version)
-# pyre-ignore Pyre has no way of knowing that this constant exists.
-LIBCST_VERSION = version.LIBCST_VERSION
-
 setuptools.setup(
+    use_scm_version={
+        'write_to': 'libcst/_version.py',
+    },
     name="libcst",
     description="A concrete syntax tree with AST-like properties for Python 3.5, 3.6, 3.7 and 3.8 programs.",
     long_description=long_description,
     long_description_content_type="text/x-rst",
-    version=LIBCST_VERSION,
     url="https://github.com/Instagram/LibCST",
     license="MIT",
     packages=setuptools.find_packages(),
@@ -46,6 +38,7 @@ setuptools.setup(
     },
     test_suite="libcst",
     python_requires=">=3.6",
+    setup_requires=['setuptools_scm'],
     install_requires=[dep.strip() for dep in open("requirements.txt").readlines()],
     extras_require={
         "dev": [dep.strip() for dep in open("requirements-dev.txt").readlines() if "=" in dep],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,11 @@
 [tox]
-envlist = py36, py37, py38, py39, lint, docs
+envlist = py36, py37, py38, lint, docs
+
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38
 
 [testenv]
 deps =
@@ -8,10 +14,9 @@ deps =
 commands =
     python -m unittest {posargs}
 
+[testenv:test]
+
 [testenv:lint]
-deps =
-    -rrequirements.txt
-    -rrequirements-dev.txt
 commands =
     flake8 {posargs}
     isort --check-only {posargs:.}
@@ -19,16 +24,10 @@ commands =
     python3 -m fixit.cli.run_rules
 
 [testenv:docs]
-deps =
-    -rrequirements.txt
-    -rrequirements-dev.txt
 commands =
     sphinx-build {posargs:docs/source/ docs/build/}
 
 [testenv:autofix]
-deps =
-    -rrequirements.txt
-    -rrequirements-dev.txt
 commands =
     flake8 {posargs}
     isort -q {posargs:.}
@@ -36,9 +35,6 @@ commands =
     python3 -m fixit.cli.apply_fix
 
 [testenv:coverage]
-deps =
-    -rrequirements.txt
-    -rrequirements-dev.txt
 passenv =
     CI
     CIRCLECI
@@ -47,11 +43,17 @@ commands =
     coverage run setup.py test
     codecov
 
+[testenv:pyre]
+usedevelop=True
+allowlist_externals=
+    cp
+commands =
+    cp .github/workflows/.pyre_configuration .
+    pyre --version
+    pyre check
+
 [testenv:fuzz36]
 basepython = python3.6
-deps =
-    -rrequirements.txt
-    -rrequirements-dev.txt
 setenv =
     HYPOTHESIS = 1
 commands =
@@ -59,9 +61,6 @@ commands =
 
 [testenv:fuzz37]
 basepython = python3.7
-deps =
-    -rrequirements.txt
-    -rrequirements-dev.txt
 setenv =
     HYPOTHESIS = 1
 commands =
@@ -69,18 +68,13 @@ commands =
 
 [testenv:fuzz38]
 basepython = python3.8
-deps =
-    -rrequirements.txt
-    -rrequirements-dev.txt
 setenv =
     HYPOTHESIS = 1
 commands =
     python3.8 -m unittest libcst/tests/test_fuzz.py
 
+
 [testenv:codegen]
-deps =
-    -rrequirements.txt
-    -rrequirements-dev.txt
 commands =
     python3 -m libcst.codegen.generate visitors
     python3 -m libcst.codegen.generate return_types

--- a/tox.ini
+++ b/tox.ini
@@ -45,12 +45,15 @@ commands =
 
 [testenv:pyre]
 usedevelop=True
+setenv = PYTHONPATH = {toxinidir}
 allowlist_externals=
     cp
 commands =
     cp .github/workflows/.pyre_configuration .
     pyre --version
     pyre check
+    python libcst/tests/test_pyre_integration.py
+    git diff --exit-code
 
 [testenv:fuzz36]
 basepython = python3.6


### PR DESCRIPTION
## Summary
Two changes here:
 - I've ported the circleci config to github actions. I propose this as a replacement to circleci
 - I've added setuptools_scm and configured it to generate `libcst\_version.py`
 
To improve our workflow around libcst releases, I'd like to propose that we publish pre-release versions of the package. 

More context about publishing here: https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#publishing-the-distribution-to-pypi-and-testpypi

And pre-release versions here: https://packaging.python.org/guides/distributing-packages-using-setuptools/#pre-release-versioning

Relating that to this change:
 - setuptools_scm makes the pre-release versioning trivial
 - We can add ~10 lines of github action yaml to handle the publishing to PyPi

## TODOs:
 - I will follow up with a commit that handles the pypi publishing
 - I will delete the circleci files
 - If this proposal is acceptable, we would need to configure some secrets in Github (ie codecov and pypi tokens)
 - Add testing on `windows-latest`. I discovered that the test suite doesn't pass on windows, which I will fix in another PR.

## Test Plan
See https://github.com/lpetre/LibCST/actions/runs/704265869

