### PR TITLE
Codemod for PEP 484 Assign w / type comments -> PEP 526 AnnAssign

### DIFF
--- a/libcst/codemod/commands/convert_type_comments.py
+++ b/libcst/codemod/commands/convert_type_comments.py
@@ -122,13 +122,13 @@ class ConvertTypeComments(VisitorBasedCodemodCommand):
         assign = updated_node.body[-1]
         if not isinstance(assign, cst.Assign):  # only Assign matters
             return updated_node
+        type_comment = _simple_statement_type_comment(original_node)
+        if type_comment is None:
+            return updated_node
         if len(assign.targets) != 1:  # multi-target Assign isn't used
             return updated_node
         target = assign.targets[0].target
         if isinstance(target, cst.Tuple):  # multi-element Assign isn't handled
-            return updated_node
-        type_comment = _simple_statement_type_comment(original_node)
-        if type_comment is None:
             return updated_node
         # At this point have a single-line Assign with a type comment.
         # Convert it to an AnnAssign and strip the comment.

--- a/libcst/codemod/commands/convert_type_comments.py
+++ b/libcst/codemod/commands/convert_type_comments.py
@@ -1,0 +1,146 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import ast
+import builtins
+import functools
+import re
+from typing import Optional, Pattern, Set, Union
+
+import libcst as cst
+from libcst.codemod import VisitorBasedCodemodCommand
+
+
+@functools.lru_cache()
+def _empty_module() -> cst.Module:
+    return cst.parse_module("")
+
+
+def _code_for_node(node: cst.CSTNode) -> str:
+    return _empty_module().code_for_node(node)
+
+
+def _ast_for_node(node: cst.CSTNode) -> ast.Module:
+    code = _code_for_node(node)
+    return ast.parse(code, type_comments=True)
+
+
+def _assign_type_comment(node: cst.SimpleStatementLine) -> Optional[str]:
+    return _ast_for_node(node).body[0].type_comment
+
+
+@functools.lru_cache()
+def _builtins() -> Set[str]:
+    return set(dir(builtins))
+
+
+def _is_builtin(annotation: str) -> bool:
+    return annotation in _builtins()
+
+
+def _convert_annotation(raw: str) -> cst.Annotation:
+    # Convert annotation comments to string annotations to be safe,
+    # otherwise runtime errors would be common.
+    #
+    # Special-case builtins to reduce the amount of quoting noise.
+    # TODO: use scope provider to detect more cases where we can skip quotes.
+    if _is_builtin(raw):
+        return cst.Annotation(annotation=cst.Name(value=raw))
+    else:
+        return cst.Annotation(annotation=cst.SimpleString(f'"{raw}"'))
+
+
+class ConvertTypeComments(VisitorBasedCodemodCommand):
+    """
+    Codemod that converts type comments, as described in
+    https://www.python.org/dev/peps/pep-0484/#type-comments,
+    into PEP 526 annotated assignments.
+
+    """
+
+    TYPE_COMMENT_REGEX: Pattern[str] = re.compile("# *type: *[^ ]+")
+    TYPE_IGNORE_PREFIX: str = "# type: ignore"
+
+    _should_strip_type_comments: bool = False
+
+    def _is_type_comment(self, comment: Optional[cst.Comment]) -> bool:
+        return (
+            comment is not None
+            and self.TYPE_COMMENT_REGEX.match(comment.value) is not None
+            and not comment.value.startswith(self.TYPE_IGNORE_PREFIX)
+        )
+
+    def _should_strip_comment(self, comment: Optional[cst.Comment]) -> bool:
+        return self._should_strip_type_comments and self._is_type_comment(comment)
+
+    def _convert_Assign(
+        self,
+        assign: cst.Assign,
+        type_comment: str,
+    ) -> Union[cst.AnnAssign, cst.Assign]:
+        if len(assign.targets) != 1:
+            return assign
+        return cst.AnnAssign(
+            target=assign.targets[0].target,
+            annotation=_convert_annotation(raw=type_comment),
+            value=assign.value,
+            semicolon=assign.semicolon,
+        )
+
+    def visit_SimpleStatementLine(
+        self,
+        node: cst.SimpleStatementLine,
+    ) -> None:
+        # manage the state used for determining comments to delete
+        self._should_strip_type_comments = True
+
+    def leave_SimpleStatementLine(
+        self,
+        original_node: cst.SimpleStatementLine,
+        updated_node: cst.SimpleStatementLine,
+    ) -> cst.SimpleStatementLine:
+        """
+        Convert any SimpleStatementLine containing an Assign with a
+        type comment into a one that uses a PEP 526 AnnAssign.
+        """
+        # manage the state used for determining comments to delete
+        self._should_strip_type_comments = False
+        # determine whether to apply an annotation
+        body = updated_node.body
+        if len(body) != 1:
+            return updated_node
+        statement = body[0]
+        if not isinstance(statement, cst.Assign):
+            return updated_node
+        type_comment = _assign_type_comment(original_node)
+        if type_comment is None:
+            return updated_node
+        # At this point have a single-line Assign with a type comment.
+        # Convert it to an AnnAssign.
+        return updated_node.with_changes(
+            body=[
+                self._convert_Assign(
+                    assign=statement,
+                    type_comment=type_comment,
+                )
+            ]
+        )
+
+    def leave_TrailingWhitespace(
+        self,
+        original_node: cst.TrailingWhitespace,
+        updated_node: cst.TrailingWhitespace,
+    ) -> cst.TrailingWhitespace:
+        """
+        Remove type comments from trailing whitespace.
+        """
+        if self._should_strip_comment(updated_node.comment):
+            return updated_node.with_changes(
+                whitespace=cst.SimpleWhitespace(
+                    ""
+                ),  # whitespace came before the comment, so strip it.
+                comment=None,
+            )
+        return updated_node

