### PR TITLE
Update relative import logic to match cpython

### DIFF
--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -241,11 +241,6 @@ def _execute_transform(  # noqa: C901
                 ),
             )
 
-        # determine the module and package name for this file
-        module_name_and_package = calculate_module_and_package(
-            config.repo_root or Path.cwd(), filename
-        )
-
         # Somewhat gross hack to provide the filename in the transform's context.
         # We do this after the fork so that a context that was initialized with
         # some defaults before calling parallel_exec_transform_with_prettyprint
@@ -253,10 +248,21 @@ def _execute_transform(  # noqa: C901
         transformer.context = replace(
             transformer.context,
             filename=filename,
-            full_module_name=module_name_and_package.name,
-            full_package_name=module_name_and_package.package,
             scratch={},
         )
+
+        # determine the module and package name for this file
+        try:
+            module_name_and_package = calculate_module_and_package(
+                config.repo_root or ".", filename
+            )
+            transformer.context = replace(
+                transformer.context,
+                full_module_name=module_name_and_package.name,
+                full_package_name=module_name_and_package.package,
+            )
+        except ValueError:
+            pass
 
         # Run the transform, bail if we failed or if we aren't formatting code
         try:

--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -241,6 +241,11 @@ def _execute_transform(  # noqa: C901
                 ),
             )
 
+        # determine the module and package name for this file
+        module_name_and_package = calculate_module_and_package(
+            config.repo_root or Path.cwd(), filename
+        )
+
         # Somewhat gross hack to provide the filename in the transform's context.
         # We do this after the fork so that a context that was initialized with
         # some defaults before calling parallel_exec_transform_with_prettyprint
