### PR TITLE
[native] Allow unparenthesized tuples inside f-strings

### DIFF
--- a/libcst/_nodes/tests/test_atom.py
+++ b/libcst/_nodes/tests/test_atom.py
@@ -740,6 +740,69 @@ class AtomTest(CSTNodeTest):
                 "parser": parse_expression,
                 "expected_position": None,
             },
+            # Unpacked tuple
+            {
+                "node": cst.FormattedString(
+                    parts=[
+                        cst.FormattedStringExpression(
+                            expression=cst.Tuple(
+                                elements=[
+                                    cst.Element(
+                                        value=cst.Name(
+                                            value="a",
+                                        ),
+                                        comma=cst.Comma(
+                                            whitespace_before=cst.SimpleWhitespace(
+                                                value="",
+                                            ),
+                                            whitespace_after=cst.SimpleWhitespace(
+                                                value=" ",
+                                            ),
+                                        ),
+                                    ),
+                                    cst.Element(
+                                        value=cst.Name(
+                                            value="b",
+                                        ),
+                                    ),
+                                ],
+                                lpar=[],
+                                rpar=[],
+                            ),
+                        ),
+                    ],
+                    start="f'",
+                    end="'",
+                ),
+                "code": "f'{a, b}'",
+                "parser": parse_expression,
+                "expected_position": None,
+            },
+            # Conditional expression
+            {
+                "node": cst.FormattedString(
+                    parts=[
+                        cst.FormattedStringExpression(
+                            expression=cst.IfExp(
+                                test=cst.Name(
+                                    value="b",
+                                ),
+                                body=cst.Name(
+                                    value="a",
+                                ),
+                                orelse=cst.Name(
+                                    value="c",
+                                ),
+                            ),
+                        ),
+                    ],
+                    start="f'",
+                    end="'",
+                ),
+                "code": "f'{a if b else c}'",
+                "parser": parse_expression,
+                "expected_position": None,
+            },
             # Concatenated strings
             {
                 "node": cst.ConcatenatedString(

--- a/native/libcst/src/parser/grammar.rs
+++ b/native/libcst/src/parser/grammar.rs
@@ -1396,7 +1396,7 @@ parser! {
 
         rule _f_expr() -> Expression<'a>
             = (g:_bare_genexp() {Expression::GeneratorExp(g)})
-            / _conditional_expression()
+            / star_expressions()
             / yield_expr()
 
         rule _f_conversion() -> &'a str


### PR DESCRIPTION
## Summary
Fixes #620
## Test Plan
Add a bunch of tests to ensure this problem is fixed.