### PR TITLE
Swallow parsing errors in string annotations.

### DIFF
--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -898,8 +898,13 @@ class ScopeVisitor(cst.CSTVisitor):
                 top_level_annotation = self.__last_string_annotation is None
                 if top_level_annotation:
                     self.__last_string_annotation = node
-                mod = cst.parse_module(value)
-                mod.visit(self)
+                try:
+                    mod = cst.parse_module(value)
+                    mod.visit(self)
+                except cst.ParserSyntaxError:
+                    # swallow string annotation parsing errors
+                    # this is the same behavior as cPython
+                    pass
                 if top_level_annotation:
                     self.__last_string_annotation = None
                 return True

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -1715,7 +1715,7 @@ class ScopeProviderTest(UnitTest):
         def assert_parsed(code, *calls):
             parse = cst.parse_module
             with mock.patch("libcst.parse_module") as parse_mock:
-                parse_mock.side_effect = lambda s: parse(s)
+                parse_mock.side_effect = parse
                 get_scope_metadata_provider(dedent(code))
                 calls = [mock.call(dedent(code))] + list(calls)
                 self.assertEqual(parse_mock.call_count, len(calls))


### PR DESCRIPTION
## Summary
This is the same behavior as cPython.

I've also rewritten the test that was relying on this exception to check where type parsing was happening

## Test Plan

```
(libcstvenv) lpetre@lpetre-mbp LibCST % python -m unittest libcst.metadata.tests.test_scope_provider.ScopeProviderTest          
................................................s..
----------------------------------------------------------------------
Ran 51 tests in 2.834s

OK (skipped=1)
(libcstvenv) lpetre@lpetre-mbp LibCST % 
```