### PR TITLE
Add some color to children-vs-codegen error

### DIFF
--- a/libcst/_nodes/tests/base.py
+++ b/libcst/_nodes/tests/base.py
@@ -137,7 +137,9 @@ class CSTNodeTest(UnitTest):
             codegen_children,
             msg=(
                 "The list of children we got from `node.children` differs from the "
-                + "children that were visited by `node._codegen`."
+                + "children that were visited by `node._codegen`. This is probably "
+                + "due to a mismatch between _visit_and_replace_children and "
+                + "_codegen_impl."
             ),
         )
 


### PR DESCRIPTION
## Summary

It took me some time to track down the root cause of `children`
not matching codegen, having the error message directly hint that
visit and codegen are probably mimatched (my visit was running
out-of-order) will likely help newbies get going faster.

## Test Plan

After introducing a mismatch in `With`:
```
root@87672ffb04a5:~/LibCST# git diff
diff --git a/libcst/_nodes/statement.py b/libcst/_nodes/statement.py
index 1351949..2eca52d 100644
--- a/libcst/_nodes/statement.py
+++ b/libcst/_nodes/statement.py
@@ -2042,12 +2042,12 @@ class With(BaseCompoundStatement):
             leading_lines=visit_sequence(
                 self, "leading_lines", self.leading_lines, visitor
             ),
-            asynchronous=visit_optional(
-                self, "asynchronous", self.asynchronous, visitor
-            ),
             whitespace_after_with=visit_required(
                 self, "whitespace_after_with", self.whitespace_after_with, visitor
             ),
+            asynchronous=visit_optional(
+                self, "asynchronous", self.asynchronous, visitor
+            ),
             items=visit_sequence(self, "items", self.items, visitor),
             whitespace_before_colon=visit_required(
                 self, "whitespace_before_colon", self.whitespace_before_colon, visitor
```


I get an error in the tests that tells me where to start looking:
```
root@87672ffb04a5:~/LibCST# python -m unittest libcst._nodes.tests.test_with
....F...........
======================================================================
FAIL: test_valid_1 (libcst._nodes.tests.test_with.WithTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/LibCST/libcst/testing/utils.py", line 87, in new_test
    return member(self, **data)
  File "/root/LibCST/libcst/_nodes/tests/test_with.py", line 184, in test_valid
    self.validate_node(**kwargs)
  File "/root/LibCST/libcst/_nodes/tests/base.py", line 88, in validate_node
    self.__assert_children_match_codegen(unwrapped_node)
  File "/root/LibCST/libcst/_nodes/tests/base.py", line 135, in __assert_children_match_codegen
    self.assertSequenceEqual(
AssertionError: Sequences differ: [SimpleWhitespace(
    value=' ',
), Async[893 chars]),
)] != [Asynchronous(
    whitespace_after=Simple[893 chars]),
)]

First differing element 0:
SimpleWhitespace(
    value=' ',
)
Asynchronous(
    whitespace_after=SimpleWhitespace(
        value=' ',
    ),
)

Diff is 1115 characters long. Set self.maxDiff to None to see it. : The list of children we got from `node.children` differs from the children that were visited by `node._codegen`. This is probably due to a mismatch between _visit_and_replace_children and _codegen_impl.
```