### PR TITLE
Do not traverse lambdas - they can have Params but there are no type comments

### DIFF
--- a/libcst/codemod/commands/convert_type_comments.py
+++ b/libcst/codemod/commands/convert_type_comments.py
@@ -747,3 +747,14 @@ class ConvertTypeComments(VisitorBasedCodemodCommand):
             )
         else:
             return updated_node
+
+    def visit_Lambda(
+        self,
+        node: cst.Lambda,
+    ) -> bool:
+        """
+        Disable traversing under lambdas. They don't have any statements
+        nested inside them so there's no need, and they do have Params which
+        we don't want to transform.
+        """
+        return False

--- a/libcst/codemod/commands/tests/test_convert_type_comments.py
+++ b/libcst/codemod/commands/tests/test_convert_type_comments.py
@@ -355,3 +355,17 @@ class TestConvertTypeComments_FunctionDef(TestConvertTypeCommentsBase):
         """
         after = before
         self.assertCodemod39Plus(before, after)
+
+    def test_do_not_traverse_lambda_Param(self) -> None:
+        """
+        The Param node can happen not just in FunctionDef but also in
+        Lambda. Make sure this doesn't cause problems.
+        """
+        before = """
+        @dataclass
+        class WrapsAFunction:
+            func: Callable
+            msg_gen: Callable = lambda self: f"calling {self.func.__name__}..."
+        """
+        after = before
+        self.assertCodemod39Plus(before, after)


### PR DESCRIPTION
## Summary

My first time testing this codemod against a good-size project, I ran into a problem: the `Param` node can happen under either `FunctionDef` or `Lambda`, which I hadn't realized and I was assuming all `Param` transforms could rely on the surrounding `FunctionDef` for context information.

Since type comments cannot occur inside of Lambda (because all type comments are on statements, which cannot exist in lambdas), this is very easy to work around: just return false from visit_Lambda to truncate traversal of the cst.

## Test Plan

I added a test case, which is a simplified example of actual code that caused me problems. I also verified that the codemod worked after this fix.
