### PR TITLE
Start building linux/arm64/v8 wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,12 +149,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - vers: i686
-            os: ubuntu-20.04
-          # aarch64 seems to be stuck
-          # - vers: aarch64
-          #   os: ubuntu-20.04
-          - vers: auto64
+          - vers: "x86_64 i686 aarch64"
             os: ubuntu-20.04
           - vers: arm64
             os: macos-10.15
@@ -189,6 +184,11 @@ jobs:
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       run: >-
         echo LIBCST_NO_LOCAL_SCHEME=1 >> $GITHUB_ENV
+    - name: Set up QEMU
+      if: matrix.os == 'ubuntu-20.04'
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: all
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.3.1
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,7 +149,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - vers: "x86_64 i686 aarch64"
+          - vers: x86_64
+            os: ubuntu-20.04
+          - vers: i686
+            os: ubuntu-20.04
+          - vers: aarch64
             os: ubuntu-20.04
           - vers: arm64
             os: macos-10.15
@@ -163,7 +167,7 @@ jobs:
       CIBW_BEFORE_ALL_MACOS: "rustup target add aarch64-apple-darwin x86_64-apple-darwin"
       CIBW_BEFORE_ALL_WINDOWS: "rustup target add x86_64-pc-windows-msvc i686-pc-windows-msvc"
       CIBW_ENVIRONMENT: 'PATH="$PATH:$HOME/.cargo/bin" LIBCST_NO_LOCAL_SCHEME=$LIBCST_NO_LOCAL_SCHEME'
-      CIBW_SKIP: "cp27-* cp34-* cp35-* pp* *-win32 *-win_arm64 *-musllinux_*"
+      CIBW_SKIP: "cp27-* cp34-* cp35-* pp* *-win32 *-win_arm64 *-musllinux_* cp36-manylinux_aarch64"
       CIBW_ARCHS: ${{ matrix.vers }}
       CIBW_BUILD_VERBOSITY: 1
     steps:


### PR DESCRIPTION
## Summary

Update the CI config workflow for wheel building to start cross compiling to arm64 linux. Also try to join the two `i686` and `auto64` jobs into one.

Could fix #603 

There is a similar PR for another project here https://github.com/lincolnloop/pyuwsgi-wheels/pull/13

## Test Plan

Can test the wheels on an M1 Mac in docker using a small Dockerfile with the wheel artifacts from the CI job

```Dockerfile
FROM python:3.9-slim

COPY yup.whl .
pip install ./yup.whl
```
```bash
docker build -t yolo .
docker run -it yolo python -m libcst.tool print /usr/local/lib/python3.9/random.py
```