### PR TITLE
Bump pyre-check to latest version

### DIFF
--- a/libcst/tests/pyre/simple_class.json
+++ b/libcst/tests/pyre/simple_class.json
@@ -37,7 +37,7 @@
           "column": 16
         }
       },
-      "annotation": "typing.Callable(libcst.tests.pyre.simple_class.Item.__init__)[[Named(self, unknown), Named(n, int)], None]"
+      "annotation": "typing.Callable(libcst.tests.pyre.simple_class.Item.__init__)[[Named(self, libcst.tests.pyre.simple_class.Item), Named(n, int)], None]"
     },
     {
       "location": {
@@ -167,7 +167,7 @@
           "column": 17
         }
       },
-      "annotation": "typing.Callable(libcst.tests.pyre.simple_class.ItemCollector.get_items)[[Named(self, unknown), Named(n, int)], typing.Sequence[libcst.tests.pyre.simple_class.Item]]"
+      "annotation": "typing.Callable(libcst.tests.pyre.simple_class.ItemCollector.get_items)[[Named(self, libcst.tests.pyre.simple_class.ItemCollector), Named(n, int)], typing.Sequence[libcst.tests.pyre.simple_class.Item]]"
     },
     {
       "location": {
@@ -219,7 +219,7 @@
           "column": 43
         }
       },
-      "annotation": "typing.Callable(typing.GenericMeta.__getitem__)[[typing.Type[Variable[typing._T_co](covariant)]], typing.Type[typing.Sequence[Variable[typing._T_co](covariant)]]]"
+      "annotation": "BoundMethod[typing.Callable(typing.GenericMeta.__getitem__)[[Named(self, unknown), typing.Type[Variable[typing._T_co](covariant)]], typing.Type[typing.Sequence[Variable[typing._T_co](covariant)]]], typing.Type[typing.Sequence]]"
     },
     {
       "location": {
@@ -427,7 +427,7 @@
           "column": 43
         }
       },
-      "annotation": "typing.Callable(libcst.tests.pyre.simple_class.ItemCollector.get_items)[[Named(n, int)], typing.Sequence[libcst.tests.pyre.simple_class.Item]]"
+      "annotation": "BoundMethod[typing.Callable(libcst.tests.pyre.simple_class.ItemCollector.get_items)[[Named(self, libcst.tests.pyre.simple_class.ItemCollector), Named(n, int)], typing.Sequence[libcst.tests.pyre.simple_class.Item]], libcst.tests.pyre.simple_class.ItemCollector]"
     },
     {
       "location": {

--- a/libcst/tests/test_pyre_integration.py
+++ b/libcst/tests/test_pyre_integration.py
@@ -122,7 +122,7 @@ if __name__ == "__main__":
     stdout: str
     stderr: str
     return_code: int
-    stdout, stderr, return_code = run_command(["pyre", "start"])
+    stdout, stderr, return_code = run_command(["pyre", "start", "--no-watchman"])
     if return_code != 0:
         print(stdout)
         print(stderr)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ hypothesmith>=0.0.4
 jupyter>=1.0.0
 nbsphinx>=0.4.2
 prompt-toolkit>=2.0.9
-pyre-check==0.0.41
+pyre-check==0.9.3
 setuptools_scm>=6.0.1
 sphinx-rtd-theme>=0.4.3
 tox>=3.18.1

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import setuptools
 # Grab the readme so that our package stays in sync with github.
 this_directory: str = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, "README.rst"), encoding="utf-8") as f:
-    long_description = f.read()
+    long_description: str = f.read()
 
 setuptools.setup(
     use_scm_version={


### PR DESCRIPTION
## Summary

Bump the version of pyre to the latest, 0.0.41 is ancient.

## Test Plan

```
pip install -r requirements-dev.txt
```
and the install went okay.

I'm pretty sure this is going to lead to a huge number of errors (I get pages of them on my computer), putting the PR up partly to see what the CI results look like and partly to get feedback about how to handle it.