--- a/libcst/codemod/commands/convert_type_comments.py
+++ b/libcst/codemod/commands/convert_type_comments.py
@@ -61,6 +61,10 @@ class ConvertTypeComments(VisitorBasedCodemodCommand):
     Codemod that converts type comments, as described in
     https://www.python.org/dev/peps/pep-0484/#type-comments,
     into PEP 526 annotated assignments.
+
+    This is a work in progress: the codemod only currently handles
+    single-annotation assigns, but it will preserve any type comments
+    that it does not consume.
     """
 
     def __init__(self, context: CodemodContext) -> None:

--- a/libcst/codemod/commands/tests/test_convert_type_comments.py
+++ b/libcst/codemod/commands/tests/test_convert_type_comments.py
@@ -1,0 +1,85 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from libcst.codemod import CodemodTest
+from libcst.codemod.commands.convert_type_comments import ConvertTypeComments
+
+
+class TestConvertTypeComments(CodemodTest):
+
+    TRANSFORM = ConvertTypeComments
+
+    # Tests converting assignment type comments -----------------
+
+    def test_convert_assignments(self) -> None:
+        before = """
+            y = 5  # type: int
+            z = ('this', 7)  # type: typing.Tuple[str, int]
+        """
+        after = """
+            y: int = 5
+            z: "typing.Tuple[str, int]" = ('this', 7)
+        """
+        self.assertCodemod(before, after)
+
+    def test_convert_assignments_in_context(self) -> None:
+        """
+        Also verify that our matching works regardless of spacing
+        """
+        before = """
+            def foo():
+                z = ('this', 7) # type: typing.Tuple[str, int]
+
+            class C:
+                attr0 = 10# type: int
+                def __init__(self):
+                    self.attr1 = True  # type: bool
+        """
+        after = """
+            def foo():
+                z: "typing.Tuple[str, int]" = ('this', 7)
+
+            class C:
+                attr0: int = 10
+                def __init__(self):
+                    self.attr1: bool = True
+        """
+        self.assertCodemod(before, after)
+
+    def test_strip_useless_type_comments(self) -> None:
+        """
+        Verify that we remove type comments that are in a place
+        not permitted by PEP 484. This is debateable behavior but
+        is intended, because according to PEP 484 such comments are
+        illegal.
+        """
+        before = """
+           print("hello")  # type: None
+        """
+        after = """
+           print("hello")
+        """
+        self.assertCodemod(before, after)
+
+    def test_non_type_comments_on_assignments(self) -> None:
+        before = """
+            # type-ignores are not type comments
+            x = 10  # type: ignore
+            # a commented type comment (per PEP 484) is not a type comment
+            z = 15  # # type: int
+        """
+        after = before
+        self.assertCodemod(before, after)
+
+    def test_no_change_to_non_single_statement_comments(self) -> None:
+        before = """
+            def f(
+                x,  # type: int
+            ):
+                # type (...) -> int
+                return x
+        """
+        after = before
+        self.assertCodemod(before, after)

--- a/libcst/codemod/commands/tests/test_convert_type_comments.py
+++ b/libcst/codemod/commands/tests/test_convert_type_comments.py
@@ -42,6 +42,8 @@ class TestConvertTypeComments(CodemodTest):
         Also verify that our matching works regardless of spacing
         """
         before = """
+            bar(); baz = 12  # type: int
+
             def foo():
                 z = ('this', 7) # type: typing.Tuple[str, int]
 
@@ -51,6 +53,8 @@ class TestConvertTypeComments(CodemodTest):
                     self.attr1 = True  # type: bool
         """
         after = """
+            bar(); baz: int = 12
+
             def foo():
                 z: "typing.Tuple[str, int]" = ('this', 7)
 
@@ -61,38 +65,16 @@ class TestConvertTypeComments(CodemodTest):
         """
         self.assertCodemod38Plus(before, after)
 