@@ -248,19 +253,10 @@ def _execute_transform(  # noqa: C901
         transformer.context = replace(
             transformer.context,
             filename=filename,
+            full_module_name=module_name_and_package.name,
+            full_package_name=module_name_and_package.package,
             scratch={},
         )
-
-        # attempt to work out the module and package name for this file
-        module_name_and_package = calculate_module_and_package(
-            config.repo_root, filename
-        )
-        if module_name_and_package is not None:
-            transformer.context = replace(
-                transformer.context,
-                full_module_name=module_name_and_package.name,
-                full_package_name=module_name_and_package.package,
-            )
 
         # Run the transform, bail if we failed or if we aren't formatting code
         try:

--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -261,8 +261,10 @@ def _execute_transform(  # noqa: C901
                 full_module_name=module_name_and_package.name,
                 full_package_name=module_name_and_package.package,
             )
-        except ValueError:
-            pass
+        except ValueError as ex:
+            print(
+                f"Failed to determine module name for {filename}: {ex}", file=sys.stderr
+            )
 
         # Run the transform, bail if we failed or if we aren't formatting code
         try:

--- a/libcst/codemod/visitors/_add_imports.py
+++ b/libcst/codemod/visitors/_add_imports.py
@@ -122,7 +122,7 @@ class AddImportsVisitor(ContextAwareTransformer):
                 raise Exception("Cannot import __future__ objects with aliases!")
 
         # Resolve relative imports if we have a module name
-        imps = [imp.resolve_relative(self.context.full_module_name) for imp in imps]
+        imps = [imp.resolve_relative(self.context.full_package_name) for imp in imps]
 
         # List of modules we need to ensure are imported
         self.module_imports: Set[str] = {
@@ -215,7 +215,7 @@ class AddImportsVisitor(ContextAwareTransformer):
 
         # Get the module we're importing as a string, see if we have work to do.
         module = get_absolute_module_for_import(
-            self.context.full_module_name, updated_node
+            self.context.full_package_name, updated_node
         )
         if (
             module is None

--- a/libcst/codemod/visitors/_gather_imports.py
+++ b/libcst/codemod/visitors/_gather_imports.py
@@ -79,7 +79,7 @@ class GatherImportsVisitor(ContextAwareVisitor):
         self.all_imports.append(node)
 
         # Get the module we're importing as a string.
-        module = get_absolute_module_for_import(self.context.full_module_name, node)
+        module = get_absolute_module_for_import(self.context.full_package_name, node)
         if module is None:
             # Can't get the absolute import from relative, so we can't
             # support this.

--- a/libcst/codemod/visitors/_imports.py
+++ b/libcst/codemod/visitors/_imports.py
@@ -31,13 +31,13 @@ class ImportItem:
     def module(self) -> str:
         return "." * self.relative + self.module_name
 
-    def resolve_relative(self, base_module: Optional[str]) -> "ImportItem":
+    def resolve_relative(self, package_name: Optional[str]) -> "ImportItem":
         """Return an ImportItem with an absolute module name if possible."""
         mod = self
         # `import ..a` -> `from .. import a`
         if mod.relative and mod.obj_name is None:
             mod = replace(mod, module_name="", obj_name=mod.module_name)
-        if base_module is None:
+        if package_name is None:
             return mod
-        m = get_absolute_module(base_module, mod.module_name or None, self.relative)
+        m = get_absolute_module(package_name, mod.module_name or None, self.relative)
         return mod if m is None else replace(mod, module_name=m, relative=0)

--- a/libcst/codemod/visitors/_remove_imports.py
+++ b/libcst/codemod/visitors/_remove_imports.py
@@ -39,7 +39,7 @@ class RemovedNodeVisitor(ContextAwareVisitor):
             return
 
         module_name = get_absolute_module_for_import(
-            self.context.full_module_name, import_node
+            self.context.full_package_name, import_node
         )
         if module_name is None:
             raise Exception("Cannot look up absolute module from relative import!")
@@ -248,7 +248,9 @@ class RemoveImportsVisitor(ContextAwareTransformer):
             if isinstance(names, cst.ImportStar):
                 # We don't handle removing this, so ignore it.
                 return
-            module_name = get_absolute_module_for_import(context.full_module_name, node)
+            module_name = get_absolute_module_for_import(
+                context.full_package_name, node
+            )
             if module_name is None:
                 raise Exception("Cannot look up absolute module from relative import!")
             for import_alias in names:
@@ -414,7 +416,7 @@ class RemoveImportsVisitor(ContextAwareTransformer):
 
         # Make sure we actually know the absolute module.
         module_name = get_absolute_module_for_import(
-            self.context.full_module_name, updated_node
+            self.context.full_package_name, updated_node
         )
         if module_name is None or module_name not in self.unused_obj_imports:
             # This node isn't on our list of todos, so let's bail.

--- a/libcst/codemod/visitors/tests/test_add_imports.py
+++ b/libcst/codemod/visitors/tests/test_add_imports.py
@@ -590,7 +590,9 @@ class TestAddImportsCodemod(CodemodTest):
             before,
             after,
             [ImportItem("a.b.c", "D", None)],
-            context_override=CodemodContext(full_module_name="a.b.foobar"),
+            context_override=CodemodContext(
+                full_module_name="a.b.foobar", full_package_name="a.b"
+            ),
         )
 
     def test_add_object_relative_modify_simple(self) -> None:
@@ -621,7 +623,9 @@ class TestAddImportsCodemod(CodemodTest):
             before,
             after,
             [ImportItem("a.b.c", "D", None)],
-            context_override=CodemodContext(full_module_name="a.b.foobar"),
+            context_override=CodemodContext(
+                full_module_name="a.b.foobar", full_package_name="a.b"
+            ),
         )
 
     def test_import_order(self) -> None:
@@ -644,7 +648,9 @@ class TestAddImportsCodemod(CodemodTest):
                 ImportItem("a", "c", None),
                 ImportItem("a", "d", "x"),
             ],
