### PR TITLE
Handle ast.parse failures when converting function type comments

### DIFF
--- a/libcst/codemod/commands/convert_type_comments.py
+++ b/libcst/codemod/commands/convert_type_comments.py
@@ -64,7 +64,7 @@ def _annotation_for_statement(
 
 def _parse_func_type_comment(
     func_type_comment: Optional[str],
-) -> Optional[ast.FunctionType]:
+) -> Optional["ast.FunctionType"]:
     if func_type_comment is None:
         return None
     return cast(


### PR DESCRIPTION
## Summary

We have to parse code using the ast module in two situations, and in either case we can hit parse errors even though the code is valid python.

(a) by parsing with `type_comments=True` to reliably extract string type comments from code. This can throw errors if there are comments of the form `# type: something` anywhere where type information is invalid according to PEP 484.

(b) by parsing the type comments themselves into expressions or ast.FunctionType values. This can throw errors, even if (a) succeeds, whenever the type itself is not well-formed.

This commit updates `convert_type_comments` to handle these situations by ignoring type information on a specific node - prior to this commit, the entire codemod would have crashed, but there may be many other type comments in the module which are perfectly valid and we'd like to be able to keep going when we hit SyntaxErrors.

## Test Plan

I added new test cases for invalid type comments
