### PR TITLE
Remove a dead method in ApplyTypeAnnotationsVisitor

### DIFF
--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -263,17 +263,6 @@ class ApplyTypeAnnotationsVisitor(ContextAwareTransformer):
         stub: cst.Module,
         overwrite_existing_annotations: bool = False,
     ) -> None:
-        # deprecated, should be removed in 0.4 release.
-        ApplyTypeAnnotationsVisitor.store_stub_in_context(
-            context, stub, overwrite_existing_annotations
-        )
-
-    @staticmethod
-    def store_stub_in_context(
-        context: CodemodContext,
-        stub: cst.Module,
-        overwrite_existing_annotations: bool = False,
-    ) -> None:
         """
         Store a stub module in the :class:`~libcst.codemod.CodemodContext` so
         that type annotations from the stub can be applied in a later


### PR DESCRIPTION


## Summary

I'm not really sure how the method got there, but it was calling
itself recursively... fortunately, it was also overwritten by
an identically named method so it was actually impossible to access.

## Test Plan

```
> python -m unittest libcst.codemod.visitors.tests.test_apply_type_annotations
..............................................
----------------------------------------------------------------------
Ran 46 tests in 1.597s

OK

```