### PR TITLE
Add support for PEP-646

### DIFF
--- a/libcst/_nodes/tests/base.py
+++ b/libcst/_nodes/tests/base.py
@@ -239,7 +239,7 @@ class CSTNodeTest(UnitTest):
     def assert_parses(
         self,
         code: str,
-        parser: Callable[[str], cst.BaseExpression],
+        parser: Callable[[str], cst.CSTNode],
         expect_success: bool,
     ) -> None:
         if not expect_success:

--- a/libcst/_typed_visitor.py
+++ b/libcst/_typed_visitor.py
@@ -2808,6 +2808,22 @@ class CSTTypedBaseFunctions:
         pass
 
     @mark_no_op
+    def visit_Index_star(self, node: "Index") -> None:
+        pass
+
+    @mark_no_op
+    def leave_Index_star(self, node: "Index") -> None:
+        pass
+
+    @mark_no_op
+    def visit_Index_whitespace_after_star(self, node: "Index") -> None:
+        pass
+
+    @mark_no_op
+    def leave_Index_whitespace_after_star(self, node: "Index") -> None:
+        pass
+
+    @mark_no_op
     def visit_Integer(self, node: "Integer") -> Optional[bool]:
         pass
 
@@ -7056,7 +7072,7 @@ class CSTTypedTransformerFunctions(CSTTypedBaseFunctions):
     @mark_no_op
     def leave_StarredElement(
         self, original_node: "StarredElement", updated_node: "StarredElement"
-    ) -> Union["BaseElement", FlattenSentinel["BaseElement"], RemovalSentinel]:
+    ) -> "BaseExpression":
         return updated_node
 
     @mark_no_op

--- a/libcst/matchers/__init__.py
+++ b/libcst/matchers/__init__.py
@@ -7364,6 +7364,46 @@ class Index(BaseSlice, BaseMatcherNode):
         OneOf[BaseExpressionMatchType],
         AllOf[BaseExpressionMatchType],
     ] = DoNotCare()
+    star: Union[
+        Optional[Literal["*"]],
+        MetadataMatchType,
+        MatchIfTrue[Optional[Literal["*"]]],
+        DoNotCareSentinel,
+        OneOf[
+            Union[
+                Optional[Literal["*"]],
+                MetadataMatchType,
+                MatchIfTrue[Optional[Literal["*"]]],
+            ]
+        ],
+        AllOf[
+            Union[
+                Optional[Literal["*"]],
+                MetadataMatchType,
+                MatchIfTrue[Optional[Literal["*"]]],
+            ]
+        ],
+    ] = DoNotCare()
+    whitespace_after_star: Union[
+        Optional["BaseParenthesizableWhitespace"],
+        MetadataMatchType,
+        MatchIfTrue[Optional[cst.BaseParenthesizableWhitespace]],
+        DoNotCareSentinel,
+        OneOf[
+            Union[
+                Optional["BaseParenthesizableWhitespace"],
+                MetadataMatchType,
+                MatchIfTrue[Optional[cst.BaseParenthesizableWhitespace]],
+            ]
+        ],
+        AllOf[
+            Union[
+                Optional["BaseParenthesizableWhitespace"],
+                MetadataMatchType,
+                MatchIfTrue[Optional[cst.BaseParenthesizableWhitespace]],
+            ]
+        ],
+    ] = DoNotCare()
     metadata: Union[
         MetadataMatchType,
         DoNotCareSentinel,
@@ -13644,7 +13684,7 @@ class StarredDictElement(BaseDictElement, BaseMatcherNode):
 
 
 @dataclass(frozen=True, eq=False, unsafe_hash=False)
-class StarredElement(BaseElement, BaseMatcherNode):
+class StarredElement(BaseElement, BaseExpression, BaseMatcherNode):
     value: Union[
         BaseExpressionMatchType,
         DoNotCareSentinel,

--- a/libcst/matchers/_return_types.py
+++ b/libcst/matchers/_return_types.py
@@ -346,7 +346,7 @@ TYPED_FUNCTION_RETURN_MAPPING: TypingDict[Type[CSTNode], object] = {
     SimpleWhitespace: Union[BaseParenthesizableWhitespace, MaybeSentinel],
     Slice: BaseSlice,
     StarredDictElement: Union[BaseDictElement, RemovalSentinel],
-    StarredElement: Union[BaseElement, RemovalSentinel],
+    StarredElement: BaseExpression,
     Subscript: BaseExpression,
     SubscriptElement: Union[SubscriptElement, RemovalSentinel],
     Subtract: BaseBinaryOp,

--- a/native/libcst/tests/fixtures/pep646.py
+++ b/native/libcst/tests/fixtures/pep646.py
@@ -1,0 +1,37 @@
+# see https://github.com/python/cpython/pull/31018/files#diff-3f516b60719dd445d33225e4f316b36e85c9c51a843a0147349d11a005c55937
+
+A[*b]
+A[  *  b  ]
+A[ *  b ,  ]
+A[*b] = 1
+del A[*b]
+
+A[* b ,  * b]
+A[ b, *b]
+A[* b, b]
+A[ *  b,b, b]
+A[b, *b, b]
+
+A[*A[b, *b, b], b]
+A[b, ...]
+A[*A[b, ...]]
+
+A[ * ( 1,2,3)]
+A[ * [ 1,2,3]]
+
+A[1:2, *t]
+A[1:, *t, 1:2]
+A[:, *t, :]
+A[*t, :, *t]
+
+A[* returns_list()]
+A[*returns_list(), * returns_list(), b]
+
+def f1(*args: *b): pass
+def f2(*args: *b, arg1): pass
+def f3(*args: *b, arg1: int): pass
+def f4(*args: *b, arg1: int = 1): pass
+
+def f(*args: *tuple[int, ...]): pass
+def f(*args: *tuple[int, *Ts]): pass
+def f() -> tuple[int, *tuple[int, ...]]: pass


### PR DESCRIPTION
## Summary
Implementation and tests based on https://github.com/python/cpython/pull/31018
The CST is modeled slightly differently from the AST:
- `Index` can now have an optional `star` (and corresponding `whitespace_after_star`)
- `StarredElement` is now a `BaseExpression`

## Test Plan

- [x] roundtrip tests
- [x] negative parse tests
- [x] parse tests
- [x] node construction tests

## TODO

- [ ] Maybe make `whitespace_after_star` into a `MaybeSentinel` instead of `Optional` and add corresponding codegen logic