### PR TITLE
Specify minimum rust toolchain version

### DIFF
--- a/native/libcst/Cargo.toml
+++ b/native/libcst/Cargo.toml
@@ -8,6 +8,7 @@ name = "libcst"
 version = "0.1.0"
 authors = ["LibCST Developers"]
 edition = "2018"
+rust-version = "1.53"
 
 [lib]
 name = "libcst_native"


### PR DESCRIPTION
In #613 people reported being unable to compile LibCST on rustc `1.52.1`. This PR specifices [the minimum version required](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field) to compile LibCST.