### PR TITLE
Fix pyre command for type inference provider

### DIFF
--- a/libcst/metadata/tests/test_type_inference_provider.py
+++ b/libcst/metadata/tests/test_type_inference_provider.py
@@ -9,6 +9,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from unittest import skipIf
 
 import libcst as cst
 from libcst import MetadataWrapper
@@ -51,6 +52,10 @@ def _test_simple_class_helper(test: UnitTest, wrapper: MetadataWrapper) -> None:
     test.assertEqual(types[items], "typing.Sequence[simple_class.Item]")
 
 
+@skipIf(
+    sys.version_info < (3, 7), "TypeInferenceProvider doesn't support 3.6 and below"
+)
+@skipIf(sys.platform == "win32", "TypeInferenceProvider doesn't support windows")
 class TypeInferenceProviderTest(UnitTest):
     @classmethod
     def setUpClass(cls):
@@ -71,8 +76,6 @@ class TypeInferenceProviderTest(UnitTest):
         ((TEST_SUITE_PATH / "simple_class.py", TEST_SUITE_PATH / "simple_class.json"),)
     )
     def test_gen_cache(self, source_path: Path, data_path: Path) -> None:
-        if sys.version_info < (3, 7):
-            self.skipTest("this test doesnt support 3.6 and below")
         cache = TypeInferenceProvider.gen_cache(
             root_path=source_path.parent, paths=[source_path.name], timeout=None
         )

--- a/libcst/metadata/tests/test_type_inference_provider.py
+++ b/libcst/metadata/tests/test_type_inference_provider.py
@@ -5,6 +5,7 @@
 
 
 import json
+import subprocess
 from pathlib import Path
 
 import libcst as cst
@@ -53,6 +54,19 @@ def _test_simple_class_helper(test: UnitTest, wrapper: MetadataWrapper) -> None:
 
 
 class TypeInferenceProviderTest(UnitTest):
+    def setUp(self):
+        try:
+            subprocess.run(["pyre", "start", "--no-watchman"])
+        except subprocess.TimeoutExpired as exc:
+            raise exc
+
+    def tearDown(self):
+        try:
+            subprocess.run(["pyre", "stop"])
+        except subprocess.TimeoutExpired as exc:
+            raise exc
+
+
     @data_provider(
         ((TEST_SUITE_PATH / "simple_class.py", TEST_SUITE_PATH / "simple_class.json"),)
     )

--- a/libcst/metadata/tests/test_type_inference_provider.py
+++ b/libcst/metadata/tests/test_type_inference_provider.py
@@ -7,6 +7,7 @@
 import json
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import libcst as cst
@@ -70,6 +71,8 @@ class TypeInferenceProviderTest(UnitTest):
         ((TEST_SUITE_PATH / "simple_class.py", TEST_SUITE_PATH / "simple_class.json"),)
     )
     def test_gen_cache(self, source_path: Path, data_path: Path) -> None:
+        if sys.version < (3, 7):
+            self.skipTest()
         cache = TypeInferenceProvider.gen_cache(
             root_path=source_path.parent, paths=[source_path.name], timeout=None
         )

--- a/libcst/metadata/tests/test_type_inference_provider.py
+++ b/libcst/metadata/tests/test_type_inference_provider.py
@@ -56,6 +56,16 @@ class TypeInferenceProviderTest(UnitTest):
     @data_provider(
         ((TEST_SUITE_PATH / "simple_class.py", TEST_SUITE_PATH / "simple_class.json"),)
     )
