### PR TITLE
Allow trailing whitespace without newline at EOF

### DIFF
--- a/native/libcst/src/tokenizer/core/mod.rs
+++ b/native/libcst/src/tokenizer/core/mod.rs
@@ -533,9 +533,13 @@ impl<'t> TokState<'t> {
             }
         }
 
-        // Lines with only whitespace and/or comments and/or a line continuation character shouldn't
-        // affect the indentation and are not passed to the parser as NEWLINE tokens.
-        self.blank_line = matches!(self.text_pos.peek(), Some('#') | Some('\n') | Some('\\'));
+        // Lines with only whitespace and/or comments and/or a line continuation
+        // character shouldn't affect the indentation and are not passed to the parser
+        // as NEWLINE tokens.
+        self.blank_line = matches!(
+            self.text_pos.peek(),
+            Some('#') | Some('\n') | Some('\\') | None
+        );
 
         if self.blank_line || !self.paren_stack.is_empty() {
             return Ok(());

--- a/native/libcst/src/tokenizer/tests.rs
+++ b/native/libcst/src/tokenizer/tests.rs
@@ -727,3 +727,20 @@ fn test_add_dedents_for_dangling_indent_with_comment() {
         ])
     );
 }
+
+#[test]
+fn test_inconsistent_indentation_at_eof() {
+    assert_eq!(
+        tokenize_all("if 1:\n  pass\n ", &default_config()),
+        Ok(vec![
+            (TokType::Name, "if"),
+            (TokType::Number, "1"),
+            (TokType::Op, ":"),
+            (TokType::Newline, "\n"),
+            (TokType::Indent, ""),
+            (TokType::Name, "pass"),
+            (TokType::Newline, "\n"),
+            (TokType::Dedent, ""),
+        ])
+    )
+}


### PR DESCRIPTION
## Summary

The native tokenizer was a bit too strict about indentation checking at EOF. This is valid Python: `if 1:\n    pass\n ` (note the extra space at the end without a newline), but the tokenizer was trying to match the single space at the end as if it was a dedent from level 4 -> 1, which failed (there was never a level 1 indentation).

This PR relaxes the tokenizer a bit to allow for such cases. Indentation checking is skipped if after consuming all whitespace at the beginning of the line, we encounter EOF.

Fixes #608 

## Test Plan

Added unit test.
