### PR TITLE
Tweak the license format again.

### DIFF
--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -1,7 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree
+# LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Sequence, Set, Tuple, Union


### PR DESCRIPTION
I'm still trying to get the code to pass all lints when we vendor it into pyre; the checks are slightly less picky about formatting in LibCST.

```
 ./check_copyright.sh
 ```
 passes

