### PR TITLE
Full handling for applying type comments to Assign

### DIFF
--- a/libcst/codemod/commands/convert_type_comments.py
+++ b/libcst/codemod/commands/convert_type_comments.py
@@ -105,7 +105,7 @@ class AnnotationSpreader:
     @staticmethod
     def unpack_target(
         target: cst.BaseExpression,
-    ) -> UnpackedTargets:
+    ) -> UnpackedTargets:  # pyre-ignore: I'm unsure what the problem is.
         """
         Take a (non-function-type) type comment and split it into
         components. A type comment body should always be either a single
@@ -208,17 +208,18 @@ class ConvertTypeComments(VisitorBasedCodemodCommand):
     """
 
     def __init__(self, context: CodemodContext) -> None:
-        if (sys.version_info.major, sys.version_info.minor) < (3, 8):
-            # The ast module did not get `type_comments` until Python 3.7.
-            # In 3.6, we should error than silently running a nonsense codemod.
+        if (sys.version_info.major, sys.version_info.minor) < (3, 9):
+            # The ast module did not get `unparse` until Python 3.9,
+            # or `type_comments` until Python 3.8
             #
-            # NOTE: it is possible to use the typed_ast library for 3.6, but
-            # this is not a high priority right now. See, e.g., the
-            # mypy.fastparse module.
+            # For earlier versions of python, raise early instead of failing
+            # later. It might be possible to use libcst parsing and the typed_ast
+            # library to support earlier python versions, but this is not a
+            # high priority.
             raise NotImplementedError(
                 "You are trying to run ConvertTypeComments on a "
                 + "python version without type comment support. Please "
-                + "try using python 3.8+ to run your codemod."
+                + "try using Python 3.9+ to run your codemod."
             )
         super().__init__(context)
 

--- a/libcst/codemod/commands/convert_type_comments.py
+++ b/libcst/codemod/commands/convert_type_comments.py
@@ -221,13 +221,15 @@ class ConvertTypeComments(VisitorBasedCodemodCommand):
             # or `type_comments` until Python 3.8
             #
             # For earlier versions of python, raise early instead of failing
-            # later. It might be possible to use libcst parsing and the typed_ast
-            # library to support earlier python versions, but this is not a
-            # high priority.
+            # later. It might be possible to use libcst parsing and the
+            # typed_ast library to support earlier python versions, but this is
+            # not a high priority.
             raise NotImplementedError(
-                "You are trying to run ConvertTypeComments on a "
-                + "python version without type comment support. Please "
-                + "try using Python 3.9+ to run your codemod."
+                "You are trying to run ConvertTypeComments, but libcst "
+                + "needs to be running with Python 3.9+ in order to "
+                + "do this. Try using Python 3.9+ to run your codemod. "
+                + "Note that the target code can be using Python 3.6+, "
+                + "it is only libcst that needs a new Python version."
             )
         super().__init__(context)
 

--- a/libcst/codemod/commands/convert_type_comments.py
+++ b/libcst/codemod/commands/convert_type_comments.py
@@ -66,7 +66,7 @@ class _ArityError(Exception):
     pass
 
 
-UnpackedTargets: TypeAlias = Union[cst.BaseExpression, "UnpackedTargets"]
+UnpackedTargets: TypeAlias = Union[cst.BaseExpression, List["UnpackedTargets"]]
 UnpackedAnnotations: TypeAlias = Union[str, List["UnpackedAnnotations"]]
 TargetAnnotationPair: TypeAlias = Tuple[cst.BaseExpression, str]
 
@@ -105,7 +105,7 @@ class AnnotationSpreader:
     @staticmethod
     def unpack_target(
         target: cst.BaseExpression,
-    ) -> UnpackedTargets:  # pyre-ignore: I'm unsure what the problem is.
+    ) -> UnpackedTargets:
         """
         Take a (non-function-type) type comment and split it into
         components. A type comment body should always be either a single

--- a/libcst/codemod/commands/convert_type_comments.py
+++ b/libcst/codemod/commands/convert_type_comments.py
@@ -77,8 +77,6 @@ class AnnotationSpreader:
     the tuples of values with which they should be associated.
     """
 
