### PR TITLE
Fix formatting for link to QualifiedName class in docs

### DIFF
--- a/libcst/metadata/name_provider.py
+++ b/libcst/metadata/name_provider.py
@@ -95,8 +95,8 @@ def _module_name(path: str) -> Optional[str]:
 class FullyQualifiedNameProvider(BatchableMetadataProvider[Collection[QualifiedName]]):
     """
     Provide fully qualified names for CST nodes. Like :class:`QualifiedNameProvider`,
-    but the provided :class:`QualifiedName`s have absolute identifier names instead of
-    local to the current module.
+    but the provided :class:`QualifiedName` instances have absolute identifier names
+    instead of local to the current module.
 
     This provider is initialized with the current module's fully qualified name, and can
     be used with :class:`~libcst.metadata.FullRepoManager`. The module's fully qualified


### PR DESCRIPTION
## Summary

While checking out the cods for the recently added `FullyQualifiedNameProvider`, I noticed that one link to a class wasn't properly handled by Sphinx:

<img width="615" alt="image" src="https://user-images.githubusercontent.com/861044/116292199-56989680-a78d-11eb-973b-e4073a060199.png">

I think the idea was to add an `s` at the end of the class name since we're talking about multiple of them, but I couldn't find how to make the `s` stick, so I've reworded a bit.

Alternative solutions I considered, with the reason why I didn't go for them:

- Specify a title with the "s" (`` :class:`QualifiedNames <QualifiedName>` ``): altering the class name might confuse people
- Add a space between the class name and the "s": formatting looks off
- Remove extra markup/formatting: seems like a step back vs having links to the class docs.

## Test Plan

Check the docs output

<img width="584" alt="image" src="https://user-images.githubusercontent.com/861044/116293079-5cdb4280-a78e-11eb-90d7-787e56a4ec04.png">
