### PR TITLE
Add support for methods with func type comment excluding self/cls

### DIFF
--- a/libcst/codemod/commands/convert_type_comments.py
+++ b/libcst/codemod/commands/convert_type_comments.py
@@ -811,7 +811,7 @@ class ConvertTypeComments(VisitorBasedCodemodCommand):
         self,
         original_node: cst.ClassDef,
         updated_node: cst.ClassDef,
-    ) -> None:
+    ) -> cst.ClassDef:
         """
         Keep track of when we are and are not inside of classes, to help with
         heuristics to handle methods correctly.

--- a/libcst/codemod/commands/convert_type_comments.py
+++ b/libcst/codemod/commands/convert_type_comments.py
@@ -645,17 +645,12 @@ class ConvertTypeComments(VisitorBasedCodemodCommand):
     #
     # PEP 484 underspecifies how to apply type comments to (non-static)
     # methods - it would be possible to provide a type for `self`, or to omit
-    # it. We use heuristics to determine when a function is a method, and allow
-    # for the `self` or `cls` argument to have no type provided.
-    #
-    # The heuristics are:
-    # - Is it inside of a class body? If not, it is never a method.
-    # - Is the name of the first parameter `cls` or `self`? This isn't required
-    #   but it's a strong enough convention that it should work as a heuristic.
+    # it. So we accept either approach when interpreting type comments on
+    # non-static methods: the first argument an have a type provided or not.
 
-    def visit_Class(
+    def visit_ClassDef(
         self,
-        node: cst.Class,
+        node: cst.ClassDef,
     ) -> None:
         """
         Keep track of when we are and are not inside of classes, to help with
@@ -812,16 +807,17 @@ class ConvertTypeComments(VisitorBasedCodemodCommand):
         else:
             return updated_node
 
-    def leave_Class(
+    def leave_ClassDef(
         self,
-        original_node: cst.Class,
-        updated_node: cst.Class,
+        original_node: cst.ClassDef,
+        updated_node: cst.ClassDef,
     ) -> None:
         """
         Keep track of when we are and are not inside of classes, to help with
         heuristics to handle methods correctly.
         """
         self.nesting_level -= 1
+        return updated_node
 
     def visit_Lambda(
         self,

--- a/libcst/codemod/commands/convert_type_comments.py
+++ b/libcst/codemod/commands/convert_type_comments.py
@@ -681,7 +681,6 @@ class ConvertTypeComments(VisitorBasedCodemodCommand):
         self.function_type_info_stack.append(function_type_info)
         self.function_body_stack.append(node.body)
 
-
     @m.call_if_not_inside(m.ClassDef())
     @m.visit(m.FunctionDef())
     def visit_method(
@@ -702,8 +701,7 @@ class ConvertTypeComments(VisitorBasedCodemodCommand):
         return self._visit_FunctionDef(
             node=node,
             is_method=not any(
-                m.matches(d.decorator, m.Name("staticmethod"))
-                for d in node.decorators
+                m.matches(d.decorator, m.Name("staticmethod")) for d in node.decorators
             ),
         )
 

--- a/libcst/codemod/commands/convert_type_comments.py
+++ b/libcst/codemod/commands/convert_type_comments.py
@@ -655,7 +655,7 @@ class ConvertTypeComments(VisitorBasedCodemodCommand):
 
     def visit_Class(
         self,
-        node: cst.FunctionDef,
+        node: cst.Class,
     ) -> None:
         """
         Keep track of when we are and are not inside of classes, to help with
@@ -814,8 +814,8 @@ class ConvertTypeComments(VisitorBasedCodemodCommand):
 
     def leave_Class(
         self,
-        original_node: cst.FunctionDef,
-        updated_node: cst.FunctionDef,
+        original_node: cst.Class,
+        updated_node: cst.Class,
     ) -> None:
         """
         Keep track of when we are and are not inside of classes, to help with

--- a/libcst/codemod/commands/tests/test_convert_type_comments.py
+++ b/libcst/codemod/commands/tests/test_convert_type_comments.py
@@ -337,6 +337,73 @@ class TestConvertTypeComments_FunctionDef(TestConvertTypeCommentsBase):
         """
         self.assertCodemod39Plus(before, after)
 
+    def test_method_transforms(self) -> None:
+        before = """
+        class A:
+
+            def __init__(self, thing):  # type: (str) -> None
+                self.thing = thing
+
+            @classmethod
+            def make(cls):  # type: () -> A
+                return cls("thing")
+
+            @staticmethod
+            def f(x, y):  # type: (object, object) -> None
+                pass
+
+            def method0(
+                self,
+                other_thing,
+            ):  # type: (str) -> bool
+                return self.thing == other_thing
+
+            def method1(
+                self,  # type: A
+                other_thing,  # type: str
+            ):  # type: (int) -> bool
+                return self.thing == other_thing
+
+            def method2(
+                self,
+                other_thing,
+            ):  # type: (A, str) -> bool
+                return self.thing == other_thing
+        """
+        after = """
+        class A:
+
+            def __init__(self, thing: str) -> None:
+                self.thing = thing
+
+            @classmethod
+            def make(cls) -> "A":
+                return cls("thing")
+
+            @staticmethod
+            def f(x: object, y: object) -> None:
+                pass
+
+            def method0(
+                self,
+                other_thing: str,
+            ) -> bool:
+                return self.thing == other_thing
+
+            def method1(
+                self: "A",
+                other_thing: str,
+            ) -> bool:
+                return self.thing == other_thing
+
+            def method2(
+                self: "A",
+                other_thing: str,
+            ) -> bool:
+                return self.thing == other_thing
+        """
+        self.assertCodemod39Plus(before, after)
+
     def test_no_change_if_function_type_comments_unused(self) -> None:
         before = """
         # arity error in arguments


### PR DESCRIPTION
## Summary

PEP 484 doesn't really specify carefully how function type
comments should work on methods, but since usually the type of
`self` / `cls` is automatic, most use cases choose to only annotate
the other arguments.

As a result, this commit modifies our codemod so that non-static
methods can specify either all the arguments, or all but one of
them. We'll correctly zip together the inline and func-type-comment
types either way, typically getting no type for `cls` or `self`.

We accomplish this by using matchers to trigger the visit
method for FunctionDef rather than using visit_FunctionDef, which gives
us enough context to determine when a function def is a regular
function versus a method (plus also matching the decorators against
`@staticmethod`, so that we trigger the normal function logic in
that case).

## Test Plan

I added a new test verifying various method cases: static and non-static,
with and without annotations of `self` / `cls` in the func type comment,
with and without inline type comments.
