### PR TITLE
Preserve as-imports when merging type annotations.

### DIFF
--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -369,8 +369,7 @@ class TypeCollector(m.MatcherDecoratableVisitor):
         return (relative_prefix + qualifier, target)
 
     def _handle_qualification_and_should_qualify(
-        self,
-        qualified_name: str,
+        self, qualified_name: str, node: Optional[cst.CSTNode] = None
     ) -> bool:
         """
         Based on a qualified name and the existing module imports, record that
@@ -384,10 +383,15 @@ class TypeCollector(m.MatcherDecoratableVisitor):
             if module in self.existing_imports:
                 return True
             else:
+                if node and isinstance(node, cst.Name):
+                    asname = node.value
+                else:
+                    asname = None
                 AddImportsVisitor.add_needed_import(
                     self.context,
                     module,
                     target,
+                    asname=asname,
                 )
                 return False
         return False

--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -383,7 +383,7 @@ class TypeCollector(m.MatcherDecoratableVisitor):
             if module in self.existing_imports:
                 return True
             else:
-                if node and isinstance(node, cst.Name):
+                if node and isinstance(node, cst.Name) and node.value != target:
                     asname = node.value
                 else:
                     asname = None
@@ -411,7 +411,7 @@ class TypeCollector(m.MatcherDecoratableVisitor):
             qualified_name,
             dequalified_node,
         ) = self._get_qualified_name_and_dequalified_node(node)
-        should_qualify = self._handle_qualification_and_should_qualify(qualified_name)
+        should_qualify = self._handle_qualification_and_should_qualify(qualified_name, node)
         self.annotations.names.add(qualified_name)
         if should_qualify:
             return node

--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -411,7 +411,9 @@ class TypeCollector(m.MatcherDecoratableVisitor):
             qualified_name,
             dequalified_node,
         ) = self._get_qualified_name_and_dequalified_node(node)
-        should_qualify = self._handle_qualification_and_should_qualify(qualified_name, node)
+        should_qualify = self._handle_qualification_and_should_qualify(
+            qualified_name, node
+        )
         self.annotations.names.add(qualified_name)
         if should_qualify:
             return node

--- a/libcst/codemod/visitors/tests/test_apply_type_annotations.py
+++ b/libcst/codemod/visitors/tests/test_apply_type_annotations.py
@@ -292,6 +292,23 @@ class TestApplyAnnotationsVisitor(CodemodTest):
                     return returns_baz()
                 """,
             ),
+            "with_as_import": (
+                """
+                def foo(x): ...
+                """,
+                """
+                from bar import A as B
+
+                def foo(x: B):
+                    pass
+                """,
+                """
+                from bar import A as B
+
+                def foo(x: B):
+                    pass
+                """,
+            ),
             "with_nested_import": (
                 """
                 def foo(x: django.http.response.HttpResponse) -> str:

--- a/libcst/codemod/visitors/tests/test_apply_type_annotations.py
+++ b/libcst/codemod/visitors/tests/test_apply_type_annotations.py
@@ -294,12 +294,12 @@ class TestApplyAnnotationsVisitor(CodemodTest):
             ),
             "with_as_import": (
                 """
-                def foo(x): ...
-                """,
-                """
                 from bar import A as B
 
-                def foo(x: B):
+                def foo(x: B): ...
+                """,
+                """
+                def foo(x):
                     pass
                 """,
                 """


### PR DESCRIPTION
# Summary

Preserves the aliased import name when merging in annotations like
```
from foo import A as B

def f(x: B): ...
```

Fixes #661