-            context_override=CodemodContext(full_module_name="a.b.foobar"),
+            context_override=CodemodContext(
+                full_module_name="a.b.foobar", full_package_name="a.b"
+            ),
         )
 
     def test_add_explicit_relative(self) -> None:
@@ -759,7 +765,9 @@ class TestAddImportsCodemod(CodemodTest):
             before,
             after,
             [ImportItem("c", "D", None, 2)],
-            context_override=CodemodContext(full_module_name="a.b.foobar"),
+            context_override=CodemodContext(
+                full_module_name="a.b.foobar", full_package_name="a.b"
+            ),
         )
 
     def test_add_object_explicit_relative_modify_simple(self) -> None:
@@ -790,7 +798,9 @@ class TestAddImportsCodemod(CodemodTest):
             before,
             after,
             [ImportItem("c", "D", None, 2)],
-            context_override=CodemodContext(full_module_name="a.b.foobar"),
+            context_override=CodemodContext(
+                full_module_name="a.b.foobar", full_package_name="a.b"
+            ),
         )
 
     def test_add_object_resolve_explicit_relative_modify_simple(self) -> None:
@@ -821,7 +831,9 @@ class TestAddImportsCodemod(CodemodTest):
             before,
             after,
             [ImportItem("c", "D", None, 2)],
-            context_override=CodemodContext(full_module_name="a.b.foobar"),
+            context_override=CodemodContext(
+                full_module_name="a.b.foobar", full_package_name="a.b"
+            ),
         )
 
     def test_add_object_resolve_dotted_relative_modify_simple(self) -> None:
@@ -852,7 +864,9 @@ class TestAddImportsCodemod(CodemodTest):
             before,
             after,
             [ImportItem("..c", "D", None)],
-            context_override=CodemodContext(full_module_name="a.b.foobar"),
+            context_override=CodemodContext(
+                full_module_name="a.b.foobar", full_package_name="a.b"
+            ),
         )
 
     def test_import_in_docstring_module(self) -> None:
@@ -873,5 +887,7 @@ class TestAddImportsCodemod(CodemodTest):
             before,
             after,
             [ImportItem("__future__", "annotations", None)],
-            context_override=CodemodContext(full_module_name="a.b.foobar"),
+            context_override=CodemodContext(
+                full_module_name="a.b.foobar", full_package_name="a.b"
+            ),
         )

--- a/libcst/codemod/visitors/tests/test_gather_imports.py
+++ b/libcst/codemod/visitors/tests/test_gather_imports.py
@@ -12,7 +12,7 @@ from libcst.testing.utils import UnitTest
 class TestGatherImportsVisitor(UnitTest):
     def gather_imports(self, code: str) -> GatherImportsVisitor:
         transform_instance = GatherImportsVisitor(
-            CodemodContext(full_module_name="a.b.foobar")
+            CodemodContext(full_module_name="a.b.foobar", full_package_name="a.b")
         )
         input_tree = parse_module(CodemodTest.make_fixture_data(code))
         input_tree.visit(transform_instance)

--- a/libcst/codemod/visitors/tests/test_remove_imports.py
+++ b/libcst/codemod/visitors/tests/test_remove_imports.py
@@ -419,7 +419,9 @@ class TestRemoveImportsCodemod(CodemodTest):
             before,
             after,
             [("a.b.c", "qux", None)],
-            context_override=CodemodContext(full_module_name="a.b.foobar"),
+            context_override=CodemodContext(
+                full_module_name="a.b.foobar", full_package_name="a.b"
+            ),
         )
 
     def test_dont_remove_inuse_importfrom_relative(self) -> None:
@@ -446,7 +448,9 @@ class TestRemoveImportsCodemod(CodemodTest):
             before,
             after,
             [("a.b.c", "qux", None)],
-            context_override=CodemodContext(full_module_name="a.b.foobar"),
+            context_override=CodemodContext(
+                full_module_name="a.b.foobar", full_package_name="a.b"
+            ),
         )
 
     def test_dont_remove_wrong_importfrom_relative(self) -> None:
