### PR TITLE
fix qualified name get bug

### DIFF
--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -304,7 +304,10 @@ class ImportAssignment(Assignment):
                         if eval_alias is not None:
                             as_name = eval_alias
                     if full_name.startswith(as_name):
-                        remaining_name = full_name.split(as_name, 1)[1].lstrip(".")
+                        remaining_name = full_name.split(as_name, 1)[1]
+                        if remaining_name and not remaining_name.startswith("."):
+                            continue
+                        remaining_name = remaining_name.lstrip(".")
                         results.add(
                             QualifiedName(
                                 f"{real_name}.{remaining_name}"

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -944,6 +944,25 @@ class ScopeProviderTest(UnitTest):
             {QualifiedName("f4.<locals>.f5.<locals>.C", QualifiedNameSource.LOCAL)},
         )
 
+    def test_get_qualified_names_for_the_same_prefix(self) -> None:
+        m, scopes = get_scope_metadata_provider(
+            """
+                from a import b, bc
+                bc()
+            """
+        )
+        call = ensure_type(
+            ensure_type(
+                ensure_type(m.body[1], cst.SimpleStatementLine).body[0], cst.Expr
+            ).value,
+            cst.Call,
+        )
+        module_scope = scopes[m]
+        self.assertEqual(
+            module_scope.get_qualified_names_for(call.func),
+            {QualifiedName("a.bc", QualifiedNameSource.IMPORT)},
+        )
+
     def test_get_qualified_names_for_dotted_imports(self) -> None:
         m, scopes = get_scope_metadata_provider(
             """


### PR DESCRIPTION
## Summary
resolves https://github.com/Instagram/LibCST/issues/656
## Test Plan
 python -m unittest libcst.metadata.tests.test_scope_provider.ScopeProviderTest.test_get_qualified_names_for_the_same_prefix