-    def test_strip_useless_type_comments(self) -> None:
-        """
-        Verify that we remove type comments that are in a place
-        not permitted by PEP 484. This is debateable behavior but
-        is intended, because according to PEP 484 such comments are
-        illegal.
-        """
-        before = """
-           print("hello")  # type: None
-        """
-        after = """
-           print("hello")
-        """
-        self.assertCodemod38Plus(before, after)
-
-    def test_non_type_comments_on_assignments(self) -> None:
+    def test_no_change_when_type_comment_unused(self) -> None:
         before = """
             # type-ignores are not type comments
             x = 10  # type: ignore
+
             # a commented type comment (per PEP 484) is not a type comment
             z = 15  # # type: int
-        """
-        after = before
-        self.assertCodemod38Plus(before, after)
 
-    def test_no_change_to_non_single_statement_comments(self) -> None:
-        before = """
-            def f(
-                x,  # type: int
-            ):
-                # type (...) -> int
-                return x
+            # a type comment in an illegal location won't be used
+            print("hello")  # type: None
         """
         after = before
         self.assertCodemod38Plus(before, after)

--- a/libcst/codemod/commands/tests/test_convert_type_comments.py
+++ b/libcst/codemod/commands/tests/test_convert_type_comments.py
@@ -13,7 +13,11 @@ class TestConvertTypeComments(CodemodTest):
 
     TRANSFORM = ConvertTypeComments
 
-    def assertCodemod(self, before: str, after: str):
+    def assertCodemod38Plus(self, before: str, after: str) -> None:
+        """
+        Assert that the codemod works on Python 3.8+, and that we raise
+        a NotImplementedError on other python versions.
+        """
         if (sys.version_info.major, sys.version_info.minor) < (3, 8):
             with self.assertRaises(NotImplementedError):
                 super().assertCodemod(before, after)
@@ -31,7 +35,7 @@ class TestConvertTypeComments(CodemodTest):
             y: int = 5
             z: "typing.Tuple[str, int]" = ('this', 7)
         """
-        self.assertCodemod(before, after)
+        self.assertCodemod38Plus(before, after)
 
     def test_convert_assignments_in_context(self) -> None:
         """
@@ -55,7 +59,7 @@ class TestConvertTypeComments(CodemodTest):
                 def __init__(self):
                     self.attr1: bool = True
         """
-        self.assertCodemod(before, after)
+        self.assertCodemod38Plus(before, after)
 
     def test_strip_useless_type_comments(self) -> None:
         """