+    def test_gen_cache(self, source_path: Path, data_path: Path) -> None:
+        cache = TypeInferenceProvider.gen_cache(
+            root_path=source_path.parent, paths=[source_path.name], timeout=None
+        )
+        data: PyreData = json.loads(data_path.read_text())
+        self.assertEqual(cache[source_path.name], data)
+
+    @data_provider(
+        ((TEST_SUITE_PATH / "simple_class.py", TEST_SUITE_PATH / "simple_class.json"),)
+    )
     def test_simple_class_types(self, source_path: Path, data_path: Path) -> None:
         data: PyreData = json.loads(data_path.read_text())
         wrapper = MetadataWrapper(

--- a/libcst/metadata/tests/test_type_inference_provider.py
+++ b/libcst/metadata/tests/test_type_inference_provider.py
@@ -5,6 +5,7 @@
 
 
 import json
+import os
 import subprocess
 from pathlib import Path
 
@@ -36,36 +37,34 @@ def _test_simple_class_helper(test: UnitTest, wrapper: MetadataWrapper) -> None:
         test.assertEqual(types[value], "int")
 
     # self
-    test.assertEqual(
-        types[self_number_attr.value], "libcst.tests.pyre.simple_class.Item"
-    )
+    test.assertEqual(types[self_number_attr.value], "simple_class.Item")
     collector_assign = cst.ensure_type(
         cst.ensure_type(m.body[3], cst.SimpleStatementLine).body[0], cst.Assign
     )
     collector = collector_assign.targets[0].target
-    test.assertEqual(types[collector], "libcst.tests.pyre.simple_class.ItemCollector")
+    test.assertEqual(types[collector], "simple_class.ItemCollector")
     items_assign = cst.ensure_type(
         cst.ensure_type(m.body[4], cst.SimpleStatementLine).body[0], cst.AnnAssign
     )
     items = items_assign.target
-    test.assertEqual(
-        types[items], "typing.Sequence[libcst.tests.pyre.simple_class.Item]"
-    )
+    test.assertEqual(types[items], "typing.Sequence[simple_class.Item]")
 
 
 class TypeInferenceProviderTest(UnitTest):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
+        os.chdir(TEST_SUITE_PATH)
         try:
-            subprocess.run(["pyre", "start", "--no-watchman"])
+            subprocess.run(["pyre", "-n", "start", "--no-watchman"])
         except subprocess.TimeoutExpired as exc:
             raise exc
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         try:
-            subprocess.run(["pyre", "stop"])
+            subprocess.run(["pyre", "-n", "stop"], cwd=TEST_SUITE_PATH)
         except subprocess.TimeoutExpired as exc:
             raise exc
-
 
     @data_provider(
         ((TEST_SUITE_PATH / "simple_class.py", TEST_SUITE_PATH / "simple_class.json"),)

--- a/libcst/metadata/tests/test_type_inference_provider.py
+++ b/libcst/metadata/tests/test_type_inference_provider.py
@@ -71,7 +71,7 @@ class TypeInferenceProviderTest(UnitTest):
         ((TEST_SUITE_PATH / "simple_class.py", TEST_SUITE_PATH / "simple_class.json"),)
     )
     def test_gen_cache(self, source_path: Path, data_path: Path) -> None:
-        if sys.version < (3, 7):
+        if sys.version_info < (3, 7):
             self.skipTest()
         cache = TypeInferenceProvider.gen_cache(
             root_path=source_path.parent, paths=[source_path.name], timeout=None

--- a/libcst/metadata/tests/test_type_inference_provider.py
+++ b/libcst/metadata/tests/test_type_inference_provider.py
@@ -72,7 +72,7 @@ class TypeInferenceProviderTest(UnitTest):
     )
     def test_gen_cache(self, source_path: Path, data_path: Path) -> None:
         if sys.version_info < (3, 7):
-            self.skipTest()
+            self.skipTest("this test doesnt support 3.6 and below")
         cache = TypeInferenceProvider.gen_cache(
             root_path=source_path.parent, paths=[source_path.name], timeout=None
         )

--- a/libcst/metadata/type_inference_provider.py
+++ b/libcst/metadata/type_inference_provider.py
@@ -57,7 +57,7 @@ class TypeInferenceProvider(BatchableMetadataProvider[str]):
         root_path: Path, paths: List[str], timeout: Optional[int]
     ) -> Mapping[str, object]:
         params = ",".join(f"path='{root_path / path}'" for path in paths)
