### PR TITLE
Remove unused argument to handle_Index

### DIFF
--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -232,7 +232,7 @@ class TypeCollector(cst.CSTVisitor):
         else:
             return dequalified_node
 
-    def _handle_Index(self, slice: cst.Index, node: cst.Subscript) -> cst.Index:
+    def _handle_Index(self, slice: cst.Index) -> cst.Index:
         value = slice.value
         if isinstance(value, cst.Subscript):
             return slice.with_changes(value=self._handle_Subscript(value))
@@ -265,7 +265,7 @@ class TypeCollector(cst.CSTVisitor):
                 else:
                     if isinstance(item.slice, cst.Index):
                         new_index = item.slice.with_changes(
-                            value=self._handle_Index(item.slice, item)
+                            value=self._handle_Index(item.slice)
                         )
                         item = item.with_changes(slice=new_index)
                     new_slice.append(item)


### PR DESCRIPTION
the method is already being called without the `node` argument here: https://github.com/Instagram/LibCST/blob/main/libcst/codemod/visitors/_apply_type_annotations.py#L274