### PR TITLE
Publish test packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,3 +188,10 @@ jobs:
         --sdist
         --wheel
         --outdir dist/
+    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      name: Publish distribution 📦 to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
## Summary

As per https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/

This should be helpful for people who want to test pre-released features

## Test Plan

GH Actions

