### PR TITLE
Add package links to PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,10 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/x-rst",
     url="https://github.com/Instagram/LibCST",
+    project_urls={
+        "Changelog": "https://github.com/Instagram/LibCST/blob/main/CHANGELOG.md",
+        "Documentation": "https://libcst.readthedocs.io/en/latest/",
+    },
     license="MIT",
     packages=setuptools.find_packages(),
     package_data={


### PR DESCRIPTION
## Summary

Add two links to the sidebar on PyPI, to make it easier for folks to jump to the relevant pages. Example: https://pypi.org/project/django-htmx/ (PyPI adds the icons based on the link names).

## Test Plan

You'll see them on next release.
