### PR TITLE
Fix slow qualified name perf in 0.4.2+

### DIFF
--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -1445,35 +1445,33 @@ class ScopeProviderTest(UnitTest):
 
     def test_global_contains_is_read_only(self) -> None:
         gscope = GlobalScope()
-        before_assignments = list(gscope._assignments.items())
-        before_accesses = list(gscope._accesses.items())
+        before_assignments = list(gscope.assignments)
+        before_accesses = list(gscope.accesses)
         self.assertFalse("doesnt_exist" in gscope)
-        self.assertEqual(list(gscope._accesses.items()), before_accesses)
-        self.assertEqual(list(gscope._assignments.items()), before_assignments)
+        self.assertEqual(list(gscope.accesses), before_accesses)
+        self.assertEqual(list(gscope.assignments), before_assignments)
 
     def test_contains_is_read_only(self) -> None:
         for s in [LocalScope, FunctionScope, ClassScope, ComprehensionScope]:
             with self.subTest(scope=s):
                 gscope = GlobalScope()
                 scope = s(parent=gscope, node=cst.Name("lol"))
-                before_assignments = list(scope._assignments.items())
-                before_accesses = list(scope._accesses.items())
+                before_assignments = list(scope.assignments)
+                before_accesses = list(scope.accesses)
                 before_overwrites = list(scope._scope_overwrites.items())
-                before_parent_assignments = list(scope.parent._assignments.items())
-                before_parent_accesses = list(scope.parent._accesses.items())
+                before_parent_assignments = list(scope.parent.assignments)
+                before_parent_accesses = list(scope.parent.accesses)
 
                 self.assertFalse("doesnt_exist" in scope)
-                self.assertEqual(list(scope._accesses.items()), before_accesses)
-                self.assertEqual(list(scope._assignments.items()), before_assignments)
+                self.assertEqual(list(scope.accesses), before_accesses)
+                self.assertEqual(list(scope.assignments), before_assignments)
                 self.assertEqual(
                     list(scope._scope_overwrites.items()), before_overwrites
                 )
                 self.assertEqual(
-                    list(scope.parent._assignments.items()), before_parent_assignments
+                    list(scope.parent.assignments), before_parent_assignments
                 )
-                self.assertEqual(
-                    list(scope.parent._accesses.items()), before_parent_accesses
-                )
+                self.assertEqual(list(scope.parent.accesses), before_parent_accesses)
 
     def test_attribute_of_function_call(self) -> None:
         get_scope_metadata_provider("foo().bar")
@@ -1496,11 +1494,11 @@ class ScopeProviderTest(UnitTest):
         )
         a = m.body[0]
         scope = scopes[a]
-        assignments_len_before = len(scope._assignments)
-        accesses_len_before = len(scope._accesses)
+        assignments_before = list(scope.assignments)
+        accesses_before = list(scope.accesses)
         scope.get_qualified_names_for("doesnt_exist")
-        self.assertEqual(len(scope._assignments), assignments_len_before)
-        self.assertEqual(len(scope._accesses), accesses_len_before)
+        self.assertEqual(list(scope.assignments), assignments_before)
+        self.assertEqual(list(scope.accesses), accesses_before)
 
     def test_gen_dotted_names(self) -> None:
         names = {name for name, node in _gen_dotted_names(cst.Name(value="a"))}


### PR DESCRIPTION
## Summary
This is a performance fix for a change I made to correct compute qualified names in #682

## Test Plan

I hacked three versions of the `node_accesses` set creation in `Scope.get_qualified_names_for` and ran a perf test on them:

```
(libcstvenv) lpetre@lpetre-mbp LibCST % cat /tmp/fastero.json 
{
    "setup": "from libcst import safe_parse_module, MetadataWrapper; from libcst.metadata import QualifiedNameProvider; import os; from wcmatch import wcmatch; env = os.environ; paths = list(wcmatch.WcMatch('/Users/lpetre/dev/src/github.com/python/cpython/Lib', '*.py', exclude_pattern='tests|test', flags=wcmatch.RECURSIVE).imatch()); paths = paths[:100]; mods = [MetadataWrapper(safe_parse_module(open(path).read())) for path in paths];",
    "results": [
        {
            "snippet_name": "0.4.2",
            "snippet_code": "env['FIX_QNAME'] = '0.4.2'; [mod.resolve(QualifiedNameProvider) for mod in mods]"
         },
         {
            "snippet_name": "0.4.4",
            "snippet_code": "env['FIX_QNAME'] = '0.4.4'; [mod.resolve(QualifiedNameProvider) for mod in mods]"
         },
         {
            "snippet_name": "0.4.5",
            "snippet_code": "env['FIX_QNAME'] = '0.4.5'; [mod.resolve(QualifiedNameProvider) for mod in mods]"
         }
    ]
 }

(libcstvenv) lpetre@lpetre-mbp LibCST % python -m fastero -f /tmp/fastero.json -m 5
╭───────────────────────────── Setup code ─────────────────────────────╮
│   1 from libcst import safe_parse_module, MetadataWrapper; from      │
│     libcst.metadata import QualifiedNameProvider; import os; from    │
│     wcmatch import wcmatch; env = os.environ; paths = list(wcmatch.W │
│     Match('/Users/lpetre/dev/src/github.com/python/cpython/Lib',     │
│     '*.py', exclude_pattern='tests|test',                            │
│     flags=wcmatch.RECURSIVE).imatch()); paths = paths[:100]; mods =  │
│     [MetadataWrapper(safe_parse_module(open(path).read())) for path  │
│     in paths];                                                       │
╰──────────────────────────────────────────────────────────────────────╯
────────────────────────────────────────────────────────────────────────────────────────────────────────────── Benchmark started… ──────────────────────────────────────────────────────────────────────────────────────────────────────────────
0.4.2: env['FIX_QNAME'] = '0.4.2'; [mod.resolve(QualifiedNameProvider) for mod in mods]
  Time  (mean ± σ):       34.785 s ± 19.85 ms
  Range (min  … max):     34.753 s … 34.805 s    [runs: 5]
0.4.4: env['FIX_QNAME'] = '0.4.4'; [mod.resolve(QualifiedNameProvider) for mod in mods]
  Time  (mean ± σ):        38.538 s ± 628.35 ms
  Range (min  … max):      37.862 s …  39.197 s    [runs: 5]
0.4.5: env['FIX_QNAME'] = '0.4.5'; [mod.resolve(QualifiedNameProvider) for mod in mods]
  Time  (mean ± σ):       34.278 s ± 50.14 ms
  Range (min  … max):     34.224 s … 34.339 s    [runs: 5]

Summary:
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Bar Chart ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ 0.4.2 [34.753 s]: ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆     ┃
┃ 0.4.4 [37.862 s]: ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆ ┃
┃ 0.4.5 [34.224 s]: ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆      ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━ (lower is better) ━━━━━━━━━━━━━━━━━━━━━━━━━━┛
  0.4.5 is the fastest.
    1.01 (1.02 … 1.01) times faster than 0.4.2
    1.12 (1.11 … 1.14) times faster than 0.4.4
```
