### PR TITLE
Clean warnings in context when transforming multiple files

### DIFF
--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -245,10 +245,13 @@ def _execute_transform(  # noqa: C901
         # We do this after the fork so that a context that was initialized with
         # some defaults before calling parallel_exec_transform_with_prettyprint
         # will be updated per-file.
+        # We should clean the warnings array as well, otherwise warnings will be
+        # passed from previous file
         transformer.context = replace(
             transformer.context,
             filename=filename,
             scratch={},
+            warnings=[],
         )
 
         # attempt to work out the module and package name for this file

--- a/libcst/codemod/tests/test_codemod_cli.py
+++ b/libcst/codemod/tests/test_codemod_cli.py
@@ -7,11 +7,12 @@
 
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 from libcst._parser.entrypoints import is_native
 from libcst.testing.utils import UnitTest
-
+from libcst.codemod import CodemodTest
 
 class TestCodemodCLI(UnitTest):
     def test_codemod_formatter_error_input(self) -> None:
@@ -36,5 +37,36 @@ class TestCodemodCLI(UnitTest):
         else:
             self.assertIn(
                 "error: cannot format -: Cannot parse: 13:10:     async with AsyncExitStack() as stack:",
+                rlt.stderr.decode("utf-8"),
+            )
+
+    def test_warning_messages_several_files(self) -> None:
+        mod = """
+        def baz() -> str:
+            return "{}: {}".format(*baz)
+
+        def foobar() -> str:
+            return "{x}: {y}".format(**baz)
+        """
+        with tempfile.TemporaryDirectory() as root:
+            p = Path(root)
+            (p / "mod1.py").write_text(CodemodTest.make_fixture_data(mod))
+            (p / "mod2.py").write_text(CodemodTest.make_fixture_data(mod))
+            (p / "mod3.py").write_text(CodemodTest.make_fixture_data(mod))
+            rlt = subprocess.run(
+                [
+                    "python",
+                    "-m",
+                    "libcst.tool",
+                    "codemod",
+                    "convert_format_to_fstring.ConvertFormatStringCommand",
+                    p,
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            # Each module will generate 2 warnings, so we should get 6 warnings in total
+            self.assertIn(
+                "- 6 warnings were generated.",
                 rlt.stderr.decode("utf-8"),
             )


### PR DESCRIPTION
## Summary

Using libCST cli tool allows to run a codemod over files inside a folder recursively. Context warning messages were not being cleaned between files, so warnings from one files could be passed to other files in the context. Because of that warnings were being shown wrongly in the summary and the total number of warnings was wrong as well.

## Test Plan

`python3 -m unittest libcst.codemod.tests.test_codemod_cli `

