### PR TITLE
fix codemodding on windows 

### DIFF
--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -55,7 +55,6 @@ def invoke_formatter(formatter_args: Sequence[str], code: AnyStr) -> AnyStr:
         AnyStr,
         subprocess.check_output(
             formatter_args,
-            env=None,
             input=code,
             universal_newlines=not work_with_bytes,
             encoding=None if work_with_bytes else "utf-8",

--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -55,7 +55,7 @@ def invoke_formatter(formatter_args: Sequence[str], code: AnyStr) -> AnyStr:
         AnyStr,
         subprocess.check_output(
             formatter_args,
-            env={},
+            env=None,
             input=code,
             universal_newlines=not work_with_bytes,
             encoding=None if work_with_bytes else "utf-8",


### PR DESCRIPTION
## Summary
running codemodding fails due to passing an empty environment `env={}` rather than `env=None` according to the Python spec.
`Note If specified, env must provide any variables required for the program to execute. On Windows, in order to run a side-by-side assembly the specified env must include a valid SystemRoot.
`
by specifying env=None things work smoothly on Windows 10

fixes: #494 

## Test Plan
I have only performed limited testing on Windows, but this should be validated across all supported platforms.
My assumption that this is already part of the CI/CD tests

