### PR TITLE
.gitignore shared-object built artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.swo
 *.pyc
 *.pyo
+*.so
 *.egg-info/
 .eggs/
 .pyre/


### PR DESCRIPTION
I noticed git complaining after I built the native parser.

