### PR TITLE
Fix space validation for AsName and Await

### DIFF
--- a/libcst/_nodes/expression.py
+++ b/libcst/_nodes/expression.py
@@ -2394,7 +2394,12 @@ class Await(BaseExpression):
         # Validate any super-class stuff, whatever it may be.
         super(Await, self)._validate()
         # Make sure we don't run identifiers together.
-        if self.whitespace_after_await.empty:
+        if (
+            self.whitespace_after_await.empty
+            and not self.expression._safe_to_use_with_word_operator(
+                ExpressionPosition.RIGHT
+            )
+        ):
             raise CSTValidationError("Must have at least one space after await")
 
     def _visit_and_replace_children(self, visitor: CSTVisitorT) -> "Await":

--- a/libcst/_nodes/tests/test_await.py
+++ b/libcst/_nodes/tests/test_await.py
@@ -46,6 +46,14 @@ class AwaitTest(CSTNodeTest):
                 ),
                 "expected_position": CodeRange((1, 2), (1, 13)),
             },
+            # Whitespace after await
+            {
+                "node": cst.Await(
+                    cst.Name("foo", lpar=[cst.LeftParen()], rpar=[cst.RightParen()]),
+                    whitespace_after_await=cst.SimpleWhitespace(""),
+                ),
+                "code": "await(foo)",
+            },
         )
     )
     def test_valid_py37(self, **kwargs: Any) -> None:

--- a/libcst/_nodes/tests/test_import.py
+++ b/libcst/_nodes/tests/test_import.py
@@ -592,7 +592,7 @@ class ImportFromCreateTest(CSTNodeTest):
                                 ),
                                 whitespace_before_as=cst.SimpleWhitespace(""),
                             ),
-                        )
+                        ),
                     ),
                 ),
                 "expected_re": "one space before as keyword",

--- a/libcst/_nodes/tests/test_import.py
+++ b/libcst/_nodes/tests/test_import.py
@@ -197,6 +197,20 @@ class ImportCreateTest(CSTNodeTest):
             },
             {
                 "get_node": lambda: cst.Import(
+                    names=(
+                        cst.ImportAlias(
+                            cst.Name("foo"),
+                            asname=cst.AsName(
+                                cst.Name("bar"),
+                                whitespace_before_as=cst.SimpleWhitespace(""),
+                            ),
+                        ),
+                    ),
+                ),
+                "expected_re": "at least one space",
+            },
+            {
+                "get_node": lambda: cst.Import(
                     names=[
                         cst.ImportAlias(
                             name=cst.Attribute(
@@ -563,6 +577,25 @@ class ImportFromCreateTest(CSTNodeTest):
                     whitespace_after_import=cst.SimpleWhitespace(""),
                 ),
                 "expected_re": "one space after import",
+            },
+            {
+                "get_node": lambda: cst.ImportFrom(
+                    module=cst.Name("foo"),
+                    names=(
+                        cst.ImportAlias(
+                            cst.Name("bar"),
+                            asname=cst.AsName(
+                                cst.Name(
+                                    "baz",
+                                    lpar=(cst.LeftParen(),),
+                                    rpar=(cst.RightParen(),),
+                                ),
+                                whitespace_before_as=cst.SimpleWhitespace(""),
+                            ),
+                        )
+                    ),
+                ),
+                "expected_re": "one space before as keyword",
             },
         )
     )

--- a/libcst/_nodes/tests/test_try.py
+++ b/libcst/_nodes/tests/test_try.py
@@ -329,6 +329,24 @@ class TryTest(CSTNodeTest):
                 "code": "try: pass\nexcept(IOError, ImportError): pass\n",
                 "parser": parse_statement,
             },
+            # No space before as
+            {
+                "node": cst.Try(
+                    cst.SimpleStatementSuite((cst.Pass(),)),
+                    handlers=[
+                        cst.ExceptHandler(
+                            cst.SimpleStatementSuite((cst.Pass(),)),
+                            whitespace_after_except=cst.SimpleWhitespace(" "),
+                            type=cst.Call(cst.Name("foo")),
+                            name=cst.AsName(
+                                whitespace_before_as=cst.SimpleWhitespace(""),
+                                name=cst.Name("bar"),
+                            ),
+                        )
+                    ],
+                ),
+                "code": "try: pass\nexcept foo()as bar: pass\n",
+            },
         )
     )
     def test_valid(self, **kwargs: Any) -> None:
@@ -345,12 +363,6 @@ class TryTest(CSTNodeTest):
                     cst.Name("bla"), whitespace_after_as=cst.SimpleWhitespace("")
                 ),
                 "expected_re": "between 'as'",
-            },
-            {
-                "get_node": lambda: cst.AsName(
-                    cst.Name("bla"), whitespace_before_as=cst.SimpleWhitespace("")
-                ),
-                "expected_re": "before 'as'",
             },
             {
                 "get_node": lambda: cst.ExceptHandler(


### PR DESCRIPTION
## Summary

Fixes #633. Unfortunately we have to move the validation of `AsName` to its parent because of different rules for different parents as well as the need for the preceding expression.

## Test Plan

Added unit tests.

