### PR TITLE
Pin rust-peg dependency

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 [[package]]
 name = "peg"
 version = "0.7.0"
-source = "git+https://github.com/kevinmehall/rust-peg#4b146b4b78a80c07e43d7ace2d97f65bfde279a8"
+source = "git+https://github.com/kevinmehall/rust-peg?rev=4b146b4b78a80c07e43d7ace2d97f65bfde279a8#4b146b4b78a80c07e43d7ace2d97f65bfde279a8"
 dependencies = [
  "peg-macros",
  "peg-runtime",
@@ -460,7 +460,7 @@ dependencies = [
 [[package]]
 name = "peg-macros"
 version = "0.7.0"
-source = "git+https://github.com/kevinmehall/rust-peg#4b146b4b78a80c07e43d7ace2d97f65bfde279a8"
+source = "git+https://github.com/kevinmehall/rust-peg?rev=4b146b4b78a80c07e43d7ace2d97f65bfde279a8#4b146b4b78a80c07e43d7ace2d97f65bfde279a8"
 dependencies = [
  "peg-runtime",
  "proc-macro2",
@@ -470,7 +470,7 @@ dependencies = [
 [[package]]
 name = "peg-runtime"
 version = "0.7.0"
-source = "git+https://github.com/kevinmehall/rust-peg#4b146b4b78a80c07e43d7ace2d97f65bfde279a8"
+source = "git+https://github.com/kevinmehall/rust-peg?rev=4b146b4b78a80c07e43d7ace2d97f65bfde279a8#4b146b4b78a80c07e43d7ace2d97f65bfde279a8"
 
 [[package]]
 name = "plotters"

--- a/native/libcst/Cargo.toml
+++ b/native/libcst/Cargo.toml
@@ -30,7 +30,7 @@ trace = ["peg/trace"]
 paste = "1.0.4"
 pyo3 = "0.14.4"
 thiserror = "1.0.23"
-peg = { git = "https://github.com/kevinmehall/rust-peg" }
+peg = { git = "https://github.com/kevinmehall/rust-peg", rev = "4b146b4b78a80c07e43d7ace2d97f65bfde279a8" }
 chic = "1.2.2"
 itertools = "0.10.0"
 once_cell = "1.5.2"


### PR DESCRIPTION
## Summary

The native bindings need some unreleased features since rust-peg 0.7.0, but don't yet compile with 0.8.0, so we pin that dependency on an unreleased version.

I'll work on a PR to update the parser for peg 0.8.0, but until then this should help people build it.

## Test Plan

it compiles :)
