### PR TITLE
Fix pypi upload CI step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,6 +216,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: exit 1
     - name: Disable scmtools local scheme
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       run: >-
         echo LIBCST_NO_LOCAL_SCHEME=1 >> $GITHUB_ENV
     - name: Build wheels
@@ -225,8 +226,8 @@ jobs:
         path: wheelhouse/*.whl
         name: wheels
 
-# Upload to pypi
   pypi:
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     name: Upload wheels to pypi
     runs-on: ubuntu-latest
     needs: build
@@ -238,17 +239,20 @@ jobs:
         with:
           name: wheels
           path: wheelhouse
-    - uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - uses: actions/cache@v2
-      id: cache
-      with:
-        path: ${{ env.pythonLocation }}
-        key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'setup.py') }}
-    - name: Validate Dependencies
-      if: steps.cache.outputs.cache-hit != 'true'
-      run: exit 1
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'setup.py') }}
+      - name: Validate Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: exit 1
+      - name: Disable scmtools local scheme
+        run: >-
+          echo LIBCST_NO_LOCAL_SCHEME=1 >> $GITHUB_ENV
       - name: Build a source tarball
         run: >-
           python -m

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,7 +224,7 @@ jobs:
       with:
         path: wheelhouse/*.whl
     - name: Build a source tarball
-      if ${{ matrix.os == 'i686' && matrix.os == 'ubuntu-20.04' }}
+      if: ${{ matrix.os }} == 'i686' && ${{ matrix.os }} == 'ubuntu-20.04'
       run: >-
         python -m
         build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,6 +224,7 @@ jobs:
       with:
         path: wheelhouse/*.whl
     - name: Build a source tarball
+      if ${{ matrix.os == 'i686' && matrix.os == 'ubuntu-20.04' }}
       run: >-
         python -m
         build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,20 +223,45 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         path: wheelhouse/*.whl
-    - name: Build a source tarball
-      if: ${{ matrix.os }} == 'i686' && ${{ matrix.os }} == 'ubuntu-20.04'
-      run: >-
-        python -m
-        build
-        --sdist
-        --outdir wheelhouse/
-    - name: Publish distribution 📦 to Test PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+        name: wheels
+
+# Upload to pypi
+  pypi:
+    name: Upload wheels to pypi
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v1
+      - name: Download binary wheels
+        id: download
+        uses: actions/download-artifact@v2
+        with:
+          name: wheels
+          path: wheelhouse
+    - uses: actions/setup-python@v2
       with:
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
-        packages_dir: wheelhouse/
+        python-version: ${{ matrix.python-version }}
+    - uses: actions/cache@v2
+      id: cache
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'setup.py') }}
+    - name: Validate Dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: exit 1
+      - name: Build a source tarball
+        run: >-
+          python -m
+          build
+          --sdist
+          --outdir ${{ steps.download.outputs.download-path }}
+      - name: Publish distribution 📦 to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+          packages_dir: ${{ steps.download.outputs.download-path }}
 
 # Test rust parts
   native:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,7 +216,6 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: exit 1
     - name: Disable scmtools local scheme
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       run: >-
         echo LIBCST_NO_LOCAL_SCHEME=1 >> $GITHUB_ENV
     - name: Build wheels
@@ -230,8 +229,7 @@ jobs:
         build
         --sdist
         --outdir wheelhouse/
-    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-      name: Publish distribution 📦 to Test PyPI
+    - name: Publish distribution 📦 to Test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,7 +198,7 @@ jobs:
       CIBW_BEFORE_ALL_LINUX: "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y"
       CIBW_BEFORE_ALL_MACOS: "rustup target add aarch64-apple-darwin x86_64-apple-darwin"
       CIBW_BEFORE_ALL_WINDOWS: "rustup target add x86_64-pc-windows-msvc i686-pc-windows-msvc"
-      CIBW_ENVIRONMENT: 'PATH="$PATH:$HOME/.cargo/bin"'
+      CIBW_ENVIRONMENT: 'PATH="$PATH:$HOME/.cargo/bin" LIBCST_NO_LOCAL_SCHEME=$LIBCST_NO_LOCAL_SCHEME'
       CIBW_SKIP: "cp27-* cp34-* cp35-* pp* *-win32 *-win_arm64 *-musllinux_*"
       CIBW_ARCHS: ${{ matrix.vers }}
       CIBW_BUILD_VERBOSITY: 1


### PR DESCRIPTION
This will get the built wheel to not have a local scheme, so they can be uploaded to test.pypi.org, then the upload will happen in a separate job, once all the binary wheels are built. Source dist is also built in this job.