### PR TITLE
Always use ... in stubs, not pass

### DIFF
--- a/libcst/codemod/visitors/tests/test_apply_type_annotations.py
+++ b/libcst/codemod/visitors/tests/test_apply_type_annotations.py
@@ -295,7 +295,7 @@ class TestApplyAnnotationsVisitor(CodemodTest):
             "with_nested_import": (
                 """
                 def foo(x: django.http.response.HttpResponse) -> str:
-                    pass
+                    ...
                 """,
                 """
                 def foo(x) -> str:


### PR DESCRIPTION
## Summary

This diff is because I realized one of the examples used `pass` in a stub, which is a recipe for confusion about which input is the stub versus the code (the order is stub, code_before, code_after).

Always using ... makes it a little clearer.

More importantly, I want to trigger a CI run because we have mystery failures (black exiting with code 1) on another PR, and I want to see if this commit triggers the same problems.