@@ -473,7 +477,9 @@ class TestRemoveImportsCodemod(CodemodTest):
             before,
             after,
             [("a.b.d", "qux", None)],
-            context_override=CodemodContext(full_module_name="a.b.foobar"),
+            context_override=CodemodContext(
+                full_module_name="a.b.foobar", full_package_name="a.b"
+            ),
         )
 
     def test_remove_import_complex(self) -> None:

--- a/libcst/helpers/module.py
+++ b/libcst/helpers/module.py
@@ -89,22 +89,10 @@ class ModuleNameAndPackage:
     package: str
 
 
-def calculate_module_and_package(
-    repo_root: Optional[str], filename: str
-) -> Optional[ModuleNameAndPackage]:
+def calculate_module_and_package(repo_root: str, filename: str) -> ModuleNameAndPackage:
     # Given an absolute repo_root and an absolute filename, calculate the
     # python module name for the file.
-    if repo_root is None:
-        # We don't have a repo root, so this is impossible to calculate.
-        return None
-
-    try:
-        relative_filename = PurePath(filename).relative_to(repo_root)
-    except ValueError:
-        # This file seems to be out of the repo root.
-        return None
-
-    # get rid of extension
+    relative_filename = PurePath(filename).relative_to(repo_root)
     relative_filename = relative_filename.with_suffix("")
 
     # handle special cases

--- a/libcst/helpers/module.py
+++ b/libcst/helpers/module.py
@@ -35,19 +35,19 @@ def insert_header_comments(node: Module, comments: List[str]) -> Module:
 
 
 def get_absolute_module(
-    currnet_package: Optional[str], module_name: Optional[str], num_dots: int
+    current_package: Optional[str], module_name: Optional[str], num_dots: int
 ) -> Optional[str]:
     if num_dots == 0:
         # This is an absolute import, so the module is correct.
         return module_name
-    if currnet_package is None:
+    if current_package is None:
         # We don't actually have the current module available, so we can't compute
         # the absolute module from relative.
         return None
 
     # see importlib._bootstrap._resolve_name
-    # https://github.com/python/cpython/blob/8146e6b636905d9872140c990d93308ac20d13f0/Lib/importlib/_bootstrap.py#L902
-    bits = currnet_package.rsplit(".", num_dots - 1)
+    # https://github.com/python/cpython/blob/3.10/Lib/importlib/_bootstrap.py#L902
+    bits = current_package.rsplit(".", num_dots - 1)
     if len(bits) < num_dots:
         return None
 