-    # TODO: find a 3.6-compatible way to handle TypeAlias
-
     @staticmethod
     def _unparse_annotation(
         expression: ast.expr,

--- a/libcst/codemod/commands/convert_type_comments.py
+++ b/libcst/codemod/commands/convert_type_comments.py
@@ -7,7 +7,9 @@ import ast
 import builtins
 import functools
 import sys
-from typing import Optional, Set, Union
+from typing import List, Optional, Set, Tuple, Union
+
+from typing_extensions import TypeAlias
 
 import libcst as cst
 from libcst.codemod import CodemodContext, VisitorBasedCodemodCommand
@@ -56,15 +58,153 @@ def _convert_annotation(raw: str) -> cst.Annotation:
         return cst.Annotation(annotation=cst.SimpleString(f'"{raw}"'))
 
 
+class _FailedToApplyAnnotation:
+    pass
+
+
+class _ArityError(Exception):
+    pass
+
+
+UnpackedTargets: TypeAlias = Union[cst.BaseExpression, "UnpackedTargets"]
+UnpackedAnnotations: TypeAlias = Union[str, List["UnpackedAnnotations"]]
+TargetAnnotationPair: TypeAlias = Tuple[cst.BaseExpression, str]
+
+
+class AnnotationSpreader:
+    """
+    Utilities to help with lining up tuples of types from type comments with
+    the tuples of values with which they should be associated.
+    """
+
+    # TODO: find a 3.6-compatible way to handle TypeAlias
+
+    @staticmethod
+    def _unparse_annotation(
+        expression: ast.expr,
+    ) -> UnpackedAnnotations:
+        if isinstance(expression, ast.Tuple):
+            return [
+                AnnotationSpreader._unparse_annotation(elt) for elt in expression.elts
+            ]
+        else:
+            return ast.unparse(expression)
+
+    @staticmethod
+    def unpack_type_comment(
+        type_comment: str,
+    ) -> UnpackedAnnotations:
+        """
+        Unpack an ast module expression and unparse it into a recursive
+        list of strings matching the tuple structure of the type comment.
+        """
+        # pyre-ignore[16]: the ast module stubs do not have full details
+        annotation_ast = ast.parse(type_comment, "<type_comment>", "eval").body
+        return AnnotationSpreader._unparse_annotation(annotation_ast)
+
+    @staticmethod
+    def unpack_target(
+        target: cst.BaseExpression,
+    ) -> UnpackedTargets:
+        """
+        Take a (non-function-type) type comment and split it into
+        components. A type comment body should always be either a single
+        type or a tuple of types.
+
+        We work with strings for annotations because without detailed scope
+        analysis that is the safest option for codemods.
+        """
+        if isinstance(target, cst.Tuple):
+            return [
+                AnnotationSpreader.unpack_target(element.value)
+                for element in target.elements
+            ]
+        else:
+            return target
+
+    @staticmethod
+    def zip_and_flatten(
+        target: UnpackedTargets,
+        type_info: UnpackedAnnotations,
+    ) -> List[Tuple[cst.BaseAssignTargetExpression, str]]:
+        if isinstance(type_info, list):
+            if isinstance(target, list) and len(target) == len(type_info):
+                # The arities match, so we return the flattened result of
+                # mapping zip_and_flatten over each pair.
+                out: List[Tuple[cst.BaseAssignTargetExpression, str]] = []
+                for target_, type_info_ in zip(target, type_info):
+                    out.extend(AnnotationSpreader.zip_and_flatten(target_, type_info_))
+                return out
+            else:
+                # Either mismatched lengths, or multi-type and one-target
+                raise _ArityError()
+        elif isinstance(target, list):
+            # multi-target and one-type
+            raise _ArityError()
+        else:
+            assert isinstance(target, cst.BaseAssignTargetExpression)
+            return [(target, type_info)]
+
+
+def convert_Assign(
+    node: cst.Assign,
+    type_comment: str,
+) -> Union[
+    _FailedToApplyAnnotation,
+    cst.AnnAssign,
+    List[Union[cst.AnnAssign, cst.Assign]],
+]:
+    type_info = AnnotationSpreader.unpack_type_comment(type_comment)
+    targets = [
+        AnnotationSpreader.unpack_target(target.target) for target in node.targets
+    ]
+    # zip the type and target information tother. If there are mismatched
+    # arities, this is a PEP 484 violation (technically we could use
+    # logic beyond the PEP to recover some cases as typing.Tuple, but this
+    # should be rare) so we give up.
+    try:
+        zipped_targets = [
+            AnnotationSpreader.zip_and_flatten(target, type_info) for target in targets
+        ]
+    except _ArityError:
+        return _FailedToApplyAnnotation()
+    if len(zipped_targets) == 1 and len(zipped_targets[0]) == 1:
+        # We can convert simple one-target assignments into a single AnnAssign
+        target, raw_annotation = zipped_targets[0][0]
+        return cst.AnnAssign(
+            target=target,
+            annotation=_convert_annotation(raw=raw_annotation),
+            value=node.value,
+            semicolon=node.semicolon,
+        )
+    else:
+        # For multi-target assigns (regardless of whether they are using tuples
+        # on the LHS or multiple `=` tokens or both), we need to add a type
+        # declaration per individual LHS target.
+        type_declarations = [
+            cst.AnnAssign(
+                target=target,
+                annotation=_convert_annotation(raw=raw_annotation),
+                value=None,
+            )
+            for zipped_target in zipped_targets
+            for target, raw_annotation in zipped_target
+        ]
+        return [
+            *type_declarations,
+            node,
+        ]
+
+
 class ConvertTypeComments(VisitorBasedCodemodCommand):
     """
     Codemod that converts type comments, as described in
     https://www.python.org/dev/peps/pep-0484/#type-comments,
     into PEP 526 annotated assignments.
 
-    This is a work in progress: the codemod only currently handles
-    single-annotation assigns, but it will preserve any type comments
-    that it does not consume.
+    This is a work in progress: we intend to also support
+    function type comments, with statements, and for statements
+    but those are not yet implemented.
     """
 
     def __init__(self, context: CodemodContext) -> None:
@@ -93,27 +233,11 @@ class ConvertTypeComments(VisitorBasedCodemodCommand):
             comment=None,
         )
 
