### PR TITLE
Split up some larger CI/tox steps into separate jobs

### DIFF
--- a/.github/workflows/.pyre_configuration.template
+++ b/.github/workflows/.pyre_configuration.template
@@ -3,7 +3,7 @@
         "."
     ],
     "search_path": [
-        "stubs", "~/cache/tox/pyre/lib/python3.9/site-packages/"
+        "stubs", "{{ .python_site_packages }}"
     ],
     "strict": true
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,84 +2,134 @@ name: Python CI
 
 on: [push, pull_request]
 
-env:
-  PIP_CACHE_DIR: ~/cache/pip
-
 jobs:
-  tox:
+# Install and cache dependencies
+  setup:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8, 3.9]
-        environment: [test]
-        include:
-          - os: ubuntu-latest
-            python-version: 3.9
-            environment: lint
-          - os: ubuntu-latest
-            python-version: 3.9
-            environment: docs
-          - os: ubuntu-latest
-            python-version: 3.9
-            environment: pyre
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+    - uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: pip cache
-      uses: actions/cache@v2
-      id:   cache
+    - uses: actions/cache@v2
+      id: cache
       with:
-        path: '~/cache'
-        key: pip-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.environment }}-${{ hashFiles('tox.ini', 'requirements.txt', 'requirements-dev.txt', 'setup.py') }}
-        restore-keys: |
-          pip-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.environment }}-
-          pip-${{ matrix.os }}-${{ matrix.python-version }}-
-          pip-${{ matrix.os }}-
-    - name: install tox
+        path: ${{ env.pythonLocation }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'setup.py') }}
+    - name: Install Dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
-        python -m pip install --upgrade pip
-        pip install tox-gh-actions -r requirements.txt -r requirements-dev.txt
-    - name: run tox
-      run: tox --workdir ~/cache/tox -e ${{ matrix.environment }}
-    - name: Archive Docs
-      if: matrix.environment == 'docs'
-      uses: actions/upload-artifact@v2
+        pip install --upgrade --upgrade-strategy eager build -r requirements.txt -r requirements-dev.txt
+
+# Run unittests
+  test:
+    needs: setup
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9]
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v2
       with:
-        name: sphinx-docs
-        path: docs/build
+        python-version: ${{ matrix.python-version }}
+    - uses: actions/cache@v2
+      id: cache
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'setup.py') }}
+    - name: Validate Dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: exit 1
+    - name: Run Tests
+      run: python -m unittest
+
+# Run linters
+  lint:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - uses: actions/cache@v2
+      id: cache
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'setup.py') }}
+    - name: Validate Dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: exit 1
+    - run: flake8
+    - run: isort --check-only .
+    - run: black --check libcst/
+    - run: python3 -m fixit.cli.run_rules
+
+# Run pyre typechecker
+  typecheck:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - uses: actions/cache@v2
+      id: cache
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'setup.py') }}
+    - name: Validate Dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: exit 1
+    - name: Get Python site-packages
+      id: python-info
+      run: |
+        echo "::set-output name=SITE_PACKAGES::$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"
+    - name: Configure Pyre
+      id: pyre_template
+      uses: chuhlomin/render-template@v1.2
+      with:
+          template: .github/workflows/.pyre_configuration.template
+          vars: |
+            python_site_packages: ${{ steps.python-info.outputs.SITE_PACKAGES }}
+    - name: Write Pyre Config
+      run: echo '${{ steps.pyre_template.outputs.result }}' > .pyre_configuration
+    - run: pyre --version
+    - run: pyre check
+    - run: python libcst/tests/test_pyre_integration.py
+    - run: git diff --exit-code
 
 # Upload test coverage
   coverage:
-    needs: tox
+    needs: setup
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python
-      uses: actions/setup-python@v2
+    - uses: actions/setup-python@v2
       with:
         python-version: 3.9
-    - name: pip cache
-      uses: actions/cache@v2
-      id:   cache
+    - uses: actions/cache@v2
+      id: cache
       with:
-        path: '~/cache'
-        key: pip-ubuntu-latest-3.9-test-${{ hashFiles('tox.ini', 'requirements.txt', 'requirements-dev.txt', 'setup.py') }}
-    - name: install pip
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt -r requirements-dev.txt
-    - name: generate coverage
+        path: ${{ env.pythonLocation }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'setup.py') }}
+    - name: Validate Dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: exit 1
+    - name: Generate Coverage
       run: |
         coverage run setup.py test
         coverage xml -i
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+    - uses: codecov/codecov-action@v2
       with:
         files: coverage.xml
         fail_ci_if_error: true
@@ -90,23 +140,48 @@ jobs:
         name: coverage
         path: coverage.xml
 
-# Build python package
-  build:
-    needs: tox
+# Build the docs
+  docs:
+    needs: setup
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python
-      uses: actions/setup-python@v2
+    - uses: actions/setup-python@v2
       with:
         python-version: 3.9
-    - name: Install pypa/build
-      run: >-
-        python -m
-        pip install
-        build
-        --user
+    - uses: actions/cache@v2
+      id: cache
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'setup.py') }}
+    - name: Validate Dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: exit 1
+    - uses: ts-graphviz/setup-graphviz@v1
+    - run: sphinx-build docs/source/ docs/build/
+    - name: Archive Docs
+      uses: actions/upload-artifact@v2
+      with:
+        name: sphinx-docs
+        path: docs/build
+
+# Build python package
+  build:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - uses: actions/cache@v2
+      id: cache
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'setup.py') }}
+    - name: Validate Dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: exit 1
     - name: Build a binary wheel and a source tarball
       run: >-
         python -m


### PR DESCRIPTION
## Summary

This takes the runtime of the CI from ~8 minutes to <5 mins.

There is some unfortunate duplication, and I wish `needs` could depend on one matrix configuration.

Otherwise I'm very happy with this change.

This also enables me to ship windows testing, as I don't rely on tox anymore.

## Test Plan
See https://github.com/lpetre/LibCST/actions/runs/1121624876
