### PR TITLE
Remove trailing comment line from LICENSE header

### DIFF
--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -2,7 +2,6 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree
-#
 
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Sequence, Set, Tuple, Union


### PR DESCRIPTION
This is pretty trivial - the goal is to prevent lint errors when we vendor this into pyre.

