### PR TITLE
Fix CI publish to test.pypi.org

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,7 @@ jobs:
       CIBW_ARCHS: ${{ matrix.vers }}
       CIBW_BUILD_VERBOSITY: 1
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
     - uses: actions/setup-python@v2
       with:
         python-version: 3.9


### PR DESCRIPTION
This should fix the failing pypi publish steps. TLDR there's a misfeature in `actions/checkout@v2` that fails to pull down tags. See https://github.com/actions/checkout/issues/290

