### PR TITLE
only run CI on pushes to main and pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Python CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
 # Install and cache dependencies


### PR DESCRIPTION
## Summary

Don't waste capacity by running checks twice on pull requests originating from a branch on the same repo.

## Test Plan

![](https://media0.giphy.com/media/x0npYExCGOZeo/giphy.gif?cid=ecf05e47exrb2yujenw0sln7z20y7dl3kfq0yaicymqp99rc&rid=giphy.gif&ct=g)

