### PR TITLE
Port pyre fixes

### DIFF
--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -662,20 +662,12 @@ class ApplyTypeAnnotationsVisitor(ContextAwareTransformer):
             cst.MetadataWrapper(stub).visit(visitor)
             self.annotations.update(visitor.annotations)
 
-            tree_with_imports = AddImportsVisitor(
-                context=self.context,
-                imports=(
-                    [
-                        ImportItem(
-                            "__future__",
-                            "annotations",
-                            None,
-                        )
-                    ]
-                    if self.use_future_annotations
-                    else ()
-                ),
-            ).transform_module(tree)
+            if self.use_future_annotations:
+                AddImportsVisitor.add_needed_import(
+                    self.context, "__future__", "annotations"
+                )
+            tree_with_imports = AddImportsVisitor(self.context).transform_module(tree)
+
         tree_with_changes = tree_with_imports.visit(self)
 
         # don't modify the imports if we didn't actually add any type information

--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -530,10 +530,12 @@ class ApplyTypeAnnotationsVisitor(ContextAwareTransformer):
 
     This is one of the transforms that is available automatically to you when
     running a codemod. To use it in this manner, import
-    :class:`~libcst.codemod.visitors.ApplyTypeAnnotationsVisitor` and then call the static
-    :meth:`~libcst.codemod.visitors.ApplyTypeAnnotationsVisitor.store_stub_in_context` method,
-    giving it the current context (found as ``self.context`` for all subclasses of
-    :class:`~libcst.codemod.Codemod`), the stub module from which you wish to add annotations.
+    :class:`~libcst.codemod.visitors.ApplyTypeAnnotationsVisitor` and then call
+    the static
+    :meth:`~libcst.codemod.visitors.ApplyTypeAnnotationsVisitor.store_stub_in_context`
+    method, giving it the current context (found as ``self.context`` for all
+    subclasses of :class:`~libcst.codemod.Codemod`), the stub module from which
+    you wish to add annotations.
 
     For example, you can store the type annotation ``int`` for ``x`` using::
 
@@ -550,7 +552,8 @@ class ApplyTypeAnnotationsVisitor(ContextAwareTransformer):
 
         x: int = 1
 
-    If the function or attribute already has a type annotation, it will not be overwritten.
+    If the function or attribute already has a type annotation, it will not be
+    overwritten.
 
     To overwrite existing annotations when applying annotations from a stub,
     use the keyword argument ``overwrite_existing_annotations=True`` when

--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -14,7 +14,6 @@ from libcst.codemod._context import CodemodContext
 from libcst.codemod._visitor import ContextAwareTransformer
 from libcst.codemod.visitors._add_imports import AddImportsVisitor
 from libcst.codemod.visitors._gather_imports import GatherImportsVisitor
-from libcst.codemod.visitors._imports import ImportItem
 from libcst.helpers import get_full_name_for_node
 from libcst.metadata import PositionProvider, QualifiedNameProvider
 

--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -823,7 +823,7 @@ class ApplyTypeAnnotationsVisitor(ContextAwareTransformer):
                 annotated_parameters.append(parameter)
             return annotated_parameters
 
