### PR TITLE
Use `from __future__ import annotations` in ATAV

### DIFF
--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -266,7 +266,7 @@ class AnnotationCounts:
     return_annotations: int = 0
     classes_added: int = 0
 
-    def applied_changes(self):
+    def any_changes(self):
         return (
             self.global_annotations
             + self.attribute_annotations
@@ -385,7 +385,13 @@ class ApplyTypeAnnotationsVisitor(ContextAwareTransformer):
             self.annotations.class_definitions.update(visitor.class_definitions)
 
         tree_with_imports = AddImportsVisitor(self.context).transform_module(tree)
-        return tree_with_imports.visit(self)
+        tree_with_changes = tree_with_imports.visit(self)
+
+        # don't modify the imports if we didn't actually add any type information
+        if self.annotation_counts.any_changes():
+            return tree_with_changes
+        else:
+            return tree
 
     # smart constructors: all applied annotations happen via one of these
 

--- a/libcst/codemod/visitors/tests/test_apply_type_annotations.py
+++ b/libcst/codemod/visitors/tests/test_apply_type_annotations.py
@@ -1012,11 +1012,7 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                     def __init__(self):
                         self.attr_will_not_be_found = None
                 """,
-                # TODO: use the annotation counts to avoid adding
-                # the import in this case.
                 """
-                from bar import X
-
                 class C:
                     def __init__(self):
                         self.attr_will_not_be_found = None
@@ -1032,7 +1028,7 @@ class TestApplyAnnotationsVisitor(CodemodTest):
         before: str,
         after: str,
         annotation_counts: AnnotationCounts,
-        applied_changes: False,
+        any_changes: False,
     ):
         stub = self.make_fixture_data(stub)
         before = self.make_fixture_data(before)
@@ -1048,4 +1044,4 @@ class TestApplyAnnotationsVisitor(CodemodTest):
 
         self.assertEqual(after, output_code)
         self.assertEqual(str(annotation_counts), str(visitor.annotation_counts))
-        self.assertEqual(applied_changes, visitor.annotation_counts.applied_changes())
+        self.assertEqual(any_changes, visitor.annotation_counts.any_changes())

--- a/libcst/codemod/visitors/tests/test_apply_type_annotations.py
+++ b/libcst/codemod/visitors/tests/test_apply_type_annotations.py
@@ -923,6 +923,46 @@ class TestApplyAnnotationsVisitor(CodemodTest):
 
     @data_provider(
         {
+            "basic_example_using_future_annotations": (
+                """
+                def f() -> bool: ...
+                """,
+                """
+                def f():
+                    return True
+                """,
+                """
+                from __future__ import annotations
+
+                def f() -> bool:
+                    return True
+                """,
+            ),
+            "no_use_future_if_no_changes": (
+                """
+                def f() -> bool: ...
+                """,
+                """
+                def f() -> bool:
+                    return True
+                """,
+                """
+                def f() -> bool:
+                    return True
+                """,
+            ),
+        }
+    )
+    def test_use_future_annotations(self, stub: str, before: str, after: str) -> None:
+        self.run_test_case_with_flags(
+            stub=stub,
+            before=before,
+            after=after,
+            use_future_annotations=True,
+        )
+
+    @data_provider(
+        {
             "test_counting_parameters_and_returns": (
                 """
                 def f(counted: int, not_counted) -> Counted: ...
@@ -1028,7 +1068,7 @@ class TestApplyAnnotationsVisitor(CodemodTest):
         before: str,
         after: str,
         annotation_counts: AnnotationCounts,
-        any_changes: False,
+        any_changes_applied: False,
     ):
         stub = self.make_fixture_data(stub)
         before = self.make_fixture_data(before)
@@ -1044,4 +1084,6 @@ class TestApplyAnnotationsVisitor(CodemodTest):
 
         self.assertEqual(after, output_code)
         self.assertEqual(str(annotation_counts), str(visitor.annotation_counts))
-        self.assertEqual(any_changes, visitor.annotation_counts.any_changes())
+        self.assertEqual(
+            any_changes_applied, visitor.annotation_counts.any_changes_applied()
+        )


### PR DESCRIPTION
## Summary

Add a new argument to `ApplyTypeAnnotationsVisitor` that will trigger it
to add a `from __future__ import annotations` import to the top of a module.

This is a flag because it won't work on python 3.6 (in that case, users should
go in and manually quote types as needed or use quoted type names in the
stub file to begin with).

But for python 3.7+ it is a powerful tool to make adding
type annotations safer - malformed types (including types that are actually
valid for typecheckers like `os.PathLike[str]`) won't lead to runtime errors
and it's safe to use types from the current module anywhere without quoting them.

NOTE: This change should be merged only after we've merged
https://github.com/Instagram/LibCST/pull/539
to keep a clean history.


## Test Plan

```
> python -m unittest libcst.codemod.visitors.tests.test_apply_type_annotations
.................................................
----------------------------------------------------------------------
Ran 49 tests in 2.415s

OK
```