-    def _convert_Assign(
-        self,
-        assign: cst.Assign,
-        type_comment: str,
-    ) -> Union[cst.AnnAssign, cst.Assign]:
-        if len(assign.targets) != 1:
-            # this case is not yet implemented, and we short-circuit
-            # it when handling SimpleStatementLine.
-            raise RuntimeError("Should not convert multi-target assign")
-        return cst.AnnAssign(
-            target=assign.targets[0].target,
-            annotation=_convert_annotation(raw=type_comment),
-            value=assign.value,
-            semicolon=assign.semicolon,
-        )
-
     def leave_SimpleStatementLine(
         self,
         original_node: cst.SimpleStatementLine,
         updated_node: cst.SimpleStatementLine,
-    ) -> cst.SimpleStatementLine:
+    ) -> Union[cst.SimpleStatementLine, cst.FlattenSentinel]:
         """
         Convert any SimpleStatementLine containing an Assign with a
         type comment into a one that uses a PEP 526 AnnAssign.
@@ -125,22 +249,58 @@ class ConvertTypeComments(VisitorBasedCodemodCommand):
         type_comment = _simple_statement_type_comment(original_node)
         if type_comment is None:
             return updated_node
-        if len(assign.targets) != 1:  # multi-target Assign isn't used
-            return updated_node
-        target = assign.targets[0].target
-        if isinstance(target, cst.Tuple):  # multi-element Assign isn't handled
-            return updated_node
         # At this point have a single-line Assign with a type comment.
         # Convert it to an AnnAssign and strip the comment.
-        return updated_node.with_changes(
-            body=[
-                *updated_node.body[:-1],
-                self._convert_Assign(
-                    assign=assign,
-                    type_comment=type_comment,
-                ),
-            ],
-            trailing_whitespace=self._strip_TrailingWhitespace(
-                updated_node.trailing_whitespace
-            ),
+        converted = convert_Assign(
+            node=assign,
+            type_comment=type_comment,
         )
+        if isinstance(converted, _FailedToApplyAnnotation):
+            # We were unable to consume the type comment, so return the
+            # original code unchanged.
+            # TODO: allow stripping the invalid type comments via a flag
+            return updated_node
+        elif isinstance(converted, cst.AnnAssign):
+            # We were able to convert the Assign into an AnnAssign, so
+            # we can update the node.
+            return updated_node.with_changes(
+                body=[*updated_node.body[:-1], converted],
+                trailing_whitespace=self._strip_TrailingWhitespace(
+                    updated_node.trailing_whitespace,
+                ),
+            )
+        elif isinstance(converted, list):
+            # We need to inject two or more type declarations.
+            #
+            # In this case, we need to split across multiple lines, and
+            # this also means we'll spread any multi-statement lines out
+            # (multi-statement lines are PEP 8 violating anyway).
+            #
+            # We still preserve leading lines from before our transform.
+            new_statements = [
+                *(
+                    statement.with_changes(
+                        semicolon=cst.MaybeSentinel.DEFAULT,
+                    )
+                    for statement in updated_node.body[:-1]
+                ),
+                *converted,
+            ]
+            if len(new_statements) < 2:
+                raise RuntimeError("Unreachable code.")
+            return cst.FlattenSentinel(
+                [
+                    updated_node.with_changes(
+                        body=[new_statements[0]],
+                        trailing_whitespace=self._strip_TrailingWhitespace(
+                            updated_node.trailing_whitespace,
+                        ),
+                    ),
+                    *(
+                        cst.SimpleStatementLine(body=[statement])
+                        for statement in new_statements[1:]
+                    ),
+                ]
+            )
+        else:
+            raise RuntimeError(f"Unhandled value {converted}")

--- a/libcst/codemod/commands/tests/test_convert_type_comments.py
+++ b/libcst/codemod/commands/tests/test_convert_type_comments.py
@@ -14,12 +14,12 @@ class TestConvertTypeComments(CodemodTest):
     maxDiff = 1500
     TRANSFORM = ConvertTypeComments
 
-    def assertCodemod38Plus(self, before: str, after: str) -> None:
+    def assertCodemod39Plus(self, before: str, after: str) -> None:
         """
