### PR TITLE
Switch code coverage from tox => gh actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,6 @@ jobs:
             environment: docs
           - os: ubuntu-latest
             python-version: 3.8
-            environment: coverage
-          - os: ubuntu-latest
-            python-version: 3.8
             environment: pyre
     steps:
     - uses: actions/checkout@v1
@@ -46,7 +43,7 @@ jobs:
     - name: install tox
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions -r requirements.txt -r requirements-dev.txt
+        pip install tox-gh-actions -r requirements.txt -r requirements-dev.txt
     - name: run tox
       run: tox --workdir ~/cache/tox -e ${{ matrix.environment }}
     - name: Archive Docs
@@ -55,8 +52,39 @@ jobs:
       with:
         name: sphinx-docs
         path: docs/build
+
+# Upload test coverage
+  coverage:
+    needs: tox
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: pip cache
+      uses: actions/cache@v2
+      id:   cache
+      with:
+        path: '~/cache'
+        key: pip-ubuntu-latest-3.8-test-${{ hashFiles('tox.ini', 'requirements.txt', 'requirements-dev.txt', 'setup.py') }}
+    - name: install pip
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt -r requirements-dev.txt
+    - name: generate coverage
+      run: |
+        coverage run setup.py test
+        coverage xml -i
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v2
+      with:
+        files: coverage.xml
+        fail_ci_if_error: true
+        verbose: true
     - name: Archive Coverage
-      if: matrix.environment == 'coverage'
       uses: actions/upload-artifact@v2
       with:
         name: coverage

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 black==20.8b1
-codecov>=2.1.4
 coverage>=4.5.4
 fixit==0.1.1
 flake8>=3.7.8

--- a/tox.ini
+++ b/tox.ini
@@ -34,15 +34,6 @@ commands =
     black {posargs:libcst/}
     python3 -m fixit.cli.apply_fix
 
-[testenv:coverage]
-passenv =
-    CI
-    CIRCLECI
-    CIRCLE_*
-commands =
-    coverage run setup.py test
-    codecov
-
 [testenv:pyre]
 usedevelop=True
 setenv = PYTHONPATH = {toxinidir}


### PR DESCRIPTION
## Summary
The previous codecov upload had a few shortcomings.
 - it ran within tox
 - it re-ran tests unnecessarily
 
 I've moved this to run w/ gh actions

## Test Plan

See https://github.com/lpetre/LibCST/runs/3302352659
and https://codecov.io/github/lpetre/LibCST/commit/8311866beeec0f1571f89fcc4c6a357c453de273