### PR TITLE
Organize the _apply_type_annotations visitor tests

### DIFF
--- a/libcst/codemod/visitors/tests/test_apply_type_annotations.py
+++ b/libcst/codemod/visitors/tests/test_apply_type_annotations.py
@@ -54,8 +54,8 @@ class TestApplyAnnotationsVisitor(CodemodTest):
         self.assertCodemod(before, after, context_override=context)
 
     @data_provider(
-        (
-            (
+        {
+            "supported_cases": (
                 """
                 from __future__ import annotations
                 from foo import Foo
@@ -72,56 +72,101 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                 from baz import Baz
                 """,
             ),
-            (
-                # Missing feature: ignore aliased imports
+            "unsupported_cases": (
                 """
                 from Foo import foo as bar
-                """,
-                """
-                from Foo import bar
-                """,
-                """
-                from Foo import bar
-                """,
-            ),
-            (
-                # Missing feature: ignore bare imports
-                """
                 import foo
+                from .. import baz
+                from boo import *
                 """,
                 """
                 """,
+                # This is a bug, it would be better to just ignor aliased
+                # imports than to add them incorrectly.
                 """
+                from Foo import bar
                 """,
             ),
-            (
-                # Missing feature: ignore relative imports
-                """
-                from .. import foo
-                """,
-                """
-                """,
-                """
-                """,
-            ),
-            (
-                # Missing feature: ignore star imports
-                """
-                from foo import *
-                """,
-                """
-                """,
-                """
-                """,
-            ),
-        )
+        }
     )
     def test_merge_module_imports(self, stub: str, before: str, after: str) -> None:
         self.run_simple_test_case(stub=stub, before=before, after=after)
 
     @data_provider(
-        (
-            (
+        {
+            "simple": (
+                """
+                bar: int = ...
+                """,
+                """
+                bar = foo()
+                """,
+                """
+                bar: int = foo()
+                """,
+            ),
+            "simple_with_existing": (
+                """
+                bar: int = ...
+                """,
+                """
+                bar: str = foo()
+                """,
+                """
+                bar: str = foo()
+                """,
+            ),
+            "with_separate_declaration": (
+                """
+                x: int = ...
+                y: int = ...
+                z: int = ...
+                """,
+                """
+                x = y = z = 1
+                """,
+                """
+                x: int
+                y: int
+                z: int
+
+                x = y = z = 1
+                """,
+            ),
+            "needs_added_import": (
+                """
+                FOO: a.b.Example = ...
+                """,
+                """
+                FOO = bar()
+                """,
+                """
+                from a.b import Example
+
+                FOO: Example = bar()
+                """,
+            ),
+            "with_generic": (
+                """
+                FOO: Union[a.b.Example, int] = ...
+                """,
+                """
+                FOO = bar()
+                """,
+                """
+                from a.b import Example
+
+                FOO: Union[Example, int] = bar()
+                """,
+            ),
+        }
+    )
+    def test_annotate_globals(self, stub: str, before: str, after: str) -> None:
+        self.run_simple_test_case(stub=stub, before=before, after=after)
+
+    @data_provider(
+        {
+            "basic_return": (
                 """
                 def foo() -> int: ...
                 """,
@@ -134,7 +179,33 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                     return 1
                 """,
             ),
-            (
+            "return_with_existing_param": (
+                """
+                def foo(x: int) -> str: ...
+                """,
+                """
+                def foo(x: str):
+                    pass
+                """,
+                """
+                def foo(x: str) -> str:
+                    pass
+                """,
+            ),
+            "param_with_existng_return": (
+                """
+                def foo(x: int) -> int: ...
+                """,
+                """
+                def foo(x) -> int:
+                    return x
+                """,
+                """
+                def foo(x: int) -> int:
+                    return x
+                """,
+            ),
+            "return_and_params_general": (
                 """
                 def foo(
                     b: str, c: int = ..., *, d: str = ..., e: int, f: int = ...
@@ -153,7 +224,22 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                     return 1
                 """,
             ),
-            (
+            "with_import__basic": (
+                """
+                def foo() -> bar.Baz: ...
+                """,
+                """
+                def foo():
+                    return returns_baz()
+                """,
+                """
+                from bar import Baz
+
+                def foo() -> Baz:
+                    return returns_baz()
+                """,
+            ),
+            "with_import__unneeded_explicit": (
                 """
                 import bar
 
@@ -171,10 +257,8 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                 """,
             ),
             # Keep the existing `import A` instead of using `from A import B`.
-            (
+            "with_import__preexisting": (
                 """
-                import bar
-
                 def foo() -> bar.Baz: ...
                 """,
                 """
@@ -190,145 +274,23 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                     return returns_baz()
                 """,
             ),
-            (
+            "with_nested_import": (
                 """
-                def foo() -> int: ...
+                def foo(x: django.http.response.HttpResponse) -> str:
+                    pass
+                """,
+                """
+                def foo(x) -> str:
+                    pass
+                """,
+                """
+                from django.http.response import HttpResponse
 
-                class A:
-                    def foo() -> str: ...
-                """,
-                """
-                def foo():
-                    return 1
-                class A:
-                    def foo():
-                        return ''
-                """,
-                """
-                def foo() -> int:
-                    return 1
-                class A:
-                    def foo() -> str:
-                        return ''
+                def foo(x: HttpResponse) -> str:
+                    pass
                 """,
             ),
-            (
-                """
-                bar: int = ...
-                """,
-                """
-                bar = foo()
-                """,
-                """
-                bar: int = foo()
-                """,
-            ),
-            (
-                """
-                bar: int = ...
-                """,
-                """
-                bar: str = foo()
-                """,
-                """
-                bar: str = foo()
-                """,
-            ),
-            (
-                """
-                bar: int = ...
-                class A:
-                    bar: str = ...
-                """,
-                """
-                bar = foo()
-                class A:
-                    bar = foobar()
-                """,
-                """
-                bar: int = foo()
-                class A:
-                    bar: str = foobar()
-                """,
-            ),
-            (
-                """
-                bar: int = ...
-                class A:
-                    bar: str = ...
-                """,
-                """
-                bar = foo()
-                class A:
-                    bar = foobar()
-                """,
-                """
-                bar: int = foo()
-                class A:
-                    bar: str = foobar()
-                """,
-            ),
-            (
-                """
-                a: int = ...
-                b: str = ...
-                """,
-                """
-                def foo() -> Tuple[int, str]:
-                    return (1, "")
-
-                a, b = foo()
-                """,
-                """
-                a: int
-                b: str
-
-                def foo() -> Tuple[int, str]:
-                    return (1, "")
-
-                a, b = foo()
-                """,
-            ),
-            (
-                """
-                a: int = ...
-                b: str = ...
-                """,
-                """
-                def foo() -> Tuple[int, str]:
-                    return (1, "")
-
-                [a, b] = foo()
-                """,
-                """
-                a: int
-                b: str
-
-                def foo() -> Tuple[int, str]:
-                    return (1, "")
-
-                [a, b] = foo()
-                """,
-            ),
-            (
-                """
-                x: int = ...
-                y: int = ...
-                z: int = ...
-                """,
-                """
-                x = y = z = 1
-                """,
-                """
-                x: int
-                y: int
-                z: int
-
-                x = y = z = 1
-                """,
-            ),
-            # Don't add annotations if one is already present
-            (
+            "no_override_existing": (
                 """
                 def foo(x: int = 1) -> List[str]: ...
                 """,
@@ -345,7 +307,7 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                     return ['']
                 """,
             ),
-            (
+            "with_typing_import__basic": (
                 """
                 from typing import List
 
@@ -362,7 +324,7 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                     return [1]
                 """,
             ),
-            (
+            "with_typing_import__add_to_preexisting_line": (
                 """
                 from typing import List
 
@@ -381,139 +343,7 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                     return [1]
                 """,
             ),
-            (
-                """
-                a: Dict[str, int] = ...
-                """,
-                """
-                def foo() -> int:
-                    return 1
-                a = {}
-                a['x'] = foo()
-                """,
-                """
-                def foo() -> int:
-                    return 1
-                a: Dict[str, int] = {}
-                a['x'] = foo()
-                """,
-            ),
-            # Test that tuples with subscripts are handled correctly
-            # and top level annotations are added in the correct place
-            (
-                """
-                a: int = ...
-                """,
-                """
-                from typing import Tuple
-
-                def foo() -> Tuple[str, int]:
-                    return "", 1
-
-                b['z'], a = foo()
-                """,
-                """
-                from typing import Tuple
-                a: int
-
-                def foo() -> Tuple[str, int]:
-                    return "", 1
-
-                b['z'], a = foo()
-                """,
-            ),
-            # Don't override existing default parameter values
-            (
-                """
-                class B:
-                    def foo(self, x: int = a.b.A.__add__(1), y=None) -> int: ...
-                """,
-                """
-                class B:
-                    def foo(self, x = A + 1, y = None) -> int:
-                        return x
-
-                """,
-                """
-                class B:
-                    def foo(self, x: int = A + 1, y = None) -> int:
-                        return x
-                """,
-            ),
-            (
-                """
-                def foo(x: int) -> int: ...
-                """,
-                """
-                def foo(x) -> int:
-                    return x
-                """,
-                """
-                def foo(x: int) -> int:
-                    return x
-                """,
-            ),
-            (
-                """
-                async def a(r: Request, z=None) -> django.http.response.HttpResponse: ...
-                async def b(r: Request, z=None) -> django.http.response.HttpResponse: ...
-                async def c(r: Request, z=None) -> django.http.response.HttpResponse: ...
-                """,
-                """
-                async def a(r: Request, z=None): ...
-                async def b(r: Request, z=None): ...
-                async def c(r: Request, z=None): ...
-                """,
-                """
-                from django.http.response import HttpResponse
-
-                async def a(r: Request, z=None) -> HttpResponse: ...
-                async def b(r: Request, z=None) -> HttpResponse: ...
-                async def c(r: Request, z=None) -> HttpResponse: ...
-                """,
-            ),
-            (
-                """
-                FOO: a.b.Example = ...
-                """,
-                """
-                FOO = bar()
-                """,
-                """
-                from a.b import Example
-
-                FOO: Example = bar()
-                """,
-            ),
-            (
-                """
-                FOO: Union[a.b.Example, int] = ...
-                """,
-                """
-                FOO = bar()
-                """,
-                """
-                from a.b import Example
-
-                FOO: Union[Example, int] = bar()
-                """,
-            ),
-            (
-                """
-                def foo(x: int) -> List[Union[a.b.Example, str]]: ...
-                """,
-                """
-                def foo(x: int):
-                    return [barfoo(), ""]
-                """,
-                """
-                from a.b import Example
-
-                def foo(x: int) -> List[Union[Example, str]]:
-                    return [barfoo(), ""]
-                """,
-            ),
-            (
+            "add_imports_for_nested_types": (
                 """
                 def foo(x: int) -> Optional[a.b.Example]: ...
                 """,
@@ -528,20 +358,35 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                     pass
                 """,
             ),
-            (
+            "UNSUPPORTED_add_imports_for_generics": (
                 """
-                def foo(x: int) -> str: ...
+                def foo(x: int) -> typing.Optional[Example]: ...
                 """,
                 """
-                def foo(x: str):
+                def foo(x: int):
                     pass
                 """,
                 """
-                def foo(x: str) -> str:
+                def foo(x: int) -> typing.Optional[Example]:
                     pass
                 """,
             ),
-            (
+            "add_imports_for_doubly_nested_types": (
+                """
+                def foo(x: int) -> List[Union[a.b.Example, str]]: ...
+                """,
+                """
+                def foo(x: int):
+                    return [barfoo(), ""]
+                """,
+                """
+                from a.b import Example
+
+                def foo(x: int) -> List[Union[Example, str]]:
+                    return [barfoo(), ""]
+                """,
+            ),
+            "deeply_nested_example_with_multiline_annotation": (
                 """
                 def foo(x: int)-> Union[
                     Coroutine[Any, Any, django.http.response.HttpResponse], str
@@ -561,41 +406,7 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                     pass
                 """,
             ),
-            (
-                """
-                def foo(x: django.http.response.HttpResponse) -> str:
-                    pass
-                """,
-                """
-                def foo(x) -> str:
-                    pass
-                """,
-                """
-                from django.http.response import HttpResponse
-
-                def foo(x: HttpResponse) -> str:
-                    pass
-                """,
-            ),
-            (
-                """
-                def foo() -> b.b.A: ...
-                """,
-                """
-                from c import A as B, bar
-
-                def foo():
-                    return bar()
-                """,
-                """
-                from c import A as B, bar
-                from b.b import A
-
-                def foo() -> A:
-                    return bar()
-                """,
-            ),
-            (
+            "do_not_add_imports_inside_of_Type": (
                 """
                 from typing import Type
 
@@ -617,7 +428,66 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                     return A
                 """,
             ),
-            (
+            "with_async": (
+                """
+                async def a(r: Request, z=None) -> django.http.response.HttpResponse: ...
+                async def b(r: Request, z=None) -> django.http.response.HttpResponse: ...
+                async def c(r: Request, z=None) -> django.http.response.HttpResponse: ...
+                """,
+                """
+                async def a(r: Request, z=None): ...
+                async def b(r: Request, z=None): ...
+                async def c(r: Request, z=None): ...
+                """,
+                """
+                from django.http.response import HttpResponse
+
+                async def a(r: Request, z=None) -> HttpResponse: ...
+                async def b(r: Request, z=None) -> HttpResponse: ...
+                async def c(r: Request, z=None) -> HttpResponse: ...
+                """,
+            ),
+            "async_with_decorators": (
+                """
+                def async_with_decorators(a: bool, b: bool) -> str: ...
+                """,
+                """
+                @second_decorator
+                @first_decorator(5)
+                async def async_with_decorators(a, b):
+                    return "hello"
+                """,
+                """
+                @second_decorator
+                @first_decorator(5)
+                async def async_with_decorators(a: bool, b: bool) -> str:
+                    return "hello"
+                """,
+            ),
+            # test cases named with the REQUIRES_PREEXISTING prefix are verifying
+            # that certain special cases work if the stub and the existing code
+            # happen to align well, but none of these cases are guaranteed to work
+            # in general - for example duplicate type names will generally result in
+            # incorrect codemod.
+            "REQURIES_PREEXISTING_new_import_okay_if_existing_aliased": (
+                """
+                def foo() -> b.b.A: ...
+                """,
+                """
+                from c import A as B, bar
+
+                def foo():
+                    return bar()
+                """,
+                """
+                from c import A as B, bar
+                from b.b import A
+
+                def foo() -> A:
+                    return bar()
+                """,
+            ),
+            "REQUIRES_PREEXISTING_fully_qualified_with_alias": (
                 """
                 def foo() -> db.Connection: ...
                 """,
@@ -632,7 +502,7 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                   return db.Connection()
                 """,
             ),
-            (
+            "REQURIRES_PREEXISTING_fully_qualified_typing": (
                 """
                 def foo() -> typing.Sequence[int]: ...
                 """,
@@ -647,69 +517,114 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                   return []
                 """,
             ),
-            # Insert a TypedDict class that is not in the source file.
-            (
-                """
-                from mypy_extensions import TypedDict
+        }
+    )
+    def test_annotate_simple_functions(
+        self, stub: str, before: str, after: str
+    ) -> None:
+        self.run_simple_test_case(stub=stub, before=before, after=after)
 
-                class MovieTypedDict(TypedDict):
-                    name: str
-                    year: int
+    @data_provider(
+        {
+            "respect_default_values_1": (
+                """
+                class B:
+                    def foo(self, x: int = a.b.A.__add__(1), y=None) -> int: ...
                 """,
                 """
-                def foo() -> None:
-                    pass
+                class B:
+                    def foo(self, x = A + 1, y = None) -> int:
+                        return x
+
                 """,
                 """
-                from mypy_extensions import TypedDict
-
-                class MovieTypedDict(TypedDict):
-                    name: str
-                    year: int
-
-                def foo() -> None:
-                    pass
-                """,
-            ),
-            # Insert only the TypedDict class that is not in the source file.
-            (
-                """
-                from mypy_extensions import TypedDict
-
-                class MovieTypedDict(TypedDict):
-                    name: str
-                    year: int
-
-                class ExistingMovieTypedDict(TypedDict):
-                    name: str
-                    year: int
-                """,
-                """
-                from mypy_extensions import TypedDict
-
-                class ExistingMovieTypedDict(TypedDict):
-                    name: str
-                    year: int
-
-                def foo() -> None:
-                    pass
-                """,
-                """
-                from mypy_extensions import TypedDict
-
-                class MovieTypedDict(TypedDict):
-                    name: str
-                    year: int
-
-                class ExistingMovieTypedDict(TypedDict):
-                    name: str
-                    year: int
-
-                def foo() -> None:
-                    pass
+                class B:
+                    def foo(self, x: int = A + 1, y = None) -> int:
+                        return x
                 """,
             ),
-            (
+            "respect_default_values_2": (
+                """
+                from typing import Optional
+
+                class A:
+                    def foo(self, atticus, b: Optional[int] = None, c: bool = False): ...
+                """,
+                """
+                class A:
+                    def foo(self, atticus, b = None, c = False): ...
+                """,
+                """
+                from typing import Optional
+
+                class A:
+                    def foo(self, atticus, b: Optional[int] = None, c: bool = False): ...
+                """,
+            ),
+        }
+    )
+    def test_annotate_classes(self, stub: str, before: str, after: str) -> None:
+        self.run_simple_test_case(stub=stub, before=before, after=after)
+
+    @data_provider(
+        {
+            "method_and_function_of_same_name": (
+                """
+                def foo() -> int: ...
+
+                class A:
+                    def foo() -> str: ...
+                """,
+                """
+                def foo():
+                    return 1
+                class A:
+                    def foo():
+                        return ''
+                """,
+                """
+                def foo() -> int:
+                    return 1
+                class A:
+                    def foo() -> str:
+                        return ''
+                """,
+            ),
+            "global_and_attribute_of_same_name": (
+                """
+                bar: int = ...
+                class A:
+                    bar: str = ...
+                """,
+                """
+                bar = foo()
+                class A:
+                    bar = foobar()
+                """,
+                """
+                bar: int = foo()
+                class A:
+                    bar: str = foobar()
+                """,
+            ),
+            "add_global_annotation_simple_case": (
+                """
+                a: Dict[str, int] = ...
+                """,
+                """
+                def foo() -> int:
+                    return 1
+                a = {}
+                a['x'] = foo()
+                """,
+                """
+                def foo() -> int:
+                    return 1
+                a: Dict[str, int] = {}
+                a['x'] = foo()
+                """,
+            ),
+            "add_global_annotation_with_Type__no_added_import": (
                 """
                 from typing import Dict
 
@@ -736,33 +651,82 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                 example: Dict[str, Type[foo.Example]] = { "test": foo() }
                 """,
             ),
-            (
+            "tuple_assign__add_new_top_level_declarations": (
                 """
-                from typing import Optional
-
-                class A:
-                    def foo(self, atticus, b: Optional[int] = None, c: bool = False): ...
+                a: int = ...
+                b: str = ...
                 """,
                 """
-                class A:
-                    def foo(self, atticus, b = None, c = False): ...
+                def foo() -> Tuple[int, str]:
+                    return (1, "")
+
+                a, b = foo()
                 """,
                 """
-                from typing import Optional
+                a: int
+                b: str
 
-                class A:
-                    def foo(self, atticus, b: Optional[int] = None, c: bool = False): ...
+                def foo() -> Tuple[int, str]:
+                    return (1, "")
+
+                a, b = foo()
                 """,
             ),
-            # Make sure we handle string annotations well
-            (
+            "list_assign__add_new_top_level_declarations": (
                 """
+                a: int = ...
+                b: str = ...
+                """,
+                """
+                def foo() -> Tuple[int, str]:
+                    return (1, "")
+
+                [a, b] = foo()
+                """,
+                """
+                a: int
+                b: str
+
+                def foo() -> Tuple[int, str]:
+                    return (1, "")
+
+                [a, b] = foo()
+                """,
+            ),
+            "tuples_with_subscripts__add_new_toplevel_declaration": (
+                """
+                a: int = ...
+                """,
+                """
+                from typing import Tuple
+
+                def foo() -> Tuple[str, int]:
+                    return "", 1
+
+                b['z'], a = foo()
+                """,
+                """
+                from typing import Tuple
+                a: int
+
+                def foo() -> Tuple[str, int]:
+                    return "", 1
+
+                b['z'], a = foo()
+                """,
+            ),
+            "handle_quoted_annotations": (
+                """
+                bar: "a.b.Example"
+
                 def f(x: "typing.Union[int, str]") -> "typing.Union[int, str]": ...
 
                 class A:
                     def f(self: "A") -> "A": ...
                 """,
                 """
+                bar = Example()
+
                 def f(x):
                     return x
 
@@ -771,6 +735,8 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                         return self
                 """,
                 """
+                bar: "a.b.Example" = Example()
+
                 def f(x: "typing.Union[int, str]") -> "typing.Union[int, str]":
                     return x
 
@@ -779,14 +745,81 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                         return self
                 """,
             ),
-        )
+        }
     )
-    def test_annotate_functions(self, stub: str, before: str, after: str) -> None:
+    def test_annotate_mixed(self, stub: str, before: str, after: str) -> None:
         self.run_simple_test_case(stub=stub, before=before, after=after)
 
     @data_provider(
-        (
-            (
+        {
+            "insert_new_TypedDict_class_not_in_source_file": (
+                """
+                from mypy_extensions import TypedDict
+
+                class MovieTypedDict(TypedDict):
+                    name: str
+                    year: int
+                """,
+                """
+                def foo() -> None:
+                    pass
+                """,
+                """
+                from mypy_extensions import TypedDict
+
+                class MovieTypedDict(TypedDict):
+                    name: str
+                    year: int
+
+                def foo() -> None:
+                    pass
+                """,
+            ),
+            "insert_only_TypedDict_class_not_already_in_source": (
+                """
+                from mypy_extensions import TypedDict
+
+                class MovieTypedDict(TypedDict):
+                    name: str
+                    year: int
+
+                class ExistingMovieTypedDict(TypedDict):
+                    name: str
+                    year: int
+                """,
+                """
+                from mypy_extensions import TypedDict
+
+                class ExistingMovieTypedDict(TypedDict):
+                    name: str
+                    year: int
+
+                def foo() -> None:
+                    pass
+                """,
+                """
+                from mypy_extensions import TypedDict
+
+                class MovieTypedDict(TypedDict):
+                    name: str
+                    year: int
+
+                class ExistingMovieTypedDict(TypedDict):
+                    name: str
+                    year: int
+
+                def foo() -> None:
+                    pass
+                """,
+            ),
+        }
+    )
+    def test_adding_typed_dicts(self, stub: str, before: str, after: str) -> None:
+        self.run_simple_test_case(stub=stub, before=before, after=after)
+
+    @data_provider(
+        {
+            "required_positional_only_args": (
                 """
                 def foo(
                     a: int, /, b: str, c: int = ..., *, d: str = ..., e: int, f: int = ...
@@ -805,7 +838,7 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                     return 1
                 """,
             ),
-            (
+            "positional_only_arg_with_default_value": (
                 """
                 def foo(
                     a: int, b: int = ..., /, c: int = ..., *, d: str = ..., e: int, f: int = ...
@@ -824,28 +857,28 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                     return 1
                 """,
             ),
-        )
+        }
     )
     @unittest.skipIf(sys.version_info < (3, 8), "Unsupported Python version")
     def test_annotate_functions_py38(self, stub: str, before: str, after: str) -> None:
         self.run_simple_test_case(stub=stub, before=before, after=after)
 
     @data_provider(
-        (
-            (
+        {
+            "fully_annotated_with_different_stub": (
                 """
-                def fully_annotated_with_different_stub(a: bool, b: bool) -> str: ...
+                def f(a: bool, b: bool) -> str: ...
                 """,
                 """
-                def fully_annotated_with_different_stub(a: int, b: str) -> bool:
+                def f(a: int, b: str) -> bool:
                     return 'hello'
                 """,
                 """
-                def fully_annotated_with_different_stub(a: bool, b: bool) -> str:
+                def f(a: bool, b: bool) -> str:
                     return 'hello'
                 """,
             ),
-        )
+        }
     )
     def test_annotate_functions_with_existing_annotations(
         self, stub: str, before: str, after: str
@@ -858,64 +891,47 @@ class TestApplyAnnotationsVisitor(CodemodTest):
         )
 
     @data_provider(
-        (
-            (
+        {
+            "fully_annotated_with_untyped_stub": (
                 """
-                def fully_annotated_with_untyped_stub(a, b): ...
+                def f(a, b): ...
                 """,
                 """
-                def fully_annotated_with_untyped_stub(a: bool, b: bool) -> str:
+                def f(a: bool, b: bool) -> str:
                     return "hello"
                 """,
                 """
-                def fully_annotated_with_untyped_stub(a: bool, b: bool) -> str:
-                    return "hello"
-                """,
-            ),
-            (
-                """
-                def params_annotated_with_return_from_stub(a, b) -> str: ...
-                """,
-                """
-                def params_annotated_with_return_from_stub(a: bool, b: bool):
-                    return "hello"
-                """,
-                """
-                def params_annotated_with_return_from_stub(a: bool, b: bool) -> str:
+                def f(a: bool, b: bool) -> str:
                     return "hello"
                 """,
             ),
-            (
+            "params_annotated_with_return_from_stub": (
                 """
-                def partially_annotated_params_with_partial_stub(a, b: int): ...
+                def f(a, b) -> str: ...
                 """,
                 """
-                def partially_annotated_params_with_partial_stub(a: bool, b) -> str:
+                def f(a: bool, b: bool):
                     return "hello"
                 """,
                 """
-                def partially_annotated_params_with_partial_stub(a: bool, b: int) -> str:
-                    return "hello"
-                """,
-            ),
-            (
-                """
-                def async_with_decorators(a: bool, b: bool) -> str: ...
-                """,
-                """
-                @second_decorator
-                @first_decorator(5)
-                async def async_with_decorators(a, b):
-                    return "hello"
-                """,
-                """
-                @second_decorator
-                @first_decorator(5)
-                async def async_with_decorators(a: bool, b: bool) -> str:
+                def f(a: bool, b: bool) -> str:
                     return "hello"
                 """,
             ),
-        )
+            "partially_annotated_params_with_partial_stub": (
+                """
+                def f(a, b: int): ...
+                """,
+                """
+                def f(a: bool, b) -> str:
+                    return "hello"
+                """,
+                """
+                def f(a: bool, b: int) -> str:
+                    return "hello"
+                """,
+            ),
+        }
     )
     def test_annotate_using_incomplete_stubs(
         self, stub: str, before: str, after: str


### PR DESCRIPTION
## Summary

The ApplyTypeAnnotationsVisitor unit tests are very important for type coverage codemod
work because the existing logic is buggy, which means we need it to be
- easy to navigate existing tests, including seeing which ones illustrate
   half-working or completely unsupported logic
- easy to add new tests

To that end, in this commit I do the following:
- break up the misleading "functions" test into globals, functions, classes, and mixed tests
- use the dict form of data provider so that every test has a well-defined name, which gets
   reported when we run into errors
- use the convention that the test case name includes UNSUPPORTED when a test records
   something the code cannot do - this is critical because downstream use cases need to work
   around any bugs in LibCST at least until a bugfix is out *and* we've fully released it
- use the convention that the test case name includes BRITTLE if it's testing logic that doesn't
   work in general (I added this because some tests *appear* to make correctness claims that
   are misleading - for example we happen to deal with aliased imports properly in the edge case
   where the existing code renames to avoid a name clash with the stub, but in general we
   will codegen all kinds of wrong code)

I also tweaked a few tests to improve readability, and removed a couple of duplicates

## Test Plan

```
> python -m unittest libcst.codemod.visitors.tests.test_apply_type_annotations
..............................................
----------------------------------------------------------------------
Ran 46 tests in 1.562s

OK
```
