### PR TITLE
parser: use references instead of smart pointers for Tokens

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -217,6 +217,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "half"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,6 +338,7 @@ version = "0.1.0"
 dependencies = [
  "quote",
  "syn",
+ "trybuild",
 ]
 
 [[package]]
@@ -670,6 +677,9 @@ name = "serde"
 version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_cbor"
@@ -721,6 +731,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,6 +776,29 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d664de8ea7e531ad4c0f5a834f20b8cb2b8e6dfe88d05796ee7887518ed67b9"
+dependencies = [
+ "glob",
+ "lazy_static",
+ "serde",
+ "serde_json",
+ "termcolor",
+ "toml",
 ]
 
 [[package]]

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -457,8 +457,9 @@ dependencies = [
 
 [[package]]
 name = "peg"
-version = "0.7.0"
-source = "git+https://github.com/kevinmehall/rust-peg?rev=4b146b4b78a80c07e43d7ace2d97f65bfde279a8#4b146b4b78a80c07e43d7ace2d97f65bfde279a8"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af728fe826811af3b38c37e93de6d104485953ea373d656eebae53d6987fcd2c"
 dependencies = [
  "peg-macros",
  "peg-runtime",
@@ -466,8 +467,9 @@ dependencies = [
 
 [[package]]
 name = "peg-macros"
-version = "0.7.0"
-source = "git+https://github.com/kevinmehall/rust-peg?rev=4b146b4b78a80c07e43d7ace2d97f65bfde279a8#4b146b4b78a80c07e43d7ace2d97f65bfde279a8"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4536be147b770b824895cbad934fccce8e49f14b4c4946eaa46a6e4a12fcdc16"
 dependencies = [
  "peg-runtime",
  "proc-macro2",
@@ -476,8 +478,9 @@ dependencies = [
 
 [[package]]
 name = "peg-runtime"
-version = "0.7.0"
-source = "git+https://github.com/kevinmehall/rust-peg?rev=4b146b4b78a80c07e43d7ace2d97f65bfde279a8#4b146b4b78a80c07e43d7ace2d97f65bfde279a8"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9b0efd3ba03c3a409d44d60425f279ec442bcf0b9e63ff4e410da31c8b0f69f"
 
 [[package]]
 name = "plotters"

--- a/native/libcst/Cargo.toml
+++ b/native/libcst/Cargo.toml
@@ -32,7 +32,7 @@ trace = ["peg/trace"]
 paste = "1.0.4"
 pyo3 = { version = "0.14.4", optional = true }
 thiserror = "1.0.23"
-peg = { git = "https://github.com/kevinmehall/rust-peg", rev = "4b146b4b78a80c07e43d7ace2d97f65bfde279a8" }
+peg = "0.8.0"
 chic = "1.2.2"
 itertools = "0.10.0"
 once_cell = "1.5.2"

--- a/native/libcst/benches/parser_benchmark.rs
+++ b/native/libcst/benches/parser_benchmark.rs
@@ -49,12 +49,13 @@ fn load_all_fixtures() -> String {
 pub fn inflate_benchmarks<T: Measurement>(c: &mut Criterion<T>) {
     let fixture = load_all_fixtures();
     let tokens = tokenize(fixture.as_str()).expect("tokenize failed");
+    let tokvec = tokens.clone().into();
     let mut group = c.benchmark_group("inflate");
     group.bench_function("all", |b| {
         b.iter_batched(
             || {
                 let conf = Config::new(fixture.as_str(), &tokens);
-                let m = parse_tokens_without_whitespace(tokens.clone(), fixture.as_str(), None)
+                let m = parse_tokens_without_whitespace(&tokvec, fixture.as_str(), None)
                     .expect("parse failed");
                 (conf, m)
             },
@@ -71,13 +72,13 @@ pub fn parser_benchmarks<T: Measurement>(c: &mut Criterion<T>) {
     group.measurement_time(Duration::from_secs(15));
     group.bench_function("all", |b| {
         b.iter_batched(
-            || tokenize(fixture.as_str()).expect("tokenize failed"),
+            || tokenize(fixture.as_str()).expect("tokenize failed").into(),
             |tokens| {
-                black_box(parse_tokens_without_whitespace(
-                    tokens,
+                black_box(drop(parse_tokens_without_whitespace(
+                    &tokens,
                     fixture.as_str(),
                     None,
-                ))
+                )))
             },
             BatchSize::SmallInput,
         )

--- a/native/libcst/src/nodes/mod.rs
+++ b/native/libcst/src/nodes/mod.rs
@@ -3,12 +3,12 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree
 
-mod whitespace;
+pub(crate) mod whitespace;
 pub use whitespace::{
     Comment, EmptyLine, Fakeness, Newline, ParenthesizableWhitespace, ParenthesizedWhitespace,
     SimpleWhitespace, TrailingWhitespace,
 };
-mod statement;
+pub(crate) mod statement;
 pub use statement::{
     AnnAssign, Annotation, AsName, Assert, Assign, AssignTarget, AssignTargetExpression, AugAssign,
     Break, ClassDef, CompoundStatement, Continue, Decorator, Del, DelTargetExpression, Else,
@@ -21,7 +21,7 @@ pub use statement::{
     TryStar, While, With, WithItem,
 };
 
-mod expression;
+pub(crate) mod expression;
 pub use expression::{
     Arg, Asynchronous, Attribute, Await, BaseSlice, BinaryOperation, BooleanOperation, Call,
     CompFor, CompIf, Comparison, ComparisonTarget, ConcatenatedString, Dict, DictComp, DictElement,
@@ -33,13 +33,13 @@ pub use expression::{
     StarredElement, String, Subscript, SubscriptElement, Tuple, UnaryOperation, Yield, YieldValue,
 };
 
-mod op;
+pub(crate) mod op;
 pub use op::{
     AssignEqual, AugOp, BinaryOp, BitOr, BooleanOp, Colon, Comma, CompOp, Dot, ImportStar,
     Semicolon, UnaryOp,
 };
 
-mod module;
+pub(crate) mod module;
 pub use module::Module;
 
 mod codegen;
@@ -49,3 +49,76 @@ pub(crate) mod traits;
 pub use traits::{Inflate, ParenthesizedNode, WithComma, WithLeadingLines};
 
 pub(crate) mod inflate_helpers;
+
+pub(crate) mod deflated {
+    pub use super::expression::{
+        DeflatedArg as Arg, DeflatedAsynchronous as Asynchronous, DeflatedAttribute as Attribute,
+        DeflatedAwait as Await, DeflatedBaseSlice as BaseSlice,
+        DeflatedBinaryOperation as BinaryOperation, DeflatedBooleanOperation as BooleanOperation,
+        DeflatedCall as Call, DeflatedCompFor as CompFor, DeflatedCompIf as CompIf,
+        DeflatedComparison as Comparison, DeflatedComparisonTarget as ComparisonTarget,
+        DeflatedConcatenatedString as ConcatenatedString, DeflatedDict as Dict,
+        DeflatedDictComp as DictComp, DeflatedDictElement as DictElement,
+        DeflatedElement as Element, DeflatedEllipsis as Ellipsis, DeflatedExpression as Expression,
+        DeflatedFloat as Float, DeflatedFormattedString as FormattedString,
+        DeflatedFormattedStringContent as FormattedStringContent,
+        DeflatedFormattedStringExpression as FormattedStringExpression,
+        DeflatedFormattedStringText as FormattedStringText, DeflatedFrom as From,
+        DeflatedGeneratorExp as GeneratorExp, DeflatedIfExp as IfExp,
+        DeflatedImaginary as Imaginary, DeflatedIndex as Index, DeflatedInteger as Integer,
+        DeflatedLambda as Lambda, DeflatedLeftCurlyBrace as LeftCurlyBrace,
+        DeflatedLeftParen as LeftParen, DeflatedLeftSquareBracket as LeftSquareBracket,
+        DeflatedList as List, DeflatedListComp as ListComp, DeflatedName as Name,
+        DeflatedNameOrAttribute as NameOrAttribute, DeflatedNamedExpr as NamedExpr,
+        DeflatedParam as Param, DeflatedParamSlash as ParamSlash, DeflatedParamStar as ParamStar,
+        DeflatedParameters as Parameters, DeflatedRightCurlyBrace as RightCurlyBrace,
+        DeflatedRightParen as RightParen, DeflatedRightSquareBracket as RightSquareBracket,
+        DeflatedSet as Set, DeflatedSetComp as SetComp, DeflatedSimpleString as SimpleString,
+        DeflatedSlice as Slice, DeflatedStarArg as StarArg,
+        DeflatedStarredDictElement as StarredDictElement, DeflatedStarredElement as StarredElement,
+        DeflatedString as String, DeflatedSubscript as Subscript,
+        DeflatedSubscriptElement as SubscriptElement, DeflatedTuple as Tuple,
+        DeflatedUnaryOperation as UnaryOperation, DeflatedYield as Yield,
+        DeflatedYieldValue as YieldValue,
+    };
+    pub use super::module::DeflatedModule as Module;
+    pub use super::op::{
+        DeflatedAssignEqual as AssignEqual, DeflatedAugOp as AugOp, DeflatedBinaryOp as BinaryOp,
+        DeflatedBitOr as BitOr, DeflatedBooleanOp as BooleanOp, DeflatedColon as Colon,
+        DeflatedComma as Comma, DeflatedCompOp as CompOp, DeflatedDot as Dot,
+        DeflatedImportStar as ImportStar, DeflatedSemicolon as Semicolon,
+        DeflatedUnaryOp as UnaryOp,
+    };
+    pub use super::statement::{
+        DeflatedAnnAssign as AnnAssign, DeflatedAnnotation as Annotation, DeflatedAsName as AsName,
+        DeflatedAssert as Assert, DeflatedAssign as Assign, DeflatedAssignTarget as AssignTarget,
+        DeflatedAssignTargetExpression as AssignTargetExpression, DeflatedAugAssign as AugAssign,
+        DeflatedBreak as Break, DeflatedClassDef as ClassDef,
+        DeflatedCompoundStatement as CompoundStatement, DeflatedContinue as Continue,
+        DeflatedDecorator as Decorator, DeflatedDel as Del,
+        DeflatedDelTargetExpression as DelTargetExpression, DeflatedElse as Else,
+        DeflatedExceptHandler as ExceptHandler, DeflatedExceptStarHandler as ExceptStarHandler,
+        DeflatedExpr as Expr, DeflatedFinally as Finally, DeflatedFor as For,
+        DeflatedFunctionDef as FunctionDef, DeflatedGlobal as Global, DeflatedIf as If,
+        DeflatedImport as Import, DeflatedImportAlias as ImportAlias,
+        DeflatedImportFrom as ImportFrom, DeflatedImportNames as ImportNames,
+        DeflatedIndentedBlock as IndentedBlock, DeflatedMatch as Match, DeflatedMatchAs as MatchAs,
+        DeflatedMatchCase as MatchCase, DeflatedMatchClass as MatchClass,
+        DeflatedMatchKeywordElement as MatchKeywordElement, DeflatedMatchList as MatchList,
+        DeflatedMatchMapping as MatchMapping, DeflatedMatchMappingElement as MatchMappingElement,
+        DeflatedMatchOr as MatchOr, DeflatedMatchOrElement as MatchOrElement,
+        DeflatedMatchPattern as MatchPattern, DeflatedMatchSequence as MatchSequence,
+        DeflatedMatchSequenceElement as MatchSequenceElement,
+        DeflatedMatchSingleton as MatchSingleton, DeflatedMatchStar as MatchStar,
+        DeflatedMatchTuple as MatchTuple, DeflatedMatchValue as MatchValue,
+        DeflatedNameItem as NameItem, DeflatedNonlocal as Nonlocal, DeflatedOrElse as OrElse,
+        DeflatedPass as Pass, DeflatedRaise as Raise, DeflatedReturn as Return,
+        DeflatedSimpleStatementLine as SimpleStatementLine,
+        DeflatedSimpleStatementSuite as SimpleStatementSuite,
+        DeflatedSmallStatement as SmallStatement,
+        DeflatedStarrableMatchSequenceElement as StarrableMatchSequenceElement,
+        DeflatedStatement as Statement, DeflatedSuite as Suite, DeflatedTry as Try,
+        DeflatedTryStar as TryStar, DeflatedWhile as While, DeflatedWith as With,
+        DeflatedWithItem as WithItem,
+    };
+}

--- a/native/libcst/src/nodes/traits.rs
+++ b/native/libcst/src/nodes/traits.rs
@@ -4,13 +4,15 @@
 // LICENSE file in the root directory of this source tree
 
 use crate::{
+    nodes::expression::{DeflatedLeftParen, DeflatedRightParen},
+    nodes::op::DeflatedComma,
     tokenizer::whitespace_parser::{Config, WhitespaceError},
-    Codegen, CodegenState, Comma, EmptyLine, LeftParen, RightParen,
+    Codegen, CodegenState, EmptyLine, LeftParen, RightParen,
 };
 use std::ops::Deref;
 
-pub trait WithComma<'a> {
-    fn with_comma(self, comma: Comma<'a>) -> Self;
+pub trait WithComma<'r, 'a> {
+    fn with_comma(self, comma: DeflatedComma<'r, 'a>) -> Self;
 }
 
 pub trait ParenthesizedNode<'a> {
@@ -51,6 +53,32 @@ impl<'a, T: ParenthesizedNode<'a>> ParenthesizedNode<'a> for Box<T> {
     }
 }
 
+pub trait ParenthesizedDeflatedNode<'r, 'a> {
+    fn lpar(&self) -> &Vec<DeflatedLeftParen<'r, 'a>>;
+    fn rpar(&self) -> &Vec<DeflatedRightParen<'r, 'a>>;
+
+    fn with_parens(
+        self,
+        left: DeflatedLeftParen<'r, 'a>,
+        right: DeflatedRightParen<'r, 'a>,
+    ) -> Self;
+}
+impl<'r, 'a, T: ParenthesizedDeflatedNode<'r, 'a>> ParenthesizedDeflatedNode<'r, 'a> for Box<T> {
+    fn lpar(&self) -> &Vec<DeflatedLeftParen<'r, 'a>> {
+        self.deref().lpar()
+    }
+    fn rpar(&self) -> &Vec<DeflatedRightParen<'r, 'a>> {
+        self.deref().rpar()
+    }
+    fn with_parens(
+        self,
+        left: DeflatedLeftParen<'r, 'a>,
+        right: DeflatedRightParen<'r, 'a>,
+    ) -> Self {
+        Self::new((*self).with_parens(left, right))
+    }
+}
+
 pub trait WithLeadingLines<'a> {
     fn leading_lines(&mut self) -> &mut Vec<EmptyLine<'a>>;
 }
@@ -61,17 +89,20 @@ pub trait Inflate<'a>
 where
     Self: Sized,
 {
-    fn inflate(self, config: &Config<'a>) -> Result<Self>;
+    type Inflated;
+    fn inflate(self, config: &Config<'a>) -> Result<Self::Inflated>;
 }
 
 impl<'a, T: Inflate<'a>> Inflate<'a> for Option<T> {
-    fn inflate(self, config: &Config<'a>) -> Result<Self> {
+    type Inflated = Option<T::Inflated>;
+    fn inflate(self, config: &Config<'a>) -> Result<Self::Inflated> {
         self.map(|x| x.inflate(config)).transpose()
     }
 }
 
 impl<'a, T: Inflate<'a> + ?Sized> Inflate<'a> for Box<T> {
-    fn inflate(self, config: &Config<'a>) -> Result<Self> {
+    type Inflated = Box<T::Inflated>;
+    fn inflate(self, config: &Config<'a>) -> Result<Self::Inflated> {
         match (*self).inflate(config) {
             Ok(a) => Ok(Box::new(a)),
             Err(e) => Err(e),
@@ -80,7 +111,8 @@ impl<'a, T: Inflate<'a> + ?Sized> Inflate<'a> for Box<T> {
 }
 
 impl<'a, T: Inflate<'a>> Inflate<'a> for Vec<T> {
-    fn inflate(self, config: &Config<'a>) -> Result<Self> {
+    type Inflated = Vec<T::Inflated>;
+    fn inflate(self, config: &Config<'a>) -> Result<Self::Inflated> {
         self.into_iter().map(|item| item.inflate(config)).collect()
     }
 }

--- a/native/libcst/src/parser/mod.rs
+++ b/native/libcst/src/parser/mod.rs
@@ -8,4 +8,5 @@ mod grammar;
 mod numbers;
 
 pub use errors::ParserError;
+pub(crate) use grammar::TokVec;
 pub use grammar::{python, Result};

--- a/native/libcst/src/parser/numbers.rs
+++ b/native/libcst/src/parser/numbers.rs
@@ -6,7 +6,7 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
 
-use crate::{Expression, Float, Imaginary, Integer};
+use crate::nodes::deflated::{Expression, Float, Imaginary, Integer};
 
 static HEX: &str = r"0[xX](?:_?[0-9a-fA-F])+";
 static BIN: &str = r"0[bB](?:_?[01])+";

--- a/native/libcst_derive/Cargo.toml
+++ b/native/libcst_derive/Cargo.toml
@@ -9,3 +9,6 @@ proc-macro = true
 [dependencies]
 syn = "1.0"
 quote = "1.0"
+
+[dev-dependencies]
+trybuild = "1.0"

--- a/native/libcst_derive/src/cstnode.rs
+++ b/native/libcst_derive/src/cstnode.rs
@@ -1,0 +1,455 @@
+// Copyright (c) Meta Platforms, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree
+
+use proc_macro::TokenStream;
+use quote::{format_ident, quote, quote_spanned, ToTokens};
+use syn::{
+    self,
+    parse::{Parse, ParseStream},
+    parse_quote,
+    punctuated::{Pair, Punctuated},
+    spanned::Spanned,
+    token::Comma,
+    AngleBracketedGenericArguments, Attribute, Data, DataEnum, DataStruct, DeriveInput, Field,
+    Fields, FieldsNamed, FieldsUnnamed, GenericArgument, Generics, Ident, Meta, MetaList,
+    NestedMeta, Path, PathArguments, PathSegment, Token, Type, TypePath, Visibility,
+};
+
+pub(crate) struct CSTNodeParams {
+    traits: Punctuated<SupportedTrait, Token![,]>,
+}
+
+#[derive(PartialEq, Eq)]
+enum SupportedTrait {
+    ParenthesizedNode,
+    Codegen,
+    Inflate,
+    NoIntoPy,
+    Default,
+}
+
+pub(crate) fn impl_cst_node(ast: DeriveInput, args: CSTNodeParams) -> TokenStream {
+    match ast.data {
+        Data::Enum(e) => impl_enum(args, ast.attrs, ast.vis, ast.ident, ast.generics, e),
+        Data::Struct(s) => impl_struct(args, ast.attrs, ast.vis, ast.ident, ast.generics, s),
+        Data::Union(u) => quote_spanned! {
+            u.union_token.span() =>
+            compile_error!("Union type is not supported")
+        }
+        .into(),
+    }
+}
+
+impl CSTNodeParams {
+    fn has_trait(&self, treyt: &SupportedTrait) -> bool {
+        self.traits.iter().any(|x| x == treyt)
+    }
+}
+
+impl Parse for SupportedTrait {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        if input.peek(Ident) {
+            let id: Ident = input.parse()?;
+            return match id.to_string().as_str() {
+                "ParenthesizedNode" => Ok(Self::ParenthesizedNode),
+                "Codegen" => Ok(Self::Codegen),
+                "Inflate" => Ok(Self::Inflate),
+                "NoIntoPy" => Ok(Self::NoIntoPy),
+                "Default" => Ok(Self::Default),
+                _ => Err(input.error("Not a supported trait to derive for cst_node")),
+            };
+        }
+        Err(input.error("Pass in trait names to be derived"))
+    }
+}
+
+impl Parse for CSTNodeParams {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(Self {
+            traits: input.parse_terminated(SupportedTrait::parse)?,
+        })
+    }
+}
+
+// enum Foo<'a> {
+//     Variant(Box<Variant<'a>>),
+// }
+// =>
+// enum Foo<'a> {
+//     Variant(Box<Variant<'a>>),
+// }
+// enum DeflatedFoo<'r, 'a> {
+//     Variant(Box<DeflatedVariant<'r, 'a>>),
+// }
+
+fn impl_enum(
+    args: CSTNodeParams,
+    mut attrs: Vec<Attribute>,
+    vis: Visibility,
+    ident: Ident,
+    generics: Generics,
+    mut e: DataEnum,
+) -> TokenStream {
+    let deflated_vis = vis.clone();
+    let deflated_ident = format_ident!("Deflated{}", &ident);
+    let deflated_generics: Generics = parse_quote!(<'r, 'a>);
+    let mut deflated_variant_tokens = vec![];
+
+    for var in e.variants.iter_mut() {
+        let (inflated_fields, deflated_fields) = impl_fields(var.fields.clone());
+        var.fields = deflated_fields;
+        deflated_variant_tokens.push(var.to_token_stream());
+        var.fields = inflated_fields;
+    }
+    add_inflated_attrs(&args, &mut attrs);
+    let inflated = DeriveInput {
+        attrs,
+        vis,
+        ident,
+        generics,
+        data: Data::Enum(e),
+    };
+
+    let deflated_attrs = get_deflated_attrs(&args);
+
+    let gen = quote! {
+        #[derive(Debug, PartialEq, Eq, Clone)]
+        #inflated
+
+        #[derive(Debug, PartialEq, Eq, Clone)]
+        #(#deflated_attrs)*
+        #deflated_vis enum #deflated_ident#deflated_generics {
+            #(#deflated_variant_tokens,)*
+        }
+    };
+    gen.into()
+}
+
+fn get_deflated_attrs(args: &CSTNodeParams) -> Vec<Attribute> {
+    let mut deflated_attrs: Vec<Attribute> = vec![];
+    if args.has_trait(&SupportedTrait::Inflate) {
+        deflated_attrs.push(parse_quote!(#[derive(Inflate)]));
+    }
+    if args.has_trait(&SupportedTrait::ParenthesizedNode) {
+        deflated_attrs.push(parse_quote!(#[derive(ParenthesizedDeflatedNode)]))
+    }
+    if args.has_trait(&SupportedTrait::Default) {
+        deflated_attrs.push(parse_quote!(#[derive(Default)]));
+    }
+    deflated_attrs
+}
+
+fn add_inflated_attrs(args: &CSTNodeParams, attrs: &mut Vec<Attribute>) {
+    if args.has_trait(&SupportedTrait::Codegen) {
+        attrs.push(parse_quote!(#[derive(Codegen)]));
+    }
+    if args.has_trait(&SupportedTrait::ParenthesizedNode) {
+        attrs.push(parse_quote!(#[derive(ParenthesizedNode)]));
+    }
+    if args.has_trait(&SupportedTrait::Default) {
+        attrs.push(parse_quote!(#[derive(Default)]));
+    }
+    if !args.has_trait(&SupportedTrait::NoIntoPy) {
+        attrs.push(parse_quote!(#[cfg_attr(feature = "py", derive(TryIntoPy))]));
+    }
+}
+
+// pub struct Foo<'a> {
+//     pub bar: Bar<'a>,
+//     pub value: &'a str,
+//     pub whitespace_after: SimpleWhitespace<'a>,
+//     pub(crate) tok: Option<TokenRef>,
+// }
+// =>
+// pub struct Foo<'a> {
+//     pub bar: Bar<'a>,
+//     pub value: &'a str,
+//     pub whitespace_after: SimpleWhitespace<'a>,
+// }
+// struct DeflatedFoo<'r, 'a> {
+//     pub bar: DeflatedBar<'r, 'a>,
+//     pub value: &'a str,
+//     pub tok: Option<TokenRef<'r, 'a>>
+// }
+
+fn impl_struct(
+    args: CSTNodeParams,
+    mut attrs: Vec<Attribute>,
+    vis: Visibility,
+    ident: Ident,
+    generics: Generics,
+    mut s: DataStruct,
+) -> TokenStream {
+    let deflated_vis = vis.clone();
+    let deflated_ident = format_ident!("Deflated{}", &ident);
+    let deflated_generics: Generics = parse_quote!(<'r, 'a>);
+
+    let (inflated_fields, deflated_fields) = impl_fields(s.fields);
+    s.fields = inflated_fields;
+
+    add_inflated_attrs(&args, &mut attrs);
+
+    let inflated = DeriveInput {
+        attrs,
+        vis,
+        ident,
+        generics,
+        data: Data::Struct(s),
+    };
+
+    let deflated_attrs = get_deflated_attrs(&args);
+
+    let gen = quote! {
+        #[derive(Debug, PartialEq, Eq, Clone)]
+        #inflated
+
+        #[derive(Debug, PartialEq, Eq, Clone)]
+        #(#deflated_attrs)*
+        #deflated_vis struct #deflated_ident#deflated_generics
+        #deflated_fields
+
+    };
+    gen.into()
+}
+
+fn impl_fields(fields: Fields) -> (Fields, Fields) {
+    match &fields {
+        Fields::Unnamed(fs) => {
+            let deflated_fields = impl_unnamed_fields(fs.clone());
+            (fields, Fields::Unnamed(deflated_fields))
+        }
+        Fields::Named(fs) => impl_named_fields(fs.clone()),
+        Fields::Unit => (Fields::Unit, Fields::Unit),
+    }
+}
+
+fn impl_unnamed_fields(mut deflated_fields: FieldsUnnamed) -> FieldsUnnamed {
+    let mut added_lifetime = false;
+    deflated_fields.unnamed = deflated_fields
+        .unnamed
+        .into_pairs()
+        .map(|pair| {
+            let (deflated, lifetime) = make_into_deflated(pair);
+            added_lifetime |= lifetime;
+            deflated
+        })
+        .collect();
+
+    // Make sure all Deflated* types have 'r 'a lifetime params
+    if !added_lifetime {
+        deflated_fields.unnamed.push(Field {
+            vis: Visibility::Inherited,
+            ty: parse_quote!(std::marker::PhantomData<&'r &'a ()>),
+            attrs: Default::default(),
+            colon_token: Default::default(),
+            ident: Default::default(),
+        });
+    }
+    deflated_fields
+}
+
+fn impl_named_fields(mut fields: FieldsNamed) -> (Fields, Fields) {
+    let mut deflated_fields = fields.clone();
+    let mut added_lifetime = false;
+    // Drop whitespace fields from deflated fields
+    // And add lifetimes to tokenref fields
+    deflated_fields.named = deflated_fields
+        .named
+        .into_pairs()
+        .filter(|pair| {
+            let id = pair.value().ident.as_ref().unwrap().to_string();
+            !id.contains("whitespace")
+                && id != "footer"
+                && id != "header"
+                && id != "leading_lines"
+                && id != "lines_after_decorators"
+        })
+        .map(|pair| {
+            if is_builtin(pair.value()) {
+                pair
+            } else {
+                let (deflated, lifetime) = make_into_deflated(pair);
+                added_lifetime |= lifetime;
+                deflated
+            }
+        })
+        .map(|pair| {
+            let (mut val, punct) = pair.into_tuple();
+            val.attrs = val.attrs.into_iter().filter(is_not_intopy_attr).collect();
+            Pair::new(val, punct)
+        })
+        .collect();
+
+    // Make sure all Deflated* types have 'r 'a lifetime params
+    if !added_lifetime {
+        deflated_fields.named.push(Field {
+            attrs: Default::default(),
+            vis: Visibility::Inherited,
+            ident: Some(parse_quote!(_phantom)),
+            colon_token: Default::default(),
+            ty: parse_quote!(std::marker::PhantomData<&'r &'a ()>),
+        });
+    }
+
+    // Drop tokenref fields from inflated fields
+    fields.named = fields
+        .named
+        .into_pairs()
+        .filter(|pair| !is_token_ref(pair.value()))
+        .collect();
+
+    (Fields::Named(fields), Fields::Named(deflated_fields))
+}
+
+fn is_builtin(field: &Field) -> bool {
+    get_pathseg(&field.ty)
+        .map(|seg| {
+            let segstr = seg.ident.to_string();
+            segstr == "str" || segstr == "bool" || segstr == "String"
+        })
+        .unwrap_or_default()
+}
+
+fn is_token_ref(field: &Field) -> bool {
+    if let Some(seg) = rightmost_path_segment(&field.ty) {
+        return format!("{}", seg.ident) == "TokenRef";
+    }
+    false
+}
+
+// foo::bar -> foo::Deflatedbar<'r, 'a>
+fn make_into_deflated(mut pair: Pair<Field, Comma>) -> (Pair<Field, Comma>, bool) {
+    let mut added_lifetime = true;
+    if let Some(seg) = rightmost_path_segment_mut(&mut pair.value_mut().ty) {
+        let seg_name = seg.ident.to_string();
+        if seg_name != "TokenRef" {
+            seg.ident = format_ident!("Deflated{}", seg_name);
+        }
+        match seg.arguments {
+            PathArguments::None => {
+                seg.arguments = PathArguments::AngleBracketed(parse_quote!(<'r, 'a>));
+            }
+            PathArguments::AngleBracketed(AngleBracketedGenericArguments {
+                ref mut args, ..
+            }) => {
+                args.insert(0, parse_quote!('r));
+            }
+            _ => todo!(),
+        }
+    } else {
+        added_lifetime = false;
+    }
+    (pair, added_lifetime)
+}
+
+// foo::bar::baz<quux<'a>> -> baz<quux<'a>>
+fn get_pathseg(ty: &Type) -> Option<&PathSegment> {
+    match ty {
+        Type::Path(TypePath { path, .. }) => path.segments.last(),
+        _ => None,
+    }
+}
+
+// foo::bar::baz<quux<'a>> -> quux<'a>
+fn rightmost_path_segment(ty: &Type) -> Option<&PathSegment> {
+    let mut candidate = get_pathseg(ty);
+    loop {
+        if let Some(pathseg) = candidate {
+            if let PathArguments::AngleBracketed(AngleBracketedGenericArguments { args, .. }) =
+                &pathseg.arguments
+            {
+                if let Some(GenericArgument::Type(t)) = args.last() {
+                    candidate = get_pathseg(t);
+                    continue;
+                }
+            }
+        }
+        break;
+    }
+    candidate
+}
+
+fn get_pathseg_mut(ty: &mut Type) -> Option<&mut PathSegment> {
+    match ty {
+        Type::Path(TypePath { path, .. }) => path.segments.last_mut(),
+        _ => None,
+    }
+}
+
+fn has_more_mut(candidate: &Option<&mut PathSegment>) -> bool {
+    if let Some(PathArguments::AngleBracketed(AngleBracketedGenericArguments {
+        ref args, ..
+    })) = candidate.as_ref().map(|c| &c.arguments)
+    {
+        matches!(args.last(), Some(GenericArgument::Type(_)))
+    } else {
+        false
+    }
+}
+
+fn rightmost_path_segment_mut(ty: &mut Type) -> Option<&mut PathSegment> {
+    let mut candidate = get_pathseg_mut(ty);
+
+    while has_more_mut(&candidate) {
+        candidate = match candidate.unwrap().arguments {
+            PathArguments::AngleBracketed(AngleBracketedGenericArguments {
+                ref mut args, ..
+            }) => {
+                if let Some(GenericArgument::Type(t)) = args.last_mut() {
+                    get_pathseg_mut(t)
+                } else {
+                    unreachable!();
+                }
+            }
+            _ => unreachable!(),
+        };
+    }
+
+    candidate
+}
+
+fn is_not_intopy_attr(attr: &Attribute) -> bool {
+    let path = &attr.path;
+    // support #[cfg_attr(feature="py", skip_py)]
+    if path.is_ident("cfg_attr") {
+        match attr.parse_meta() {
+            Ok(Meta::List(MetaList { nested, .. })) => {
+                for meta in nested {
+                    if let NestedMeta::Meta(Meta::Path(path)) = meta {
+                        return !is_intopy_attr_path(&path);
+                    }
+                }
+            }
+            _ => return false,
+        }
+    }
+    !is_intopy_attr_path(path)
+}
+
+fn is_intopy_attr_path(path: &Path) -> bool {
+    path.is_ident("skip_py") || path.is_ident("no_py_default")
+}
+
+#[test]
+fn trybuild() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/pass/*.rs");
+}
+
+#[test]
+fn test_is_not_intopy_attr() {
+    assert!(!is_not_intopy_attr(&parse_quote!(#[skip_py])));
+    assert!(!is_not_intopy_attr(&parse_quote!(#[no_py_default])));
+    assert!(!is_not_intopy_attr(
+        &parse_quote!(#[cfg_attr(foo="bar",skip_py)])
+    ));
+    assert!(!is_not_intopy_attr(
+        &parse_quote!(#[cfg_attr(foo="bar",no_py_default)])
+    ));
+    assert!(is_not_intopy_attr(&parse_quote!(#[skippy])));
+    assert!(is_not_intopy_attr(
+        &parse_quote!(#[cfg_attr(foo="bar",skippy)])
+    ));
+}

--- a/native/libcst_derive/src/cstnode.rs
+++ b/native/libcst_derive/src/cstnode.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Meta Platforms, Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree

--- a/native/libcst_derive/src/lib.rs
+++ b/native/libcst_derive/src/lib.rs
@@ -11,8 +11,11 @@ mod codegen;
 use codegen::impl_codegen;
 mod into_py;
 use into_py::impl_into_py;
+mod cstnode;
+use cstnode::{impl_cst_node, CSTNodeParams};
 
 use proc_macro::TokenStream;
+use syn::{parse, parse_macro_input, DeriveInput};
 
 #[proc_macro_derive(Inflate)]
 pub fn inflate_derive(input: TokenStream) -> TokenStream {
@@ -33,4 +36,10 @@ pub fn parenthesized_node_codegen(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(TryIntoPy, attributes(skip_py, no_py_default))]
 pub fn into_py(input: TokenStream) -> TokenStream {
     impl_into_py(&syn::parse(input).unwrap())
+}
+
+#[proc_macro_attribute]
+pub fn cst_node(args: TokenStream, input: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(args as CSTNodeParams);
+    impl_cst_node(parse_macro_input!(input as DeriveInput), args)
 }

--- a/native/libcst_derive/src/lib.rs
+++ b/native/libcst_derive/src/lib.rs
@@ -15,7 +15,7 @@ mod cstnode;
 use cstnode::{impl_cst_node, CSTNodeParams};
 
 use proc_macro::TokenStream;
-use syn::{parse, parse_macro_input, DeriveInput};
+use syn::{parse_macro_input, DeriveInput};
 
 #[proc_macro_derive(Inflate)]
 pub fn inflate_derive(input: TokenStream) -> TokenStream {
@@ -25,11 +25,16 @@ pub fn inflate_derive(input: TokenStream) -> TokenStream {
 
 #[proc_macro_derive(ParenthesizedNode)]
 pub fn parenthesized_node_derive(input: TokenStream) -> TokenStream {
-    impl_parenthesized_node(&syn::parse(input).unwrap())
+    impl_parenthesized_node(&syn::parse(input).unwrap(), false)
+}
+
+#[proc_macro_derive(ParenthesizedDeflatedNode)]
+pub fn parenthesized_deflated_node_derive(input: TokenStream) -> TokenStream {
+    impl_parenthesized_node(&syn::parse(input).unwrap(), true)
 }
 
 #[proc_macro_derive(Codegen)]
-pub fn parenthesized_node_codegen(input: TokenStream) -> TokenStream {
+pub fn codegen_derive(input: TokenStream) -> TokenStream {
     impl_codegen(&syn::parse(input).unwrap())
 }
 

--- a/native/libcst_derive/tests/pass/minimal_cst.rs
+++ b/native/libcst_derive/tests/pass/minimal_cst.rs
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree
+
 use libcst_derive::{cst_node, Codegen};
 
 pub enum Error {}

--- a/native/libcst_derive/tests/pass/minimal_cst.rs
+++ b/native/libcst_derive/tests/pass/minimal_cst.rs
@@ -1,0 +1,122 @@
+use libcst_derive::{cst_node, Codegen};
+
+pub enum Error {}
+
+type TokenRef<'r, 'a> = &'r &'a str;
+pub type Result<T> = std::result::Result<T, Error>;
+
+pub struct Config<'a> {
+    #[allow(dead_code)]
+    foo: &'a str,
+}
+pub trait Inflate<'a>
+where
+    Self: Sized,
+{
+    type Inflated;
+    fn inflate(self, config: &Config<'a>) -> Result<Self::Inflated>;
+}
+
+impl<'a, T: Inflate<'a> + ?Sized> Inflate<'a> for Box<T> {
+    type Inflated = Box<T::Inflated>;
+    fn inflate(self, config: &Config<'a>) -> Result<Self::Inflated> {
+        match (*self).inflate(config) {
+            Ok(a) => Ok(Box::new(a)),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+pub struct CodegenState<'a> {
+    #[allow(dead_code)]
+    foo: &'a str,
+}
+pub trait Codegen<'a> {
+    fn codegen(&self, state: &mut CodegenState<'a>);
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct WS<'a> {
+    pub last_line: &'a str,
+}
+
+#[cst_node]
+pub struct Parameters<'a> {
+    pub params: Vec<Param<'a>>,
+    pub foo: Param<'a>,
+}
+
+impl<'r, 'a> Inflate<'a> for DeflatedParameters<'r, 'a> {
+    type Inflated = Parameters<'a>;
+    fn inflate(self, config: &Config<'a>) -> Result<Self::Inflated> {
+        let params = vec![];
+        #[allow(clippy::blacklisted_name)]
+        let foo = self.foo.inflate(config)?;
+        Ok(Self::Inflated { params, foo })
+    }
+}
+
+#[cst_node]
+pub struct Param<'a> {
+    pub star: Option<&'a str>,
+    pub(crate) star_tok: Option<TokenRef<'a>>,
+}
+
+impl<'r, 'a> Inflate<'a> for DeflatedParam<'r, 'a> {
+    type Inflated = Param<'a>;
+    fn inflate(self, _config: &Config<'a>) -> Result<Self::Inflated> {
+        Ok(Self::Inflated { star: self.star })
+    }
+}
+
+impl<'a> Codegen<'a> for Param<'a> {
+    fn codegen(&self, _state: &mut CodegenState<'a>) {}
+}
+
+#[cst_node]
+pub struct BitOr<'a> {
+    pub whitespace_before: WS<'a>,
+    pub whitespace_after: WS<'a>,
+
+    pub(crate) tok: TokenRef<'a>,
+}
+
+#[cst_node]
+pub enum CompOp<'a> {
+    LessThan {
+        whitespace_before: WS<'a>,
+        tok: TokenRef<'a>,
+    },
+    GreaterThan {
+        whitespace_after: WS<'a>,
+        tok: TokenRef<'a>,
+    },
+}
+
+impl<'r, 'a> Inflate<'a> for DeflatedCompOp<'r, 'a> {
+    type Inflated = CompOp<'a>;
+    fn inflate(self, _config: &Config<'a>) -> Result<Self::Inflated> {
+        Ok(match self {
+            Self::LessThan { tok: _, .. } => Self::Inflated::LessThan {
+                whitespace_before: WS { last_line: "yo" },
+            },
+            Self::GreaterThan { tok: _, .. } => Self::Inflated::GreaterThan {
+                whitespace_after: WS { last_line: "" },
+            },
+        })
+    }
+}
+
+impl<'a> Codegen<'a> for CompOp<'a> {
+    fn codegen(&self, _state: &mut CodegenState<'a>) {}
+}
+
+#[cst_node(Codegen)]
+enum Expr<'a> {
+    #[allow(dead_code)]
+    One(Box<Param<'a>>),
+    #[allow(dead_code)]
+    Two(CompOp<'a>),
+}
+
+fn main() {}

--- a/native/libcst_derive/tests/pass/simple.rs
+++ b/native/libcst_derive/tests/pass/simple.rs
@@ -1,0 +1,49 @@
+use libcst_derive::cst_node;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct WS<'a>(&'a str);
+
+type TokenRef<'r, 'a> = &'r &'a str;
+
+#[cst_node]
+pub enum Foo<'a> {
+    One(One<'a>),
+    Two(Box<Two<'a>>),
+}
+
+#[cst_node]
+pub struct One<'a> {
+    pub two: Box<Two<'a>>,
+    pub header: WS<'a>,
+
+    pub(crate) newline_tok: TokenRef<'a>,
+}
+
+#[cst_node]
+pub struct Two<'a> {
+    pub whitespace_before: WS<'a>,
+    pub(crate) tok: TokenRef<'a>,
+}
+
+#[cst_node]
+struct Thin<'a> {
+    pub whitespace: WS<'a>,
+}
+
+#[cst_node]
+struct Value<'a> {
+    pub value: &'a str,
+}
+
+#[cst_node]
+struct Empty {}
+
+#[cst_node]
+enum Smol<'a> {
+    #[allow(dead_code)]
+    Thin(Thin<'a>),
+    #[allow(dead_code)]
+    Empty(Empty),
+}
+
+fn main() {}

--- a/native/libcst_derive/tests/pass/simple.rs
+++ b/native/libcst_derive/tests/pass/simple.rs
@@ -1,3 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree
+
 use libcst_derive::cst_node;
 
 #[derive(Debug, PartialEq, Eq, Clone)]


### PR DESCRIPTION
## Summary
 This PR does a few things that are inherently tightly coupled unfortunately. The main motivation is to leverage https://github.com/kevinmehall/rust-peg/pull/269 and use `&'input Token<'a>` as the `Element` type of `ParseElem` instead of `Rc<Token<'a>>`.
This change allows us to
- upgrade to `rust-peg==0.8.0` instead of an unpublished commit
- more importantly, it removes the overhead of managing the refcount in `Rc` while parsing. This turns out to be a significant cost, benchmarks show parsing to be ~33% faster, inflate to be ~65% faster, and overall `parse_module` to be ~25% faster.

To implement this, a couple of changes were necessary:
- create a parallel node hierarchy called `Deflated...`, which contains tokenrefs but not whitespace nodes, and as such has two lifetime parameters
- change the `Inflate` trait to be the bridge between `DeflatedFoo` and `Foo` nodes
- implement a `#[cst_node]` proc macro to facilitate all of this without lots of code duplication
- remove all calls to `clone()` in the grammar implementation

## Test Plan

- added some trybuild tests to have basic coverage of various macros in `libcst_derive`
- rely on existing tests to prevent regressions
