### PR TITLE
Fixes TypeInferenceProvider breakage with empty cache.

### DIFF
--- a/libcst/metadata/tests/test_type_inference_provider.py
+++ b/libcst/metadata/tests/test_type_inference_provider.py
@@ -66,3 +66,7 @@ class TypeInferenceProviderTest(UnitTest):
             cache={TypeInferenceProvider: data},
         )
         _test_simple_class_helper(self, wrapper)
+
+    def test_with_empty_cache(self):
+        tip = TypeInferenceProvider({})
+        self.assertEqual(tip.lookup, {})

--- a/libcst/metadata/tests/test_type_inference_provider.py
+++ b/libcst/metadata/tests/test_type_inference_provider.py
@@ -67,6 +67,9 @@ class TypeInferenceProviderTest(UnitTest):
         )
         _test_simple_class_helper(self, wrapper)
 
-    def test_with_empty_cache(self):
+    def test_with_empty_cache(self) -> None:
         tip = TypeInferenceProvider({})
+        self.assertEqual(tip.lookup, {})
+
+        tip = TypeInferenceProvider(PyreData())
         self.assertEqual(tip.lookup, {})

--- a/libcst/metadata/type_inference_provider.py
+++ b/libcst/metadata/type_inference_provider.py
@@ -32,7 +32,7 @@ class InferredType(TypedDict):
     annotation: str
 
 
-class PyreData(TypedDict):
+class PyreData(TypedDict, total=False):
     types: Sequence[InferredType]
 
 

--- a/libcst/metadata/type_inference_provider.py
+++ b/libcst/metadata/type_inference_provider.py
@@ -75,7 +75,8 @@ class TypeInferenceProvider(BatchableMetadataProvider[str]):
     def __init__(self, cache: PyreData) -> None:
         super().__init__(cache)
         lookup: Dict[CodeRange, str] = {}
-        for item in cache["types"]:
+        cache_types = cache.get("types", [])
+        for item in cache_types:
             location = item["location"]
             start = location["start"]
             end = location["stop"]


### PR DESCRIPTION
## Summary
https://github.com/Instagram/LibCST/issues/475

`TypeInferenceProvider` crashes if an empty `cache` is passed to it, which resulted in the creation of [PLACEHOLDER_CACHES](https://github.com/Instagram/Fixit/blob/1f11c185c0541d419ada74fb938f4ac78f122971/fixit/common/full_repo_metadata.py#L23) in Fixit. I'm working on a [PR](https://github.com/Instagram/Fixit/pull/182) to allow a user to pass into Fixit no providers, and found this bug via this [conversation](https://github.com/Instagram/Fixit/pull/31#discussion_r452945560).

The fix itself is very simple. 

## Test Plan
Added a unit test.
