### PR TITLE
Proxy both parentheses in some pattern matching nodes

### DIFF
--- a/libcst/_nodes/statement.py
+++ b/libcst/_nodes/statement.py
@@ -2848,6 +2848,14 @@ class MatchValue(MatchPattern):
     def lpar(self, value: Sequence[LeftParen]) -> None:
         self.value.lpar = value
 
+    @property
+    def rpar(self) -> Sequence[RightParen]:
+        return self.value.rpar
+
+    @rpar.setter
+    def rpar(self, value: Sequence[RightParen]) -> None:
+        self.value.rpar = value
+
 
 @add_slots
 @dataclass(frozen=True)
@@ -2880,6 +2888,15 @@ class MatchSingleton(MatchPattern):
     def lpar(self, value: Sequence[LeftParen]) -> None:
         # pyre-fixme[41]: Cannot reassign final attribute `lpar`.
         self.value.lpar = value
+
+    @property
+    def rpar(self) -> Sequence[RightParen]:
+        return self.value.rpar
+
+    @rpar.setter
+    def rpar(self, value: Sequence[RightParen]) -> None:
+        # pyre-fixme[41]: Cannot reassign final attribute `rpar`.
+        self.value.rpar = value
 
 
 @add_slots

--- a/libcst/_nodes/tests/test_match.py
+++ b/libcst/_nodes/tests/test_match.py
@@ -39,6 +39,39 @@ class MatchTest(CSTNodeTest):
                 + '    case "foo": pass\n',
                 "parser": parser,
             },
+            # Parenthesized value
+            {
+                "node": cst.Match(
+                    subject=cst.Name(
+                        value="x",
+                    ),
+                    cases=[
+                        cst.MatchCase(
+                            pattern=cst.MatchAs(
+                                pattern=cst.MatchValue(
+                                    value=cst.Integer(
+                                        value="1",
+                                        lpar=[
+                                            cst.LeftParen(),
+                                        ],
+                                        rpar=[
+                                            cst.RightParen(),
+                                        ],
+                                    ),
+                                ),
+                                name=cst.Name(
+                                    value="z",
+                                ),
+                                whitespace_before_as=cst.SimpleWhitespace(" "),
+                                whitespace_after_as=cst.SimpleWhitespace(" "),
+                            ),
+                            body=cst.SimpleStatementSuite([cst.Pass()]),
+                        ),
+                    ],
+                ),
+                "code": "match x:\n    case (1) as z: pass\n",
+                "parser": parser,
+            },
             # List patterns
             {
                 "node": cst.Match(


### PR DESCRIPTION
## Summary
This patch adds support for proxying the right parentheses to the underlying child node, so it would be consistent with the left one. Resolves #625.

## Test Plan
Added a test about a case that was broken before.
