### PR TITLE
Don't require whitespace right after match

### DIFF
--- a/libcst/_nodes/statement.py
+++ b/libcst/_nodes/statement.py
@@ -2687,11 +2687,6 @@ class Match(BaseCompoundStatement):
         if len(self.cases) == 0:
             raise CSTValidationError("A match statement must have at least one case.")
 
-        if self.whitespace_after_match.empty:
-            raise CSTValidationError(
-                "Must have at least one space after a 'match' keyword"
-            )
-
         indent = self.indent
         if indent is not None:
             if len(indent) == 0:

--- a/libcst/_nodes/tests/test_match.py
+++ b/libcst/_nodes/tests/test_match.py
@@ -425,6 +425,34 @@ class MatchTest(CSTNodeTest):
                 + "    case None | False | True: pass\n",
                 "parser": None,
             },
+            # Match without whitespace between keyword and the expr
+            {
+                "node": cst.Match(
+                    subject=cst.Name(
+                        "x", lpar=[cst.LeftParen()], rpar=[cst.RightParen()]
+                    ),
+                    cases=[
+                        cst.MatchCase(
+                            pattern=cst.MatchSingleton(
+                                cst.Name(
+                                    "None",
+                                    lpar=[cst.LeftParen()],
+                                    rpar=[cst.RightParen()],
+                                )
+                            ),
+                            body=cst.SimpleStatementSuite((cst.Pass(),)),
+                            whitespace_after_case=cst.SimpleWhitespace(
+                                value="",
+                            ),
+                        ),
+                    ],
+                    whitespace_after_match=cst.SimpleWhitespace(
+                        value="",
+                    ),
+                ),
+                "code": "match(x):\n    case(None): pass\n",
+                "parser": parser,
+            },
         )
     )
     def test_valid(self, **kwargs: Any) -> None:


### PR DESCRIPTION
## Summary
Fixes #627. This check seems like preventing something that is allowed in the regular Python.

## Test Plan
Added a test which didn't work before this patch.