-        cmd_args = ["pyre", "--noninteractive", "query", f'"types({params})"']
+        cmd_args = ["pyre", "--noninteractive", "query", f"types({params})"]
         try:
             stdout, stderr, return_code = run_command(cmd_args, timeout=timeout)
         except subprocess.TimeoutExpired as exc:

--- a/libcst/tests/pyre/.pyre_configuration
+++ b/libcst/tests/pyre/.pyre_configuration
@@ -1,0 +1,7 @@
+{
+  "source_directories": [
+    "."
+  ],
+  "search_path": [],
+  "workers": 1
+}

--- a/libcst/tests/pyre/simple_class.json
+++ b/libcst/tests/pyre/simple_class.json
@@ -24,7 +24,7 @@
           "column": 10
         }
       },
-      "annotation": "typing.Type[libcst.tests.pyre.simple_class.Item]"
+      "annotation": "typing.Type[simple_class.Item]"
     },
     {
       "location": {
@@ -37,7 +37,7 @@
           "column": 16
         }
       },
-      "annotation": "typing.Callable(libcst.tests.pyre.simple_class.Item.__init__)[[Named(self, libcst.tests.pyre.simple_class.Item), Named(n, int)], None]"
+      "annotation": "typing.Callable(simple_class.Item.__init__)[[Named(self, simple_class.Item), Named(n, int)], None]"
     },
     {
       "location": {
@@ -50,7 +50,7 @@
           "column": 21
         }
       },
-      "annotation": "libcst.tests.pyre.simple_class.Item"
+      "annotation": "simple_class.Item"
     },
     {
       "location": {
@@ -102,7 +102,7 @@
           "column": 12
         }
       },
-      "annotation": "libcst.tests.pyre.simple_class.Item"
+      "annotation": "simple_class.Item"
     },
     {
       "location": {
@@ -154,7 +154,7 @@
           "column": 19
         }
       },
-      "annotation": "typing.Type[libcst.tests.pyre.simple_class.ItemCollector]"
+      "annotation": "typing.Type[simple_class.ItemCollector]"
     },
     {
       "location": {
@@ -167,7 +167,7 @@
           "column": 17
         }
       },
-      "annotation": "typing.Callable(libcst.tests.pyre.simple_class.ItemCollector.get_items)[[Named(self, libcst.tests.pyre.simple_class.ItemCollector), Named(n, int)], typing.Sequence[libcst.tests.pyre.simple_class.Item]]"
+      "annotation": "typing.Callable(simple_class.ItemCollector.get_items)[[Named(self, simple_class.ItemCollector), Named(n, int)], typing.Sequence[simple_class.Item]]"
     },
     {
       "location": {
@@ -180,7 +180,7 @@
           "column": 22
         }
       },
-      "annotation": "libcst.tests.pyre.simple_class.ItemCollector"
+      "annotation": "simple_class.ItemCollector"
     },
     {
       "location": {
@@ -232,7 +232,7 @@
           "column": 49
         }
       },
-      "annotation": "typing.Type[typing.Sequence[libcst.tests.pyre.simple_class.Item]]"
+      "annotation": "typing.Type[typing.Sequence[simple_class.Item]]"
     },
     {
       "location": {
@@ -245,7 +245,7 @@
           "column": 48
         }
       },
-      "annotation": "typing.Type[libcst.tests.pyre.simple_class.Item]"
+      "annotation": "typing.Type[simple_class.Item]"
     },
     {
       "location": {
@@ -258,7 +258,7 @@
           "column": 42
         }
       },
-      "annotation": "typing.List[libcst.tests.pyre.simple_class.Item]"
+      "annotation": "typing.List[simple_class.Item]"
     },
     {
       "location": {
@@ -271,7 +271,7 @@
           "column": 20
         }
       },
-      "annotation": "typing.Type[libcst.tests.pyre.simple_class.Item]"
+      "annotation": "typing.Type[simple_class.Item]"
     },
     {
       "location": {
@@ -284,7 +284,7 @@
           "column": 23
         }
       },
-      "annotation": "libcst.tests.pyre.simple_class.Item"
+      "annotation": "simple_class.Item"
     },
     {
       "location": {
@@ -349,7 +349,7 @@
           "column": 9
         }
       },
