### PR TITLE
Create an AddTrailingCommas codemod

### DIFF
--- a/libcst/codemod/commands/add_trailing_commas.py
+++ b/libcst/codemod/commands/add_trailing_commas.py
@@ -53,7 +53,7 @@ class AddTrailingCommas(VisitorBasedCodemodCommand):
         if presets is None:
             raise ValueError(
                 f"Unknown formatter {formatter!r}. Presets exist for "
-                + ', '.join(presets_per_formatter.keys())
+                + ", ".join(presets_per_formatter.keys())
             )
         self.parameter_count: int = parameter_count or presets["parameter_count"]
         self.argument_count: int = argument_count or presets["argument_count"]
@@ -66,7 +66,7 @@ class AddTrailingCommas(VisitorBasedCodemodCommand):
             metavar="FORMATTER",
             help="Formatter to target (e.g. yapf or black)",
             type=str,
-            default="black"
+            default="black",
         )
         arg_parser.add_argument(
             "--paramter-count",
@@ -74,7 +74,7 @@ class AddTrailingCommas(VisitorBasedCodemodCommand):
             metavar="PARAMETER_COUNT",
             help="Minimal number of parameters for us to add trailing comma",
             type=int,
-            default=None
+            default=None,
         )
         arg_parser.add_argument(
             "--argument-count",
@@ -82,7 +82,7 @@ class AddTrailingCommas(VisitorBasedCodemodCommand):
             metavar="ARGUMENT_COUNT",
             help="Minimal number of arguments for us to add trailing comma",
             type=int,
-            default=None
+            default=None,
         )
 
     def leave_Parameters(
@@ -104,13 +104,11 @@ class AddTrailingCommas(VisitorBasedCodemodCommand):
         else:
             last_param = updated_node.params[-1]
             return updated_node.with_changes(
-                params=updated_node.params[:-1] + (
-                    last_param.with_changes(
-                        comma=cst.Comma()
-                    ),
-                )
+                params=(
+                    *updated_node.params[:-1],
+                    last_param.with_changes(comma=cst.Comma()),
+                ),
             )
-
 
     def leave_Call(
         self,
@@ -122,9 +120,8 @@ class AddTrailingCommas(VisitorBasedCodemodCommand):
         else:
             last_arg = updated_node.args[-1]
             return updated_node.with_changes(
-                args=updated_node.args[:-1] + (
-                    last_arg.with_changes(
-                        comma=cst.Comma()
-                    ),
-                )
+                args=(
+                    *updated_node.args[:-1],
+                    last_arg.with_changes(comma=cst.Comma()),
+                ),
             )

--- a/libcst/codemod/commands/add_trailing_commas.py
+++ b/libcst/codemod/commands/add_trailing_commas.py
@@ -1,0 +1,130 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import textwrap
+from typing import Dict, Optional
+
+import libcst as cst
+from libcst.codemod import CodemodContext, VisitorBasedCodemodCommand
+
+
+presets_per_formatter: Dict[str, Dict[str, int]] = {
+    "black": {
+        "parameter_count": 1,
+        "argument_count": 3,
+    },
+    "yapf": {
+        "parameter_count": 2,
+        "argument_count": 3,
+    },
+}
+
+
+class AddTrailingCommas(VisitorBasedCodemodCommand):
+    DESCRIPTION: str = textwrap.dedent(
+        """
+        Codemod that adds trailing commas to arguments in function
+        headers and function calls.
+
+        The idea is that both the black and yapf autoformatters will
+        tend to split headers and function calls so that there
+        is one parameter / argument per line if there is a trailing
+        comma:
+        - Black will always separate them by line
+        - Yapf appears to do so whenever there are at least two arguments
+
+        Applying this codemod (and then an autoformatter) may make
+        it easier to read function definitions and calls
+        """
+    )
+
+    def __init__(
+        self,
+        context: CodemodContext,
+        formatter: str = "black",
+        parameter_count: Optional[int] = None,
+        argument_count: Optional[int] = None,
+    ) -> None:
+        super().__init__(context)
+        presets = presets_per_formatter.get(formatter)
+        if presets is None:
+            raise ValueError(
+                f"Unknown formatter {formatter!r}. Presets exist for "
+                + ', '.join(presets_per_formatter.keys())
+            )
+        self.parameter_count: int = parameter_count or presets["parameter_count"]
+        self.argument_count: int = argument_count or presets["argument_count"]
+
+    @staticmethod
+    def add_args(arg_parser: argparse.ArgumentParser) -> None:
+        arg_parser.add_argument(
+            "--formatter",
+            dest="formatter",
+            metavar="FORMATTER",
+            help="Formatter to target (e.g. yapf or black)",
+            type=str,
+            default="black"
+        )
+        arg_parser.add_argument(
+            "--paramter-count",
+            dest="parameter_count",
+            metavar="PARAMETER_COUNT",
+            help="Minimal number of parameters for us to add trailing comma",
+            type=int,
+            default=None
+        )
+        arg_parser.add_argument(
+            "--argument-count",
+            dest="argument_count",
+            metavar="ARGUMENT_COUNT",
+            help="Minimal number of arguments for us to add trailing comma",
+            type=int,
+            default=None
+        )
+
+    def leave_Parameters(
+        self,
+        original_node: cst.Parameters,
+        updated_node: cst.Parameters,
+    ) -> cst.Parameters:
+        skip = (
+            #
+            self.parameter_count is None
+            or len(updated_node.params) < self.parameter_count
+            or (
+                len(updated_node.params) == 1
+                and updated_node.params[0].name.value in {"self", "cls"}
+            )
+        )
+        if skip:
+            return updated_node
+        else:
+            last_param = updated_node.params[-1]
+            return updated_node.with_changes(
+                params=updated_node.params[:-1] + (
+                    last_param.with_changes(
+                        comma=cst.Comma()
+                    ),
+                )
+            )
+
+
+    def leave_Call(
+        self,
+        original_node: cst.Call,
+        updated_node: cst.Call,
+    ) -> cst.Call:
+        if len(updated_node.args) < self.argument_count:
+            return updated_node
+        else:
+            last_arg = updated_node.args[-1]
+            return updated_node.with_changes(
+                args=updated_node.args[:-1] + (
+                    last_arg.with_changes(
+                        comma=cst.Comma()
+                    ),
+                )
+            )

--- a/libcst/codemod/commands/add_trailing_commas.py
+++ b/libcst/codemod/commands/add_trailing_commas.py
@@ -1,5 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-#
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
@@ -14,11 +12,11 @@ from libcst.codemod import CodemodContext, VisitorBasedCodemodCommand
 presets_per_formatter: Dict[str, Dict[str, int]] = {
     "black": {
         "parameter_count": 1,
-        "argument_count": 3,
+        "argument_count": 2,
     },
     "yapf": {
         "parameter_count": 2,
-        "argument_count": 3,
+        "argument_count": 2,
     },
 }
 

--- a/libcst/codemod/commands/tests/test_add_trailing_commas.py
+++ b/libcst/codemod/commands/tests/test_add_trailing_commas.py
@@ -1,0 +1,90 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+from libcst.codemod import CodemodTest
+from libcst.codemod.commands.add_trailing_commas import AddTrailingCommas
+
+
+class AddTrailingCommasTest(CodemodTest):
+    TRANSFORM = AddTrailingCommas
+
+    def test_transform_defines(self) -> None:
+        before = """
+        def f(x, y):
+            pass
+
+        """
+        after = """
+        def f(x, y,):
+            pass
+        """
+        self.assertCodemod(before, after)
+
+    def test_skip_transforming_defines(self) -> None:
+        before = """
+        # skip defines with no params.
+        def f0():
+            pass
+
+        # skip defines with a single param named `self`.
+        class Foo:
+            def __init__(self):
+                pass
+        """
+        after = before
+        self.assertCodemod(before, after)
+
+    def test_transform_calls(self) -> None:
+        before = """
+        f(a, b, c)
+
+        g(x=a, y=b, z=c)
+        """
+        after = """
+        f(a, b, c,)
+
+        g(x=a, y=b, z=c,)
+        """
+        self.assertCodemod(before, after)
+
+    def test_skip_transforming_calls(self) -> None:
+        before = """
+        # skip empty calls
+        f()
+
+        # skip calls with one argument
+        g(a)
+        g(x=a)
+        """
+        after = before
+        self.assertCodemod(before, after)
+
+    def test_using_yapf_presets(self) -> None:
+        before = """
+        def f(x):  # skip single parameters for yapf
+            pass
+
+        def g(x, y):
+            pass
+        """
+        after = """
+        def f(x):  # skip single parameters for yapf
+            pass
+
+        def g(x, y,):
+            pass
+        """
+        self.assertCodemod(before, after, formatter="yapf")
+
+    def test_using_custom_presets(self) -> None:
+        before = """
+        def f(x, y, z):
+            pass
+
+        f(5, 6, 7)
+        """
+        after = before
+        self.assertCodemod(before, after, parameter_count=4, argument_count=4)


### PR DESCRIPTION
## Summary

This codemod adds trailing commas to parameter and arguments
lists when there are sufficient arguments or parameters.

The idea is this:
- both black and yapf will generally split lines when there
  are trailing commas at the end of a parameter / arguments list
- It's easier on my eye to have names and types in more predictable
  locations within a function header, i.e. left-aligned. And in
  function calls, I also find it easier to compare arguments to
  function parameters whenever the arguments are one-per line, at
  least when there are more than two arguments.

By default, we ensure trailing commas for functions with one or more
parameters (but do not include `self` or `cls` method arguments) which
is suitable for `black`, and calls with 3 or more arguments.

Both the parameter count and the argument count can be overridden.
Moreover, by passing `--formatter yapf` someone can use the
yapf-suitable default of 2 parameters which is handy since then the
user doesn't have to memorize black vs yapf settings; this is necesary
because yapf does not split lines after a trailing comma in one-argument
defines.


## Test Plan

```
> python -m unittest libcst.codemod.commands.tests.test_add_trailing_commas
......
----------------------------------------------------------------------
Ran 6 tests in 0.134s

OK
```

For a real-world test (and an example of the affect of applying this change) see #642 where I
apply this codemod to _apply_type_annotations.py

