### PR TITLE
Consider access information when computing qualified names for nodes

### DIFF
--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -543,6 +543,22 @@ class Scope(abc.ABC):
         considering it could be a complex type annotation in the string which is hard to
         resolve, e.g. ``List[Union[int, str]]``.
         """
+
+        # if this node is an access we know the assignment and we can use that name
+        node_accesses = {
+            access
+            for all_accesses in self._accesses.values()
+            for access in all_accesses
+            if access.node == node
+        }
+        if node_accesses:
+            return {
+                qname
+                for access in node_accesses
+                for referent in access.referents
+                for qname in referent.get_qualified_names_for(referent.name)
+            }
+
         results = set()
         full_name = get_full_name_for_node(node)
         if full_name is None:

--- a/libcst/metadata/tests/test_name_provider.py
+++ b/libcst/metadata/tests/test_name_provider.py
@@ -101,8 +101,9 @@ class QualifiedNameProviderTest(UnitTest):
         )
         cls = ensure_type(m.body[1], cst.ClassDef)
         f = ensure_type(cls.body.body[0], cst.FunctionDef)
-        self.assertEqual(
-            names[ensure_type(f.returns, cst.Annotation).annotation], set()
+        self.assertSetEqual(
+            names[ensure_type(f.returns, cst.Annotation).annotation],
+            {QualifiedName("a.b.c", QualifiedNameSource.IMPORT)},
         )
 
         c_call = ensure_type(
@@ -432,22 +433,13 @@ class QualifiedNameProviderTest(UnitTest):
             ).value
             self.assertEqual(names[name], qnames)
 
-        test_name(
-            m.body[1],
-            {
-                QualifiedName("lib.a", QualifiedNameSource.IMPORT),
-                QualifiedName("a", QualifiedNameSource.LOCAL),
-            },
-        )
+        test_name(m.body[1], {QualifiedName("lib.a", QualifiedNameSource.IMPORT)})
 
         cls = ensure_type(m.body[2], cst.ClassDef)
-        test_name(cls.body.body[0], {QualifiedName("Test.b", QualifiedNameSource.LOCAL)})
+        test_name(cls.body.body[0], {QualifiedName("lib.b", QualifiedNameSource.IMPORT)})
 
         func = ensure_type(m.body[3], cst.FunctionDef)
-        test_name(
-            func.body.body[0],
-            {QualifiedName("func.<locals>.c", QualifiedNameSource.LOCAL)},
-        )
+        test_name(func.body.body[0], {QualifiedName("lib.c", QualifiedNameSource.IMPORT)})
 
 
 class FullyQualifiedNameProviderTest(UnitTest):


### PR DESCRIPTION
## Summary
`Scope.get_qualified_names_for` has to do a lot of work to determine the qualified name for a node. The current version does not consider the data we have for accesses. If the given node is known to be an access, we can take advantage of that to work out the proper name.

This also means we now get the qualified names for string annotations for imports.

## Test Plan
I've added a new test case in the QualifiedNameProviderTest to show the before/after effects of this change
