### PR TITLE
Don't gather metadata if the wrapper already contains it

### DIFF
--- a/libcst/metadata/tests/test_metadata_wrapper.py
+++ b/libcst/metadata/tests/test_metadata_wrapper.py
@@ -123,3 +123,7 @@ class MetadataWrapperTest(UnitTest):
         wrapper.resolve(ProviderB)
         mock.visited_a.assert_called_once()
         mock.visited_b.assert_called_once()
+
+        wrapper.resolve(ProviderA)
+        mock.visited_a.assert_called_once()
+        mock.visited_b.assert_called_once()

--- a/libcst/metadata/wrapper.py
+++ b/libcst/metadata/wrapper.py
@@ -74,7 +74,7 @@ def _resolve_impl(
     as well as their dependencies.
     """
     completed = set(wrapper._metadata.keys())
-    remaining = _gather_providers(providers, set()) - completed
+    remaining = _gather_providers(set(providers), set()) - completed
 
     while len(remaining) > 0:
         batchable = set()

--- a/libcst/metadata/wrapper.py
+++ b/libcst/metadata/wrapper.py
@@ -73,10 +73,9 @@ def _resolve_impl(
     Updates the _metadata map on wrapper with metadata from the given providers
     as well as their dependencies.
     """
-    providers = set(providers) - set(wrapper._metadata.keys())
-    remaining = _gather_providers(providers, set())
+    completed = set(wrapper._metadata.keys())
+    remaining = _gather_providers(providers, set()) - completed
 
-    completed = set()
     while len(remaining) > 0:
         batchable = set()
 


### PR DESCRIPTION
## Summary
The MetadataWrapper is meant to resolve METADATA_DEPENDENCIES and prevent a single provider from being invoked multiple times. 

This logic was flawed if the wrapper already contained a provider. 

## Test Plan
python3 -m unittest libcst.metadata.tests.test_metadata_wrapper.MetadataWrapperTest
