### PR TITLE
[native] make sure ParserError's line is zero-indexed

### DIFF
--- a/libcst/_parser/tests/test_parse_errors.py
+++ b/libcst/_parser/tests/test_parse_errors.py
@@ -172,6 +172,8 @@ class ParseErrorsTest(UnitTest):
     ) -> None:
         with self.assertRaises(cst.ParserSyntaxError) as cm:
             parse_fn()
+        # make sure str() doesn't blow up
+        self.assertIn("Syntax Error", str(cm.exception))
         if not is_native():
             self.assertEqual(str(cm.exception), expected)
 

--- a/native/libcst/src/parser/errors.rs
+++ b/native/libcst/src/parser/errors.rs
@@ -49,16 +49,20 @@ mod py_error {
                     }
                     _ => vec![""],
                 };
-                let (line, col) = match &e {
+                let (mut line, mut col) = match &e {
                     ParserError::ParserError(err, ..) => {
                         (err.location.start_pos.line, err.location.start_pos.column)
                     }
                     _ => (0, 0),
                 };
+                if line + 1 > lines.len() {
+                    line = lines.len() - 1;
+                    col = 0;
+                }
                 let kwargs = [
                     ("message", e.to_string().into_py(py)),
                     ("lines", lines.into_py(py)),
-                    ("raw_line", line.into_py(py)),
+                    ("raw_line", (line + 1).into_py(py)),
                     ("raw_column", col.into_py(py)),
                 ]
                 .into_py_dict(py);


### PR DESCRIPTION
## Summary

The `ParserError` raised from the peg parser has 0-based line indices, but its `__str__` implementation expects it to be 1-based. This causes exceptions while trying to render the `ParserError` exception.

Fixes #678.

## Test Plan
Added tests to verify `str()` doesn't blow up.

