### PR TITLE
Add a check for copyright headers to lint stage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,7 @@ jobs:
     - run: ufmt check .
     - run: python3 -m fixit.cli.run_rules
     - run: python -m slotscheck libcst
+    - run: ./check_copyright.sh
 
 # Run pyre typechecker
   typecheck:


### PR DESCRIPTION
## Summary

I had a copy-paste error in add_trailing_commas.py.

I'll fix it in a follow-up PR, but first I want to make sure we can make CI fail so that this doesn't go unnoticed again.

## Test Plan

Wait for github actions - if lint fails, this change is good.
