### PR TITLE
bump version to 0.3.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.3.20 - 2021-08-09
+
+## Fixed
+- Don't reset subprocess environment to fix codemodding on windows [#495](https://github.com/Instagram/LibCST/pull/495)
+- TypeAnnotationsVisitor: don't truncate function return type [#499](https://github.com/Instagram/LibCST/pull/499)
+- Docs: Fix typo [#492](https://github.com/Instagram/LibCST/pull/492)
+
 # 0.3.19 - 2021-05-12
 
 # Updated

--- a/libcst/_version.py
+++ b/libcst/_version.py
@@ -4,4 +4,4 @@
 # LICENSE file in the root directory of this source tree.
 
 
-LIBCST_VERSION: str = "0.3.19"
+LIBCST_VERSION: str = "0.3.20"


### PR DESCRIPTION
## Fixed
- Don't reset subprocess environment to fix codemodding on windows [#495](https://github.com/Instagram/LibCST/pull/495)
- TypeAnnotationsVisitor: don't truncate function return type [#499](https://github.com/Instagram/LibCST/pull/499)
- Docs: Fix typo [#492](https://github.com/Instagram/LibCST/pull/492)