### PR TITLE
disable setuptools local scheme when env var is set

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,6 +182,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: exit 1
     - name: Disable scmtools local scheme
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       run: >-
         echo LIBCST_NO_LOCAL_SCHEME=1 >> $GITHUB_ENV
     - name: Build a binary wheel and a source tarball

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,6 +181,9 @@ jobs:
     - name: Validate Dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       run: exit 1
+    - name: Disable scmtools local scheme
+      run: >-
+        echo LIBCST_NO_LOCAL_SCHEME=1 >> $GITHUB_ENV
     - name: Build a binary wheel and a source tarball
       run: >-
         python -m

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
-from os import path
+from os import path, environ
 
 import setuptools
 
@@ -13,9 +13,19 @@ this_directory: str = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, "README.rst"), encoding="utf-8") as f:
     long_description: str = f.read()
 
+
+def no_local_scheme(version):
+    return ""
+
+
 setuptools.setup(
     use_scm_version={
         "write_to": "libcst/_version.py",
+        **(
+            {"local_scheme": no_local_scheme}
+            if "LIBCST_NO_LOCAL_SCHEME" in environ
+            else {}
+        ),
     },
     name="libcst",
     description="A concrete syntax tree with AST-like properties for Python 3.5, 3.6, 3.7 and 3.8 programs.",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(this_directory, "README.rst"), encoding="utf-8") as f:
     long_description: str = f.read()
 
 
-def no_local_scheme(version):
+def no_local_scheme(version: str) -> str:
     return ""
 
 


### PR DESCRIPTION
## Summary
When `LIBCST_NO_LOCAL_SCHEME` is set while packaging, the local scheme will be removed from the version number (i.e. `0.3.22.dev16` instead of `0.3.22.dev16+g5c05001.d20211118`).
## Test Plan

```
env LIBCST_NO_LOCAL_SCHEME=1 python setup.py sdist
ls dist/libcst-0.3.22.dev16.tar.gz
```


