### PR TITLE
add slotscheck to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
     - run: flake8
     - run: ufmt check .
     - run: python3 -m fixit.cli.run_rules
-    - run: slotscheck libcst
+    - run: python -m slotscheck libcst
 
 # Run pyre typechecker
   typecheck:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
     - run: flake8
     - run: ufmt check .
     - run: python3 -m fixit.cli.run_rules
+    - run: slotscheck libcst
 
 # Run pyre typechecker
   typecheck:

--- a/README.rst
+++ b/README.rst
@@ -164,6 +164,13 @@ changes to be conformant, run the following in the root:
 
     ufmt format && python -m fixit.cli.apply_fix
 
+We use `slotscheck <https://slotscheck.rtfd.io>`_ to check the correctness
+of class ``__slots__``. To check that slots are defined properly, run:
+
+.. code-block:: shell
+
+   slotscheck libcst
+
 To run all tests, you'll need to do the following in the root:
 
 .. code-block:: shell

--- a/README.rst
+++ b/README.rst
@@ -169,7 +169,7 @@ of class ``__slots__``. To check that slots are defined properly, run:
 
 .. code-block:: shell
 
-   slotscheck libcst
+    slotscheck libcst
 
 To run all tests, you'll need to do the following in the root:
 

--- a/README.rst
+++ b/README.rst
@@ -169,7 +169,7 @@ of class ``__slots__``. To check that slots are defined properly, run:
 
 .. code-block:: shell
 
-    slotscheck libcst
+    python -m slotscheck libcst
 
 To run all tests, you'll need to do the following in the root:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,5 +5,8 @@ exclude = "native/.*"
 [tool.ufmt]
 excludes = ["native/", "stubs/"]
 
+[tool.slotscheck]
+exclude-modules = '^libcst\.(testing|tests)'
+
 [build-system]
 requires = ["setuptools", "wheel", "setuptools-rust"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,4 @@ sphinx-rtd-theme>=0.4.3
 ufmt==1.3
 usort==1.0.0rc1
 setuptools-rust>=0.12.1
+slotscheck>=0.7.0,<0.8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,4 +15,4 @@ sphinx-rtd-theme>=0.4.3
 ufmt==1.3
 usort==1.0.0rc1
 setuptools-rust>=0.12.1
-slotscheck>=0.7.0,<0.8
+slotscheck>=0.7.1,<0.8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,4 +15,4 @@ sphinx-rtd-theme>=0.4.3
 ufmt==1.3
 usort==1.0.0rc1
 setuptools-rust>=0.12.1
-slotscheck>=0.7.1,<0.8
+slotscheck>=0.7.1


### PR DESCRIPTION
## Summary

@zsol [requested](https://github.com/Instagram/LibCST/issues/574#issuecomment-1006397621) I add [slotscheck](https://github.com/ariebovenberg/slotscheck) to the CI. 

Slotscheck prevents mistakes in `__slots__` from creeping in again. Fixing slots in #605 resulted in big memory savings.

Instructions for pre-commit are documented [here](https://slotscheck.readthedocs.io/en/latest/advanced.html#pre-commit-hook).

## Test Plan

I've added `slotscheck` to the github build action. Let me know if you'd like it mentioned in `CONTRIBUTING.md` or `README.rst`

fixes #574 