### PR TITLE
TypeAnnotationsVisitor: don't truncate function return type

### DIFF
--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -466,7 +466,10 @@ class ApplyTypeAnnotationsVisitor(ContextAwareTransformer):
             function_annotation = self.annotations.function_annotations[key]
             # Only add new annotation if explicitly told to overwrite existing
             # annotations or if one doesn't already exist.
-            if self.overwrite_existing_annotations or not updated_node.returns:
+            set_return_annotation = not updated_node.returns or (
+                self.overwrite_existing_annotations and function_annotation.returns
+            )
+            if set_return_annotation:
                 updated_node = updated_node.with_changes(
                     returns=function_annotation.returns
                 )


### PR DESCRIPTION
**What?**

I added tests of how TypeAnnotationsVisitor reacts to
- stubs that ignore decorators and the async keyword
- stubs that lack parameter and/or return annotations where
  a callable has them.

I discovered one case where TypeAnnotationsVisitor didn't do what
I want it to do: if we're missing a return annotation in the stubs
but have one in our function and `overwrite_existing_annotations` is
set, we'll actually strip out the existing annotation. So I tweaked
the logic to only use the annotation from the stub if it is nonmissing.

**Why?**

I'm working on a project (pyre infer) that depends on
TypeAnnotationsVisitor, and a problem we've run into is that we don't
yet have perfect logic for resolving imports in a way that's
sufficiently sensitive to local context to be good for codemods - for
example, we're not yet sure how to reliably diff against the existing
imports for aliased imports (when bar imports foo.Foo and then baz
includes `from bar import Foo`) and relative imports.

Because we try to give full type annotations on parameters, even where
there is a preexisting annotation, this can lead to a lot of noise
where diffs fail because of imports changing due to the stub even
though there was no actual change to the annotations.

In the short term, the easiest solution is to simply omit given
annotations from the stubs we generate. But that means we have to
be sure TypeAnnotations

**Test Plan**

```
> python -m unittest libcst.codemod.visitors.tests.test_apply_type_annotations
...........................................
----------------------------------------------------------------------
Ran 43 tests in 1.548s

OK
```


## Summary

## Test Plan

