### PR TITLE
Move find_qualified_names_for in the Assignment class.

### DIFF
--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -192,7 +192,9 @@ class BaseAssignment(abc.ABC):
         """Return an integer that represents the order of assignments in `scope`"""
         return -1
 
-    def get_qualified_names_for(self, get_qualified_names_for: str) -> Set[QualifiedName]:
+    def get_qualified_names_for(
+        self, get_qualified_names_for: str
+    ) -> Set[QualifiedName]:
         raise NotImplementedError(
             "get_qualified_names_for needs to be implemented by sub classes."
         )

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -193,9 +193,7 @@ class BaseAssignment(abc.ABC):
         return -1
 
     @abc.abstractmethod
-    def get_qualified_names_for(
-        self, full_name: str
-    ) -> Set[QualifiedName]:
+    def get_qualified_names_for(self, full_name: str) -> Set[QualifiedName]:
         ...
 
 
@@ -248,9 +246,7 @@ class BuiltinAssignment(BaseAssignment):
     `types <https://docs.python.org/3/library/stdtypes.html>`_.
     """
 
-    def get_qualified_names_for(
-        self, full_name: str
-    ) -> Set[QualifiedName]:
+    def get_qualified_names_for(self, full_name: str) -> Set[QualifiedName]:
         return {QualifiedName(f"builtins.{self.name}", QualifiedNameSource.BUILTIN)}
 
 

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -234,7 +234,7 @@ class Assignment(BaseAssignment):
 
         parts = [*reversed(name_prefixes)]
         if full_name:
-            parts.append(remaining_name)
+            parts.append(full_name)
         return {QualifiedName(".".join(parts), QualifiedNameSource.LOCAL)}
 
 


### PR DESCRIPTION
## Summary
Move _NameUtil.find_qualified_name_for ... method inside Assignment classes.
For non imports we move this implementation inside Assignment.
For Imports we move this implementation inside ImportAssignment. 

## Test Plan
python -m unittest libcst.metadata.tests.test_scope_provider