-        return annotations.parameters.with_changes(
+        return updated_node.params.with_changes(
             params=update_annotation(
                 updated_node.params.params,
                 annotations.parameters.params,

--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -312,7 +312,7 @@ class TypeCollector(m.MatcherDecoratableVisitor):
     ) -> None:
         # pyre-ignore current_assign is never None here
         name = get_full_name_for_node(self.current_assign.targets[0].target)
-        if name:
+        if name is not None:
             # pyre-ignore current_assign is never None here
             self.annotations.typevars[name] = self.current_assign
             self._handle_qualification_and_should_qualify("typing.TypeVar")
@@ -730,7 +730,7 @@ class ApplyTypeAnnotationsVisitor(ContextAwareTransformer):
             for element in only_target.elements:
                 value = element.value
                 name = get_full_name_for_node(value)
-                if name:
+                if name is not None and name != "_":
                     self._add_to_toplevel_annotations(name)
         elif isinstance(only_target, (cst.Subscript)):
             pass
@@ -1019,7 +1019,7 @@ class ApplyTypeAnnotationsVisitor(ContextAwareTransformer):
     ) -> None:
         # pyre-ignore current_assign is never None here
         name = get_full_name_for_node(self.current_assign.targets[0].target)
-        if name:
+        if name is not None:
             # Preserve the whole node, even though we currently just use the
             # name, so that we can match bounds and variance at some point and
             # determine if two typevars with the same name are indeed the same.
@@ -1041,7 +1041,7 @@ class ApplyTypeAnnotationsVisitor(ContextAwareTransformer):
                 target = assign.target
                 if isinstance(target, (cst.Name, cst.Attribute)):
                     name = get_full_name_for_node(target)
-                    if name is not None:
+                    if name is not None and name != "_":
                         # Add separate top-level annotations for `a = b = 1`
                         # as `a: int` and `b: int`.
                         self._add_to_toplevel_annotations(name)

--- a/libcst/codemod/visitors/tests/test_apply_type_annotations.py
+++ b/libcst/codemod/visitors/tests/test_apply_type_annotations.py
@@ -491,6 +491,31 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                     return respond(r, b)
                 """,
             ),
+            "with_variadic_arguments": (
+                """
+                def incomplete_stubs_with_stars(
+                    x: int,
+                    *args,
+                    **kwargs,
+                ) -> None: ...
+                """,
+                """
+                def incomplete_stubs_with_stars(
+                    x,
+                    *args: P.args,
+                    **kwargs: P.kwargs,
+                ):
+                    pass
+                """,
+                """
+                def incomplete_stubs_with_stars(
+                    x: int,
+                    *args,
+                    **kwargs,
+                ) -> None:
+                    pass
+                """,
+            ),
             # test cases named with the REQUIRES_PREEXISTING prefix are verifying
             # that certain special cases work if the stub and the existing code
             # happen to align well, but none of these cases are guaranteed to work

--- a/libcst/codemod/visitors/tests/test_apply_type_annotations.py
+++ b/libcst/codemod/visitors/tests/test_apply_type_annotations.py
@@ -510,8 +510,8 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                 """
                 def incomplete_stubs_with_stars(
                     x: int,
-                    *args,
-                    **kwargs,
+                    *args: P.args,
+                    **kwargs: P.kwargs,
                 ) -> None:
                     pass
                 """,

--- a/libcst/codemod/visitors/tests/test_apply_type_annotations.py
+++ b/libcst/codemod/visitors/tests/test_apply_type_annotations.py
@@ -154,6 +154,30 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                 x2: Optional[T2] = None
                 """,
             ),
+            "splitting_multi_assigns": (
+                """
+                a: str = ...
+                x: int = ...
+                y: int = ...
+                _: str = ...
+                z: str = ...
+                """,
+                """
+                a = 'a'
+                x, y = 1, 2
+                _, z = 'hello world'.split()
+                """,
+                """
+                x: int
+                y: int
+                _: str
+                z: str
+
+                a: str = 'a'
+                x, y = 1, 2
+                _, z = 'hello world'.split()
+                """,
+            ),
         }
     )
     def test_annotate_globals(self, stub: str, before: str, after: str) -> None:

--- a/libcst/codemod/visitors/tests/test_apply_type_annotations.py
+++ b/libcst/codemod/visitors/tests/test_apply_type_annotations.py
@@ -170,7 +170,6 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                 """
                 x: int
                 y: int
-                _: str
                 z: str
 
                 a: str = 'a'


### PR DESCRIPTION
## Summary

Because it isn't feasible to continuously push new releases of LibCST, we vendored a copy of
_apply_type_annotations.py into the pyre codebase so that we could rapidly improve `pyre infer`.

But as a result several bugfixes have wound up in pyre that belong here. This commit closes the
gap.

Each commit is either:
- a test harness commit, setting up (undesirable) test results that we'll fix in the next, or
- a port from a change made to pyre, whose commit message points to the original commit

## Test Plan

```
> python -m unittest libcst.codemod.visitors.tests.test_apply_type_annotations
.....................................................................
----------------------------------------------------------------------
Ran 69 tests in 7.039s

OK
```