### PR TITLE
Fix the copyright heading on add_trailing_commas.py

### DIFF
--- a/libcst/codemod/commands/add_trailing_commas.py
+++ b/libcst/codemod/commands/add_trailing_commas.py
@@ -1,3 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 


### PR DESCRIPTION
## Summary

I had a copy-paste error.

## Test Plan

We now check headers in the lint stage, so as soon as that comes back clean we are good (I also did run the check locally, but I want to see CI working end-to-end before merging).