@@ -70,7 +74,7 @@ class TestConvertTypeComments(CodemodTest):
         after = """
            print("hello")
         """
-        self.assertCodemod(before, after)
+        self.assertCodemod38Plus(before, after)
 
     def test_non_type_comments_on_assignments(self) -> None:
         before = """
@@ -80,7 +84,7 @@ class TestConvertTypeComments(CodemodTest):
             z = 15  # # type: int
         """
         after = before
-        self.assertCodemod(before, after)
+        self.assertCodemod38Plus(before, after)
 
     def test_no_change_to_non_single_statement_comments(self) -> None:
         before = """
@@ -91,4 +95,4 @@ class TestConvertTypeComments(CodemodTest):
                 return x
         """
         after = before
-        self.assertCodemod(before, after)
+        self.assertCodemod38Plus(before, after)

--- a/libcst/codemod/commands/tests/test_convert_type_comments.py
+++ b/libcst/codemod/commands/tests/test_convert_type_comments.py
@@ -2,7 +2,9 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-#
+
+import sys
+
 from libcst.codemod import CodemodTest
 from libcst.codemod.commands.convert_type_comments import ConvertTypeComments
 
@@ -10,6 +12,13 @@ from libcst.codemod.commands.convert_type_comments import ConvertTypeComments
 class TestConvertTypeComments(CodemodTest):
 
     TRANSFORM = ConvertTypeComments
+
+    def assertCodemod(self, before: str, after: str):
+        if (sys.version_info.major, sys.version_info.minor) < (3, 8):
+            with self.assertRaises(NotImplementedError):
+                super().assertCodemod(before, after)
+        else:
+            super().assertCodemod(before, after)
 
     # Tests converting assignment type comments -----------------
 

--- a/libcst/codemod/commands/tests/test_convert_type_comments.py
+++ b/libcst/codemod/commands/tests/test_convert_type_comments.py
@@ -11,6 +11,7 @@ from libcst.codemod.commands.convert_type_comments import ConvertTypeComments
 
 class TestConvertTypeComments(CodemodTest):
 
+    maxDiff = 1000
     TRANSFORM = ConvertTypeComments
 
     def assertCodemod38Plus(self, before: str, after: str) -> None:
@@ -75,6 +76,13 @@ class TestConvertTypeComments(CodemodTest):
 
             # a type comment in an illegal location won't be used
             print("hello")  # type: None
+
+            # We currently cannot handle multiple-target assigns.
+            # Make sure we won't strip those type comments.
+            x, y, z = [], [], []  # type: List[int], List[int], List[str]
+            x, y, z = [], [], []  # type: (List[int], List[int], List[str])
+            a, b, *c = range(5)   # type: float, float, List[float]
+            a, b = 1, 2  # type: Tuple[int, int]
         """
         after = before
         self.assertCodemod38Plus(before, after)


### PR DESCRIPTION
Summary:

This codemod is intended to eventually handle all type comments from
PEP 484. This is a partial implementation specifically handling
assignment type comments, which as of PEP 526 are better dealt
with using AnnAssign nodes.

There is more work to do because there are two other kinds of
comments to support: function heading comments and function parameter
inline comments. But the PEP 526 functionality is complete so I feel
like it's worth having a PR / CI signals / code review at this stage.

Implementation Note:

It's a little weird that inside the transform we serialize small bits of the CST back
to code in order to use the `ast` module, but that's the most robust way to get
type comments and guaranteed to be PEP 484 compliant. Perf isn't an issue here
and I discussed with @zsol, we agreed this was the best way to go because
implementing our own type comment extraction would be a pain for no real benefit.

The resulting implementation is simple, but it won't work on Python < 3.8. This seems
fine for now; there's a `type_ast` library and if anyone is motivated to make this
work on 3.6 or 3.7 they could use it - I left a note in the code about where to look.

Test Plan:

```
python -m unittest libcst.codemod.commands.tests.test_convert_type_comments
```
