### PR TITLE
Return more specific QNames for assignments

### DIFF
--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -817,11 +817,9 @@ class ScopeVisitor(cst.CSTVisitor):
         # make sure node.names is Sequence[ImportAlias]
         for name in names:
             self.provider.set_metadata(name, self.scope)
-            self.provider.set_metadata(name.name, self.scope)
             asname = name.asname
             if asname is not None:
                 name_values = _gen_dotted_names(cst.ensure_type(asname.name, cst.Name))
-                self.provider.set_metadata(asname.name, self.scope)
             else:
                 name_values = _gen_dotted_names(name.name)
 

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -522,13 +522,17 @@ class Scope(abc.ABC):
             if isinstance(assignment, Assignment):
                 assignment_node = assignment.node
                 if isinstance(assignment_node, (cst.Import, cst.ImportFrom)):
-                    results |= _NameUtil.find_qualified_name_for_import_alike(
+                    names = _NameUtil.find_qualified_name_for_import_alike(
                         assignment_node, full_name
                     )
                 else:
-                    results |= _NameUtil.find_qualified_name_for_non_import(
+                    names = _NameUtil.find_qualified_name_for_non_import(
                         assignment, full_name
                     )
+                if assignment_node is node:
+                    return names
+                else:
+                    results |= names
             elif isinstance(assignment, BuiltinAssignment):
                 results.add(
                     QualifiedName(

--- a/libcst/metadata/tests/test_name_provider.py
+++ b/libcst/metadata/tests/test_name_provider.py
@@ -352,6 +352,79 @@ class QualifiedNameProviderTest(UnitTest):
             names[attribute], {QualifiedName("a.aa.aaa", QualifiedNameSource.IMPORT)}
         )
 
+    def test_multiple_qualified_names(self) -> None:
+        m, names = get_qualified_name_metadata_provider(
+            """
+            if False:
+                def f(): pass
+            elif False:
+                from b import f
+            else:
+                import f
+            import a.b as f
+            
+            f()
+            """
+        )
+        if_ = ensure_type(m.body[0], cst.If)
+        first_f = ensure_type(if_.body.body[0], cst.FunctionDef)
+        second_f_alias = ensure_type(
+            ensure_type(
+                ensure_type(if_.orelse, cst.If).body.body[0],
+                cst.SimpleStatementLine,
+            ).body[0],
+            cst.ImportFrom,
+        ).names
+        self.assertFalse(isinstance(second_f_alias, cst.ImportStar))
+        second_f = second_f_alias[0].name
+        third_f_alias = ensure_type(
+            ensure_type(
+                ensure_type(ensure_type(if_.orelse, cst.If).orelse, cst.Else).body.body[
+                    0
+                ],
+                cst.SimpleStatementLine,
+            ).body[0],
+            cst.Import,
+        ).names
+        self.assertFalse(isinstance(third_f_alias, cst.ImportStar))
+        third_f = third_f_alias[0].name
+        fourth_f = ensure_type(
+            ensure_type(
+                ensure_type(m.body[1], cst.SimpleStatementLine).body[0], cst.Import
+            )
+            .names[0]
+            .asname,
+            cst.AsName,
+        ).name
+        call = ensure_type(
+            ensure_type(
+                ensure_type(m.body[2], cst.SimpleStatementLine).body[0], cst.Expr
+            ).value,
+            cst.Call,
+        )
+
+        self.assertEqual(
+            names[first_f], {QualifiedName("f", QualifiedNameSource.LOCAL)}
+        )
+        self.assertEqual(
+            names[second_f], {QualifiedName("b.f", QualifiedNameSource.IMPORT)}
+        )
+        self.assertEqual(
+            names[third_f], {QualifiedName("f", QualifiedNameSource.IMPORT)}
+        )
+        self.assertEqual(
+            names[fourth_f], {QualifiedName("a.b", QualifiedNameSource.IMPORT)}
+        )
+        self.assertEqual(
+            names[call],
+            {
+                QualifiedName("f", QualifiedNameSource.IMPORT),
+                QualifiedName("b.f", QualifiedNameSource.IMPORT),
+                QualifiedName("f", QualifiedNameSource.LOCAL),
+                QualifiedName("a.b", QualifiedNameSource.IMPORT),
+            },
+        )
+
 
 class FullyQualifiedNameProviderTest(UnitTest):
     def test_builtins(self) -> None:

--- a/libcst/metadata/tests/test_name_provider.py
+++ b/libcst/metadata/tests/test_name_provider.py
@@ -406,15 +406,9 @@ class QualifiedNameProviderTest(UnitTest):
         self.assertEqual(
             names[first_f], {QualifiedName("f", QualifiedNameSource.LOCAL)}
         )
-        self.assertEqual(
-            names[second_f], {QualifiedName("b.f", QualifiedNameSource.IMPORT)}
-        )
-        self.assertEqual(
-            names[third_f], {QualifiedName("f", QualifiedNameSource.IMPORT)}
-        )
-        self.assertEqual(
-            names[fourth_f], {QualifiedName("a.b", QualifiedNameSource.IMPORT)}
-        )
+        self.assertEqual(names[second_f], set())
+        self.assertEqual(names[third_f], set())
+        self.assertEqual(names[fourth_f], set())
         self.assertEqual(
             names[call],
             {


### PR DESCRIPTION
## Summary

When `scope.get_qualified_names_for()` is called with a node that's an `Assignment`, return the qualified name for that node instead of all the assignments for the same name.

For example:
```
if False:
  def f(): pass  # {"f"}
else:
  from a import f  # {"a.f"}

f()  # {"f", "a.f"}
```

Before this PR, all three nodes had the same set of qnames returned (`{"f", "a.f"}`).

## Test Plan

Will add tests before merging.

