### PR TITLE
Test overwriting imports w/ global and nonlocal stmts

### DIFF
--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -478,31 +478,39 @@ class ScopeProviderTest(UnitTest):
         self.assertIs(scopes[inner_for_in.target], scope_of_list_comp)
 
     def test_global_scope_overwrites(self) -> None:
-        m, scopes = get_scope_metadata_provider(
+        codes = (
             """
             class Cls:
                 def f():
                     global var
                     var = ...
+            """,
             """
+            class Cls:
+                def f():
+                    global var
+                    import f as var
+            """,
         )
-        scope_of_module = scopes[m]
-        self.assertIsInstance(scope_of_module, GlobalScope)
-        self.assertTrue("var" in scope_of_module)
+        for code in codes:
+            m, scopes = get_scope_metadata_provider(code)
+            scope_of_module = scopes[m]
+            self.assertIsInstance(scope_of_module, GlobalScope)
+            self.assertTrue("var" in scope_of_module)
 
-        cls = ensure_type(m.body[0], cst.ClassDef)
-        scope_of_cls = scopes[cls.body.body[0]]
-        self.assertIsInstance(scope_of_cls, ClassScope)
-        self.assertTrue("var" in scope_of_cls)
+            cls = ensure_type(m.body[0], cst.ClassDef)
+            scope_of_cls = scopes[cls.body.body[0]]
+            self.assertIsInstance(scope_of_cls, ClassScope)
+            self.assertTrue("var" in scope_of_cls)
 
-        f = ensure_type(cls.body.body[0], cst.FunctionDef)
-        scope_of_f = scopes[f.body.body[0]]
-        self.assertIsInstance(scope_of_f, FunctionScope)
-        self.assertTrue("var" in scope_of_f)
-        self.assertEqual(scope_of_f["var"], scope_of_module["var"])
+            f = ensure_type(cls.body.body[0], cst.FunctionDef)
+            scope_of_f = scopes[f.body.body[0]]
+            self.assertIsInstance(scope_of_f, FunctionScope)
+            self.assertTrue("var" in scope_of_f)
+            self.assertEqual(scope_of_f["var"], scope_of_module["var"])
 
     def test_nonlocal_scope_overwrites(self) -> None:
-        m, scopes = get_scope_metadata_provider(
+        codes = (
             """
             def outer_f():
                 var = ...
@@ -511,46 +519,70 @@ class ScopeProviderTest(UnitTest):
                     def inner_f():
                         nonlocal var
                         var = ...
+            """,
             """
+            def outer_f():
+                import f as var
+                class Cls:
+                    var = ...
+                    def inner_f():
+                        nonlocal var
+                        var = ...
+            """,
+            """
+            def outer_f():
+                var = ...
+                class Cls:
+                    var = ...
+                    def inner_f():
+                        nonlocal var
+                        import f as var
+            """,
         )
-        scope_of_module = scopes[m]
-        self.assertIsInstance(scope_of_module, GlobalScope)
-        self.assertTrue("var" not in scope_of_module)
+        for code in codes:
+            m, scopes = get_scope_metadata_provider(code)
+            scope_of_module = scopes[m]
+            self.assertIsInstance(scope_of_module, GlobalScope)
+            self.assertTrue("var" not in scope_of_module)
 
-        outer_f = ensure_type(m.body[0], cst.FunctionDef)
-        outer_f_body_var_assign = ensure_type(
-            ensure_type(outer_f.body.body[0], cst.SimpleStatementLine).body[0],
-            cst.Assign,
-        )
-        scope_of_outer_f = scopes[outer_f_body_var_assign]
-        self.assertIsInstance(scope_of_outer_f, FunctionScope)
-        self.assertTrue("var" in scope_of_outer_f)
-        self.assertEqual(len(scope_of_outer_f["var"]), 2)
+            outer_f = ensure_type(m.body[0], cst.FunctionDef)
+            outer_f_body_var = ensure_type(
+                ensure_type(outer_f.body.body[0], cst.SimpleStatementLine).body[0],
+                cst.CSTNode,
+            )
+            scope_of_outer_f = scopes[outer_f_body_var]
+            self.assertIsInstance(scope_of_outer_f, FunctionScope)
+            self.assertTrue("var" in scope_of_outer_f)
+            self.assertEqual(len(scope_of_outer_f["var"]), 2)
 
-        cls = ensure_type(outer_f.body.body[1], cst.ClassDef)
-        scope_of_cls = scopes[cls.body.body[0]]
-        self.assertIsInstance(scope_of_cls, ClassScope)
-        self.assertTrue("var" in scope_of_cls)
+            cls = ensure_type(outer_f.body.body[1], cst.ClassDef)
+            scope_of_cls = scopes[cls.body.body[0]]
+            self.assertIsInstance(scope_of_cls, ClassScope)
+            self.assertTrue("var" in scope_of_cls)
 
-        inner_f = ensure_type(cls.body.body[1], cst.FunctionDef)
-        inner_f_body_var_assign = ensure_type(
-            ensure_type(inner_f.body.body[1], cst.SimpleStatementLine).body[0],
-            cst.Assign,
-        )
-        scope_of_inner_f = scopes[inner_f_body_var_assign]
-        self.assertIsInstance(scope_of_inner_f, FunctionScope)
-        self.assertTrue("var" in scope_of_inner_f)
-        self.assertEqual(len(scope_of_inner_f["var"]), 2)
-        self.assertEqual(
-            {
-                cast(Assignment, assignment).node
-                for assignment in scope_of_outer_f["var"]
-            },
-            {
-                outer_f_body_var_assign.targets[0].target,
-                inner_f_body_var_assign.targets[0].target,
-            },
-        )
+            inner_f = ensure_type(cls.body.body[1], cst.FunctionDef)
+            inner_f_body_var = ensure_type(
+                ensure_type(inner_f.body.body[1], cst.SimpleStatementLine).body[0],
+                cst.CSTNode,
+            )
+            scope_of_inner_f = scopes[inner_f_body_var]
+            self.assertIsInstance(scope_of_inner_f, FunctionScope)
+            self.assertTrue("var" in scope_of_inner_f)
+            self.assertEqual(len(scope_of_inner_f["var"]), 2)
+            self.assertEqual(
+                {
+                    cast(Assignment, assignment).node
+                    for assignment in scope_of_outer_f["var"]
+                },
+                {
+                    outer_f_body_var.targets[0].target
+                    if isinstance(outer_f_body_var, cst.Assign)
+                    else outer_f_body_var,
+                    inner_f_body_var.targets[0].target
+                    if isinstance(inner_f_body_var, cst.Assign)
+                    else inner_f_body_var,
+                },
+            )
 
     def test_local_scope_shadowing_with_functions(self) -> None:
         m, scopes = get_scope_metadata_provider(


### PR DESCRIPTION
## Summary

I want to improve the coverage of the scope provider when imports interact with overwrite statements

## Test Plan

```
(libcstvenv398) lpetre@lpetre-mbp LibCST % python -m unittest libcst.metadata.tests.test_scope_provider.ScopeProviderTest
...................................................
----------------------------------------------------------------------
Ran 51 tests in 2.306s

OK
```
