### PR TITLE
Add instructions to codegen test failures

### DIFF
--- a/libcst/codegen/tests/test_codegen_clean.py
+++ b/libcst/codegen/tests/test_codegen_clean.py
@@ -13,7 +13,23 @@ from libcst.codegen.generate import clean_generated_code, format_file
 from libcst.testing.utils import UnitTest
 
 
+
+
 class TestCodegenClean(UnitTest):
+    def assert_code_matches(
+        self,
+        old_code: str,
+        new_code: str,
+        module_name: str,
+    ) -> None:
+        self.assertTrue(
+            old_code == new_code,
+            f"{module_name} needs new codegen, see "
+            "`python -m libcst.codegen.generate --help` "
+            "for instructions"
+        )
+
+    
     def test_codegen_clean_visitor_functions(self) -> None:
         """
         Verifies that codegen of visitor functions would not result in a
@@ -44,9 +60,7 @@ class TestCodegenClean(UnitTest):
             old_code = fp.read()
 
         # Now that we've done simple codegen, verify that it matches.
-        self.assertTrue(
-            old_code == new_code, "libcst._typed_visitor needs new codegen!"
-        )
+        self.assert_code_matches(old_code, new_code, "libcst._typed_visitor")
 
     def test_codegen_clean_matcher_classes(self) -> None:
         """
@@ -78,9 +92,7 @@ class TestCodegenClean(UnitTest):
             old_code = fp.read()
 
         # Now that we've done simple codegen, verify that it matches.
-        self.assertTrue(
-            old_code == new_code, "libcst.matchers.__init__ needs new codegen!"
-        )
+        self.assert_code_matches(old_code, new_code, "libcst.matchers.__init__")
 
     def test_codegen_clean_return_types(self) -> None:
         """
@@ -113,6 +125,4 @@ class TestCodegenClean(UnitTest):
             old_code = fp.read()
 
         # Now that we've done simple codegen, verify that it matches.
-        self.assertTrue(
-            old_code == new_code, "libcst.matchers._return_types needs new codegen!"
-        )
+        self.assert_code_matches(old_code, new_code, "libcst.matchers._return_types")

--- a/libcst/codegen/tests/test_codegen_clean.py
+++ b/libcst/codegen/tests/test_codegen_clean.py
@@ -23,8 +23,8 @@ class TestCodegenClean(UnitTest):
         self.assertTrue(
             old_code == new_code,
             f"{module_name} needs new codegen, see "
-            "`python -m libcst.codegen.generate --help` "
-            "for instructions",
+            + "`python -m libcst.codegen.generate --help` "
+            + "for instructions, or run `tox -e codegen`",
         )
 
     def test_codegen_clean_visitor_functions(self) -> None:

--- a/libcst/codegen/tests/test_codegen_clean.py
+++ b/libcst/codegen/tests/test_codegen_clean.py
@@ -13,8 +13,6 @@ from libcst.codegen.generate import clean_generated_code, format_file
 from libcst.testing.utils import UnitTest
 
 
-
-
 class TestCodegenClean(UnitTest):
     def assert_code_matches(
         self,
@@ -26,10 +24,9 @@ class TestCodegenClean(UnitTest):
             old_code == new_code,
             f"{module_name} needs new codegen, see "
             "`python -m libcst.codegen.generate --help` "
-            "for instructions"
+            "for instructions",
         )
 
-    
     def test_codegen_clean_visitor_functions(self) -> None:
         """
         Verifies that codegen of visitor functions would not result in a


### PR DESCRIPTION
## Summary

It's nice that the tests warn us if you need to rerun code generation, but we don't actually document how to run code generation anywhere so every time I hit the failures I get frustrated trying to remember!

I thought about adding it to the README but I'm not actually sure it adds any value - instead, why not add it to the relevant failures. That way the codegen instructions aren't adding noise to the general getting-started docs, but they are right there whenever we need them.

## Test Plan

In a branch where I added lpar and rpar to `With` statements, I ran
```
> python -m unittest libcst.codegen.tests.test_codegen_clean
FFF
======================================================================
FAIL: test_codegen_clean_matcher_classes (libcst.codegen.tests.test_codegen_clean.TestCodegenClean)
Verifies that codegen of matcher classes would not result in a
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/stroxler/kode/LibCST/libcst/codegen/tests/test_codegen_clean.py", line 95, in test_codegen_clean_matcher_classes
    self.assert_code_matches(old_code, new_code, "libcst.matchers.__init__")
  File "/Users/stroxler/kode/LibCST/libcst/codegen/tests/test_codegen_clean.py", line 25, in assert_code_matches
    self.assertTrue(
AssertionError: False is not true : libcst.matchers.__init__ needs new codegen, see `python -m libcst.codegen.generate --help` for instructions

======================================================================
FAIL: test_codegen_clean_return_types (libcst.codegen.tests.test_codegen_clean.TestCodegenClean)
Verifies that codegen of return types would not result in a
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/stroxler/kode/LibCST/libcst/codegen/tests/test_codegen_clean.py", line 128, in test_codegen_clean_return_types
    self.assert_code_matches(old_code, new_code, "libcst.matchers._return_types")
  File "/Users/stroxler/kode/LibCST/libcst/codegen/tests/test_codegen_clean.py", line 25, in assert_code_matches
    self.assertTrue(
AssertionError: False is not true : libcst.matchers._return_types needs new codegen, see `python -m libcst.codegen.generate --help` for instructions

======================================================================
FAIL: test_codegen_clean_visitor_functions (libcst.codegen.tests.test_codegen_clean.TestCodegenClean)
Verifies that codegen of visitor functions would not result in a
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/stroxler/kode/LibCST/libcst/codegen/tests/test_codegen_clean.py", line 63, in test_codegen_clean_visitor_functions
    self.assert_code_matches(old_code, new_code, "libcst._typed_visitor")
  File "/Users/stroxler/kode/LibCST/libcst/codegen/tests/test_codegen_clean.py", line 25, in assert_code_matches
    self.assertTrue(
AssertionError: False is not true : libcst._typed_visitor needs new codegen, see `python -m libcst.codegen.generate --help` for instructions

----------------------------------------------------------------------
Ran 3 tests in 40.231s

FAILED (failures=3)
```