-        Assert that the codemod works on Python 3.8+, and that we raise
-        a NotImplementedError on other python versions.
+        Assert that the codemod works on Python 3.9+, and that we raise
+        a NotImplementedError on other Python versions.
         """
-        if (sys.version_info.major, sys.version_info.minor) < (3, 8):
+        if (sys.version_info.major, sys.version_info.minor) < (3, 9):
             with self.assertRaises(NotImplementedError):
                 super().assertCodemod(before, after)
         else:
@@ -36,7 +36,7 @@ class TestConvertTypeComments(CodemodTest):
             y: int = 5
             z: "typing.Tuple[str, int]" = ('this', 7)
         """
-        self.assertCodemod38Plus(before, after)
+        self.assertCodemod39Plus(before, after)
 
     def test_convert_assignments_in_context(self) -> None:
         """
@@ -60,7 +60,7 @@ class TestConvertTypeComments(CodemodTest):
                 def __init__(self):
                     self.attr1: bool = True
         """
-        self.assertCodemod38Plus(before, after)
+        self.assertCodemod39Plus(before, after)
 
     def test_multiple_elements_in_assign_lhs(self) -> None:
         before = """
@@ -89,7 +89,7 @@ class TestConvertTypeComments(CodemodTest):
             e2: str
             d, (e1, e2) = foo()
         """
-        self.assertCodemod38Plus(before, after)
+        self.assertCodemod39Plus(before, after)
 
     def test_multiple_assignments(self) -> None:
         before = """
@@ -109,7 +109,7 @@ class TestConvertTypeComments(CodemodTest):
             d: str
             a, b = c, d = 'this', 'that'
         """
-        self.assertCodemod38Plus(before, after)
+        self.assertCodemod39Plus(before, after)
 
     def test_semicolons_with_assignment(self) -> None:
         """
@@ -130,7 +130,7 @@ class TestConvertTypeComments(CodemodTest):
             z: str
             y, z = baz()
         """
-        self.assertCodemod38Plus(before, after)
+        self.assertCodemod39Plus(before, after)
 
     def test_no_change_when_type_comment_unused(self) -> None:
         before = """
@@ -152,4 +152,4 @@ class TestConvertTypeComments(CodemodTest):
             v = v0, v1 = (3, 5)  # type: int, int
         """
         after = before
-        self.assertCodemod38Plus(before, after)
+        self.assertCodemod39Plus(before, after)

--- a/libcst/codemod/commands/tests/test_convert_type_comments.py
+++ b/libcst/codemod/commands/tests/test_convert_type_comments.py
@@ -11,7 +11,7 @@ from libcst.codemod.commands.convert_type_comments import ConvertTypeComments
 
 class TestConvertTypeComments(CodemodTest):
 
-    maxDiff = 1000
+    maxDiff = 1500
     TRANSFORM = ConvertTypeComments
 
     def assertCodemod38Plus(self, before: str, after: str) -> None:
@@ -43,8 +43,6 @@ class TestConvertTypeComments(CodemodTest):
         Also verify that our matching works regardless of spacing
         """
         before = """
