### PR TITLE
Add a DESCRIPTION to ApplyTypeComments

### DIFF
--- a/libcst/codemod/commands/convert_type_comments.py
+++ b/libcst/codemod/commands/convert_type_comments.py
@@ -394,9 +394,19 @@ class FunctionTypeInfo:
 
 
 class ConvertTypeComments(VisitorBasedCodemodCommand):
-    """
+    DESCRIPTION = """
     Codemod that converts type comments into Python 3.6+ style
     annotations.
+
+    Notes:
+    - This transform requires using the `ast` module, which is not compatible
+      with multiprocessing. So you should run using a recent version of python,
+      and set `--jobs=1` if using `python -m libcst.tool codemod ...` from the
+      commandline.
+    - This transform requires capabilities from `ast` that are not available
+      prior to Python 3.9, so libcst must run on Python 3.9+. The code you are
+      transforming can by Python 3.6+, this limitation applies only to libcst
+      itself.
 
     We can handle type comments in the following statement types:
     - Assign


### PR DESCRIPTION
## Summary

It's nice to have a doc in general, and it's particularly nice to document in the cli help
that we have to use `--job=1` to avoid `ast` crashing.

Unfortunately our docs printer deletes formatting but it's still better than nothing.

## Test Plan

```
> python -m libcst.tool codemod --no-format --jobs=1 convert_type_comments.ConvertTypeComments --help
usage: libcst.tool codemod [-h] [-j JOBS] [-p VERSION] [-u [CONTEXT]] [--include-generated] [--include-stubs] [--no-format] [--show-successes] [--hide-generated-warnings] [--hide-blacklisted-warnings] [--hide-progress] [--no-quote-annotations] COMMAND PATH [PATH ...]

Codemod that converts type comments into Python 3.6+ style annotations. Notes: - This transform requires using the `ast` module, which is not compatible with multiprocessing. So you should run using a recent version of python, and set `--jobs=1` if using `python -m libcst.tool codemod ...` from the commandline. - This transform requires capabilities from
`ast` that are not available prior to Python 3.9, so libcst must run on Python 3.9+. The code you are transforming can by Python 3.6+, this limitation applies only to libcst itself. We can handle type comments in the following statement types: - Assign - This is converted into a single AnnAssign when possible - In more complicated cases it will produce
multiple AnnAssign nodes with no value (i.e. "type declaration" statements) followed by an Assign - For and With - We prepend both of these with type declaration statements. - FunctionDef - We apply all the types we can find. If we find several: - We prefer any existing annotations to type comments - For parameters, we prefer inline type comments to
function-level type comments if we find both. We always apply the type comments as quote_annotations annotations, unless we know that it refers to a builtin. We do not guarantee that the resulting string annotations would parse, but they should never cause failures at module import time. We attempt to: - Always strip type comments for statements where we
successfully applied types. - Never strip type comments for statements where we failed to apply types. There are many edge case possible where the arity of a type hint (which is either a tuple or a func_type) might not match the code. In these cases we generally give up: - For Assign, For, and With, we require that every target of bindings (e.g. a tuple of
names being bound) must have exactly the same arity as the comment. - So, for example, we would skip an assignment statement such as ``x = y, z = 1, 2 # type: int, int`` because the arity of ``x`` does not match the arity of the hint. - For FunctionDef, we do *not* check arity of inline parameter type comments but we do skip the transform if the arity of the
function does not match the function-level comment.

positional arguments:
  COMMAND               The name of the file (minus the path and extension) and class joined with a '.' that defines your command (e.g. strip_strings_from_types.StripStringsCommand)
  PATH                  Path to codemod. Can be a directory, file, or multiple of either. To instead read from stdin and write to stdout, use "-"

optional arguments:
  -h, --help            show this help message and exit
  -j JOBS, --jobs JOBS  Number of jobs to use when processing files. Defaults to number of cores
  -p VERSION, --python-version VERSION
                        Override the version string used for parsing Python source files. Defaults to the version of python used to run this tool.
  -u [CONTEXT], --unified-diff [CONTEXT]
                        Output unified diff instead of contents. Implies outputting to stdout
  --include-generated   Codemod generated files.
  --include-stubs       Codemod typing stub files.
  --no-format           Don't format resulting codemod with configured formatter.
  --show-successes      Print files successfully codemodded with no warnings.
  --hide-generated-warnings
                        Do not print files that are skipped for being autogenerated.
  --hide-blacklisted-warnings
                        Do not print files that are skipped for being blacklisted.
  --hide-progress       Do not print progress indicator. Useful if calling from a script.
  --no-quote-annotations
                        Add unquoted annotations. This leads to prettier code but possibly more errors if type comments are invalid.
```