@@ -56,20 +56,20 @@ def get_absolute_module(
 
 
 def get_absolute_module_for_import(
-    currnet_package: Optional[str], import_node: ImportFrom
+    current_package: Optional[str], import_node: ImportFrom
 ) -> Optional[str]:
     # First, let's try to grab the module name, regardless of relative status.
     module = import_node.module
     module_name = get_full_name_for_node(module) if module is not None else None
     # Now, get the relative import location if it exists.
     num_dots = len(import_node.relative)
-    return get_absolute_module(currnet_package, module_name, num_dots)
+    return get_absolute_module(current_package, module_name, num_dots)
 
 
 def get_absolute_module_for_import_or_raise(
-    currnet_package: Optional[str], import_node: ImportFrom
+    current_package: Optional[str], import_node: ImportFrom
 ) -> str:
-    module = get_absolute_module_for_import(currnet_package, import_node)
+    module = get_absolute_module_for_import(current_package, import_node)
     if module is None:
         raise Exception(f"Unable to compute absolute module for {import_node}")
     return module

--- a/libcst/helpers/tests/test_module.py
+++ b/libcst/helpers/tests/test_module.py
@@ -140,12 +140,6 @@ class ModuleTest(UnitTest):
 
     @data_provider(
         (
-            # Providing no root should give back no module.
-            (None, "/some/dummy/file.py", None),
-            # Providing a file outside the root should give back no module.
-            ("/home/username/root", "/some/dummy/file.py", None),
-            ("/home/username/root/", "/some/dummy/file.py", None),
-            ("/home/username/root", "/home/username/file.py", None),
             # Various files inside the root should give back valid modules.
             (
                 "/home/username/root",
@@ -173,17 +167,6 @@ class ModuleTest(UnitTest):
                 "/home/username/root/some/dir/__main__.py",
                 ModuleNameAndPackage("some.dir", "some.dir"),
             ),
-            # some windows tests
-            (
-                "c:/Program Files/",
-                "d:/Program Files/some/dir/file.py",
-                None,
-            ),
-            (
-                "c:/Program Files/other/",
-                "c:/Program Files/some/dir/file.py",
-                None,
-            ),
             (
                 "c:/Program Files/",
                 "c:/Program Files/some/dir/file.py",
@@ -198,10 +181,35 @@ class ModuleTest(UnitTest):
     )
     def test_calculate_module_and_package(
         self,
-        repo_root: Optional[str],
+        repo_root: str,
         filename: str,
         module_and_package: Optional[ModuleNameAndPackage],
     ) -> None:
         self.assertEqual(
             calculate_module_and_package(repo_root, filename), module_and_package
         )
+
+    @data_provider(
+        (
+            # Providing a file outside the root should raise an exception
+            ("/home/username/root", "/some/dummy/file.py"),
+            ("/home/username/root/", "/some/dummy/file.py"),
+            ("/home/username/root", "/home/username/file.py"),
+            # some windows tests
+            (
+                "c:/Program Files/",
+                "d:/Program Files/some/dir/file.py",
+            ),
+            (
+                "c:/Program Files/other/",
+                "c:/Program Files/some/dir/file.py",
+            ),
+        )
+    )
+    def test_invalid_module_and_package(
+        self,
+        repo_root: str,
+        filename: str,
+    ) -> None:
+        with self.assertRaises(ValueError):
+            calculate_module_and_package(repo_root, filename)

--- a/libcst/metadata/name_provider.py
+++ b/libcst/metadata/name_provider.py
@@ -4,9 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import dataclasses
-import re
 from pathlib import Path
-from typing import Collection, List, Mapping, Optional, Pattern, Union
+from typing import Collection, List, Mapping, Optional, Union
 
 import libcst as cst
 from libcst._metadata_dependent import MetadataDependent
@@ -139,6 +138,8 @@ class FullyQualifiedNameVisitor(cst.CSTVisitor):
         # handle relative import
         if num_dots > 0:
             name = abs_name
+            # see importlib._bootstrap._resolve_name
+            # https://github.com/python/cpython/blob/3.10/Lib/importlib/_bootstrap.py#L902
             bits = package_name.rsplit(".", num_dots - 1)
             if len(bits) < num_dots:
                 raise ImportError("attempted relative import beyond top-level package")

--- a/libcst/metadata/name_provider.py
+++ b/libcst/metadata/name_provider.py
@@ -85,7 +85,7 @@ class QualifiedNameVisitor(cst.CSTVisitor):
         return True
 
 
-DOT_PY: Pattern[str] = re.compile(r"(__init__)?\.py$")
+DOT_PY: Pattern[str] = re.compile(r"(__init__|__main__)?\.py$")
 
 
 def _module_name(path: str) -> Optional[str]:


### PR DESCRIPTION
## Summary

 * LibCST does not correctly handle relative imports from an __init__.py file
 * Python relative imports work based on package name, not module name.
 * `a/b.y` and `a/b/__init__.py` have the same module name, but different package names.
 * So the same relative import statement in both of those files mean different things.
 * Currently libcst only properly handles the `a/b.y` case correctly

## Test Plan
I've added a bunch of test cases to show that this was not working correctly.
