### PR TITLE
Upgrade black to fix errors in 3.9.8

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-black==20.8b1
+black==21.10b0
 coverage>=4.5.4
 fixit==0.1.1
 flake8>=3.7.8


### PR DESCRIPTION
## Summary
The pinned version of black is failing in 3.9.8 during one of the codemod tests.

Upgrade black

## Test Plan
python -m unittest libcst.codemod.tests.test_codemod_cli.TestCodemodCLI

