### PR TITLE
Pass absolute path to codemod test

### DIFF
--- a/libcst/codemod/tests/test_codemod_cli.py
+++ b/libcst/codemod/tests/test_codemod_cli.py
@@ -7,6 +7,7 @@
 
 import subprocess
 import sys
+from pathlib import Path
 
 from libcst.testing.utils import UnitTest
 
@@ -20,7 +21,7 @@ class TestCodemodCLI(UnitTest):
                 "libcst.tool",
                 "codemod",
                 "remove_unused_imports.RemoveUnusedImportsCommand",
-                "libcst/codemod/tests/codemod_formatter_error_input.py.txt",
+                str(Path(__file__).parent / "codemod_formatter_error_input.py.txt"),
             ],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,


### PR DESCRIPTION
## Summary
This test is breaking in #548 

## Test Plan

 python -m unittest libcst.codemod.tests.test_codemod_cli 