### PR TITLE
Clean up ApplyTypeAnnotationsVisitor

### DIFF
--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -43,9 +43,17 @@ def _get_import_alias_names(
     return import_names
 
 
-def _get_import_names(
+def _get_imported_names(
     imports: Sequence[Union[cst.Import, cst.ImportFrom]],
 ) -> Set[str]:
+    """
+    Given a series of import statements (both Import and ImportFrom),
+    determine all of the names that have been imported into the current
+    scope. For example:
+    - ``import foo.bar as bar, foo.baz`` produces ``{'bar', 'foo.baz'}``
+    - ``from foo import (Bar, Baz as B)`` produces ``{'Bar', 'B'}``
+    - ``from foo import *`` produces ``set()` because we cannot resolve names
+    """
     import_names = set()
     for _import in imports:
         if isinstance(_import, cst.Import):
@@ -568,7 +576,7 @@ class ApplyTypeAnnotationsVisitor(ContextAwareTransformer):
         """
         import_gatherer = GatherImportsVisitor(CodemodContext())
         tree.visit(import_gatherer)
-        existing_import_names = _get_import_names(import_gatherer.all_imports)
+        existing_import_names = _get_imported_names(import_gatherer.all_imports)
 
         context_contents = self.context.scratch.get(
             ApplyTypeAnnotationsVisitor.CONTEXT_KEY

--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -89,6 +89,12 @@ def _find_generic_base(
 
 @dataclass(frozen=True)
 class FunctionKey:
+    """
+    Class representing a funciton name and signature.
+
+    This exists to ensure we do not attempt to apply stubs to functions whose
+    definition is incompatible.
+    """
     name: str
     pos: int
     kwonly: str

--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -307,9 +307,7 @@ class TypeCollector(m.MatcherDecoratableVisitor):
         if module in ("", "builtins"):
             return False
         elif qualified_name not in self.existing_imports:
-            if module == "builtins":
-                return False
-            elif module in self.existing_imports:
+            if module in self.existing_imports:
                 return True
             else:
                 AddImportsVisitor.add_needed_import(

--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -65,7 +65,7 @@ def _get_imported_names(
     return import_names
 
 
-def _is_set(
+def _is_non_sentinel(
     x: Union[None, cst.CSTNode, cst.MaybeSentinel],
 ) -> bool:
     return x is not None and x != cst.MaybeSentinel.DEFAULT
@@ -105,8 +105,8 @@ class FunctionKey:
         pos = len(params.params)
         kwonly = ",".join(sorted(x.name.value for x in params.kwonly_params))
         posonly = len(params.posonly_params)
-        star_arg = _is_set(params.star_arg)
-        star_kwarg = _is_set(params.star_kwarg)
+        star_arg = _is_non_sentinel(params.star_arg)
+        star_kwarg = _is_non_sentinel(params.star_kwarg)
         return cls(
             name,
             pos,
@@ -829,7 +829,11 @@ class ApplyTypeAnnotationsVisitor(ContextAwareTransformer):
             p: Optional[cst.Annotation],
             q: Optional[cst.Annotation],
         ) -> bool:
-            if self.overwrite_existing_annotations or not _is_set(p) or not _is_set(q):
+            if (
+                self.overwrite_existing_annotations
+                or not _is_non_sentinel(p)
+                or not _is_non_sentinel(q)
+            ):
                 return True
             if not self.strict_annotation_matching:
                 # We will not overwrite clashing annotations, but the signature as a
@@ -867,7 +871,7 @@ class ApplyTypeAnnotationsVisitor(ContextAwareTransformer):
             p: StarParamType,
             q: StarParamType,
         ) -> bool:
-            return _is_set(p) == _is_set(q)
+            return _is_non_sentinel(p) == _is_non_sentinel(q)
 
         def match_params(
             f: cst.FunctionDef,

--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree
 #
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import libcst as cst
@@ -130,7 +130,7 @@ class FunctionAnnotation:
     returns: Optional[cst.Annotation]
 
 
-@dataclass()
+@dataclass
 class Annotations:
     """
     Represents all of the annotation information we might add to
@@ -155,16 +155,16 @@ class Annotations:
       all of the names used in annotations; together these fields
       tell us which typevars should be included in the codemod
       (all typevars that appear in annotations.)
-
-    TODO: consider simplifying this in a few ways:
-    - We could probably just inject all typevars, used or not.
-      It doesn't seem to me that our codemod needs to act like
-      a linter checking for unused names.
-    - We could probably decide which classes are typing-only
-      in the visitor rather than the codemod, which would make
-      it easier to reason locally about (and document) how the
-      class_definitions field works.
     """
+
+    # TODO: consider simplifying this in a few ways:
+    # - We could probably just inject all typevars, used or not.
+    #   It doesn't seem to me that our codemod needs to act like
+    #   a linter checking for unused names.
+    # - We could probably decide which classes are typing-only
+    #   in the visitor rather than the codemod, which would make
+    #   it easier to reason locally about (and document) how the
+    #   class_definitions field works.
 
     functions: Dict[FunctionKey, FunctionAnnotation]
     attributes: Dict[str, cst.Annotation]


### PR DESCRIPTION
## Summary

- Deduplicate some code for storing type information by extracting an Annotations dataclass.
- Rename several function to be more descriptive
- Add some docstrings

## Test Plan

Run unit tests. There's no logic change here.
