### PR TITLE
Update readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,12 +5,16 @@ sphinx:
 
 formats: all
 
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3"
+    rust: "1.55"
+
 python:
-   version: "3.8"
    install:
       - requirements: requirements.txt
       - requirements: requirements-dev.txt
       - method: pip
         path: .
-   system_packages: true
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ sphinx:
 formats: all
 
 python:
-   version: 3.7
+   version: "3.8"
    install:
       - requirements: requirements.txt
       - requirements: requirements-dev.txt


### PR DESCRIPTION
This PR should fix the readthedocs build.

Tested by temporarily introducing a stable tag at this PR and triggering a build: https://readthedocs.org/projects/libcst/builds/15948805/