### PR TITLE
rename codemod: Correct last renamed import from

### DIFF
--- a/libcst/codemod/commands/rename.py
+++ b/libcst/codemod/commands/rename.py
@@ -206,11 +206,11 @@ class RenameCommand(VisitorBasedCodemodCommand):
                         ] = self.gen_name_or_attr_node(replacement_obj)
                         # Rename on the spot only if this is the only imported name under the module.
                         if len(names) == 1:
-                            self.bypass_import = True
-                            return updated_node.with_changes(
+                            updated_node = updated_node.with_changes(
                                 module=cst.parse_expression(replacement_module),
-                                names=(cst.ImportAlias(name=new_import_alias_name),),
                             )
+                            self.scheduled_removals.add(updated_node)
+                            new_names.append(import_alias)
                         # Or if the module name is to stay the same.
                         elif replacement_module == imported_module_name:
                             self.bypass_import = True

--- a/libcst/codemod/commands/tests/test_rename.py
+++ b/libcst/codemod/commands/tests/test_rename.py
@@ -660,3 +660,21 @@ class TestRenameCommand(CodemodTest):
             bar(42)
         """
         self.assertCodemod(before, before, old_name="baz.bar", new_name="qux.bar")
+
+    def test_rename_single_with_colon(self) -> None:
+        before = """
+            from a.b import qux
+
+            print(qux)
+        """
+        after = """
+            from a import b
+
+            print(b.qux)
+        """
+        self.assertCodemod(
+            before,
+            after,
+            old_name="a.b.qux",
+            new_name="a:b.qux",
+        )


### PR DESCRIPTION
## Summary
Correct the renamed import from structure when renaming last imported name from a module.

Given

    from a.b import qux

    print(qux)

And providing old_name="a.b.qux" and new_name="a:b.qux" I expect the
following output (similar to what is described in the command description):

    from a import b

    print(b.qux)

But what I get is:

    from a import b.qux

    print(b.qux)

It pulls the old name up into the new one.

The provided test is the important part but I've attempted a fix too. I suspect there is a better one and that the special casing of the "this is that last name" situation shouldn't be needed. For instance there is import removing code in leave_Module and renaming the first of many names (as opposed to the last) happily adds a correct import line. I didn't manage to grok the code and all the concepts it requires to provide a better fix though.

This leaves the alias adjustments to the existing code at the end of the function and just does the module renaming the in the special casing block.
I don't know why scheduling removal of the updated node is required, it makes the tests pass though.
I'm not sure that updating the node in place fits with the style of the rest of the file either.

## Test Plan

I added a test case for this situation. All the other tests continue to pass (and #308 noted that this codemod has good coverage).