-      "annotation": "libcst.tests.pyre.simple_class.ItemCollector"
+      "annotation": "simple_class.ItemCollector"
     },
     {
       "location": {
@@ -362,7 +362,7 @@
           "column": 25
         }
       },
-      "annotation": "typing.Type[libcst.tests.pyre.simple_class.ItemCollector]"
+      "annotation": "typing.Type[simple_class.ItemCollector]"
     },
     {
       "location": {
@@ -375,7 +375,7 @@
           "column": 27
         }
       },
-      "annotation": "libcst.tests.pyre.simple_class.ItemCollector"
+      "annotation": "simple_class.ItemCollector"
     },
     {
       "location": {
@@ -388,7 +388,7 @@
           "column": 5
         }
       },
-      "annotation": "typing.Sequence[libcst.tests.pyre.simple_class.Item]"
+      "annotation": "typing.Sequence[simple_class.Item]"
     },
     {
       "location": {
@@ -401,7 +401,7 @@
           "column": 21
         }
       },
-      "annotation": "typing.Type[typing.Sequence[libcst.tests.pyre.simple_class.Item]]"
+      "annotation": "typing.Type[typing.Sequence[simple_class.Item]]"
     },
     {
       "location": {
@@ -414,7 +414,7 @@
           "column": 33
         }
       },
-      "annotation": "libcst.tests.pyre.simple_class.ItemCollector"
+      "annotation": "simple_class.ItemCollector"
     },
     {
       "location": {
@@ -427,7 +427,7 @@
           "column": 43
         }
       },
-      "annotation": "BoundMethod[typing.Callable(libcst.tests.pyre.simple_class.ItemCollector.get_items)[[Named(self, libcst.tests.pyre.simple_class.ItemCollector), Named(n, int)], typing.Sequence[libcst.tests.pyre.simple_class.Item]], libcst.tests.pyre.simple_class.ItemCollector]"
+      "annotation": "BoundMethod[typing.Callable(simple_class.ItemCollector.get_items)[[Named(self, simple_class.ItemCollector), Named(n, int)], typing.Sequence[simple_class.Item]], simple_class.ItemCollector]"
     },
     {
       "location": {
@@ -440,7 +440,7 @@
           "column": 46
         }
       },
-      "annotation": "typing.Sequence[libcst.tests.pyre.simple_class.Item]"
+      "annotation": "typing.Sequence[simple_class.Item]"
     },
     {
       "location": {
@@ -466,7 +466,7 @@
           "column": 8
         }
       },
-      "annotation": "libcst.tests.pyre.simple_class.Item"
+      "annotation": "simple_class.Item"
     },
     {
       "location": {
@@ -479,7 +479,7 @@
           "column": 17
         }
       },
-      "annotation": "typing.Sequence[libcst.tests.pyre.simple_class.Item]"
+      "annotation": "typing.Sequence[simple_class.Item]"
     },
     {
       "location": {
@@ -492,7 +492,7 @@
           "column": 8
         }
       },
-      "annotation": "libcst.tests.pyre.simple_class.Item"
+      "annotation": "simple_class.Item"
     },
     {
       "location": {

--- a/libcst/tests/test_pyre_integration.py
+++ b/libcst/tests/test_pyre_integration.py
@@ -5,6 +5,7 @@
 
 
 import json
+import os
 from pathlib import Path
 from typing import Dict, List, Mapping, Optional, Tuple, Union
 
@@ -122,6 +123,7 @@ if __name__ == "__main__":
     stdout: str
     stderr: str
     return_code: int
+    os.chdir(TEST_SUITE_PATH)
     stdout, stderr, return_code = run_command(["pyre", "start", "--no-watchman"])
     if return_code != 0:
         print(stdout)


### PR DESCRIPTION
## Summary

Pyre command for type inference provider has one of its params quoted and causing the Pyre to fail to parse the command line.

## Test Plan

Added unit test to generate the cache and compare with the expected result.