### PR TITLE
Add tests verifying TypeAnnotationsVisitor current behaviors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ build/
 .coverage
 .hypothesis/
 .pyre_configuration
+.python-version

--- a/libcst/codemod/visitors/tests/test_apply_type_annotations.py
+++ b/libcst/codemod/visitors/tests/test_apply_type_annotations.py
@@ -669,6 +669,31 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                     def foo(self, atticus, b: Optional[int] = None, c: bool = False): ...
                 """,
             ),
+            # Make sure we handle string annotations well
+            (
+                """
+                def f(x: "typing.Union[int, str]") -> "typing.Union[int, str]": ...
+
+                class A:
+                    def f(self: "A") -> "A": ...
+                """,
+                """
+                def f(x):
+                    return x
+
+                class A:
+                    def f(self):
+                        return self
+                """,
+                """
+                def f(x: "typing.Union[int, str]") -> "typing.Union[int, str]":
+                    return x
+
+                class A:
+                    def f(self: "A") -> "A":
+                        return self
+                """,
+            ),
         )
     )
     def test_annotate_functions(self, stub: str, before: str, after: str) -> None:


### PR DESCRIPTION
No changes to production code, just adding tests to make the existing
logic self-documented and regression-proof.

## Test that LibCST TypeAnnotationsVisitor handles string annotations

This is an important property for certain use cases, so it
makes sense to verify it in tests so that we can safely
depend on it.

At present, the reason we want to be able to rely on this is:
- at the moment, imports added by infer can make pysa traces
  hard to understand, because the line numbers are off
- if we add the ability to use fully-qualified string annotations
  for the stubs from infer, then we can do so without adding
  any import lines and pyre will understand the types.

## Test various cases of merging imports

The goal here is to have LibCST's current TypeAnnotationsVisitor
behavior - which handles some types of imports and not others -
be well-documented in a test.

The reason is that import handling bugs are one of the main problems
preventing pyre infer from being 100% reliable, and to think about
how to improve it (change LibCST, change infer, change both?) we need
to have a clear understanding of what currently works, isolated in a
small test.