-            bar(); baz = 12  # type: int
-
             def foo():
                 z = ('this', 7) # type: typing.Tuple[str, int]
 
@@ -54,8 +52,6 @@ class TestConvertTypeComments(CodemodTest):
                     self.attr1 = True  # type: bool
         """
         after = """
-            bar(); baz: int = 12
-
             def foo():
                 z: "typing.Tuple[str, int]" = ('this', 7)
 
@@ -63,6 +59,76 @@ class TestConvertTypeComments(CodemodTest):
                 attr0: int = 10
                 def __init__(self):
                     self.attr1: bool = True
+        """
+        self.assertCodemod38Plus(before, after)
+
+    def test_multiple_elements_in_assign_lhs(self) -> None:
+        before = """
+            x, y = [], []        # type: List[int], List[str]
+            z, w = [], []        # type: (List[int], List[str])
+
+            a, b, *c = range(5)  # type: float, float, List[float]
+
+            d, (e1, e2) = foo()  # type: float, (int, str)
+        """
+        after = """
+            x: "List[int]"
+            y: "List[str]"
+            x, y = [], []
+            z: "List[int]"
+            w: "List[str]"
+            z, w = [], []
+
+            a: float
+            b: float
+            c: "List[float]"
+            a, b, *c = range(5)
+
+            d: float
+            e1: int
+            e2: str
+            d, (e1, e2) = foo()
+        """
+        self.assertCodemod38Plus(before, after)
+
+    def test_multiple_assignments(self) -> None:
+        before = """
+            x = y = z = 15 # type: int
+
+            a, b = c, d = 'this', 'that' # type: (str, str)
+        """
+        after = """
+            x: int
+            y: int
+            z: int
+            x = y = z = 15
+
+            a: str
+            b: str
+            c: str
+            d: str
+            a, b = c, d = 'this', 'that'
+        """
+        self.assertCodemod38Plus(before, after)
+
+    def test_semicolons_with_assignment(self) -> None:
+        """
+        When we convert an Assign to an AnnAssign, preserve
+        semicolons. But if we have to add separate type declarations,
+        expand them.
+        """
+        before = """
+            foo(); x = 12  # type: int
+
+            bar(); y, z = baz() # type: int, str
+        """
+        after = """
+            foo(); x: int = 12
+
+            bar()
+            y: int
+            z: str
+            y, z = baz()
         """
         self.assertCodemod38Plus(before, after)
 
@@ -77,12 +143,13 @@ class TestConvertTypeComments(CodemodTest):
             # a type comment in an illegal location won't be used
             print("hello")  # type: None
 
-            # We currently cannot handle multiple-target assigns.
-            # Make sure we won't strip those type comments.
-            x, y, z = [], [], []  # type: List[int], List[int], List[str]
-            x, y, z = [], [], []  # type: (List[int], List[int], List[str])
-            a, b, *c = range(5)   # type: float, float, List[float]
+            # These examples are not PEP 484 compliant, and result in arity errors
             a, b = 1, 2  # type: Tuple[int, int]
+            w = foo()  # type: float, str
+
+            # Multiple assigns with mismatched LHS arities always result in arity
+            # errors, and we only codemod if each target is error-free
+            v = v0, v1 = (3, 5)  # type: int, int
         """
         after = before
         self.assertCodemod38Plus(before, after)


### PR DESCRIPTION
## Summary

In the previous PR, I added basic support for converting an
Assign with a type comment to an AnnAssign, as long as there was
only one target.

This PR handles all fully PEP 484 compliant cases:
- multiple assignments
- multiple elements in the LHS l-value

We cannot handle arity errors because there's no way to do it. And
we don't try to handle the ambiguous case of multiple assignments with
mismatched arities (PEP 484 isn't super clear on which LHS is supposed
to pick up the type, we are conservative here). The ambiguous case is
probably very uncommon in real code anyway, multiple assignment is not
a widely used feature.

NOTE: my local pyre is complaining and I don't understand it, putting
a PR up anyway to see what CI does.

## Test Plan

There are new test cases covering:
- multiple elements in the LHS
- multiple assignment
- both of the above together
- semicolon expansion, which is handled differently in the cases
  where we have to add type declarations
- new error cases:
  - mismatched arity in both directions on one assignment
  - mismatched arity in multiple assignment
```
> python -m unittest libcst.codemod.commands.tests.test_convert_type_comments
.....
----------------------------------------------------------------------
Ran 5 tests in 0.150s

OK
```


