### PR TITLE
Only skip supported escaped characters in f-strings

### DIFF
--- a/native/libcst/src/tokenizer/core/mod.rs
+++ b/native/libcst/src/tokenizer/core/mod.rs
@@ -940,7 +940,25 @@ impl<'t> TokState<'t> {
                             // skip escaped char (e.g. \', \", or newline/line continuation)
                             self.text_pos.next();
                         }
-                    } else {
+                    } else if let Some(
+                        '\n'
+                        | '\\'
+                        | '\''
+                        | '"'
+                        | 'a'
+                        | 'b'
+                        | 'f'
+                        | 'n'
+                        | 'r'
+                        | 't'
+                        | 'v'
+                        | 'x'
+                        | '0'..='9'
+                        | 'N'
+                        | 'u'
+                        | 'U',
+                    ) = self.text_pos.peek()
+                    {
                         // skip escaped char
                         let next_ch = self.text_pos.next();
                         // check if this is a \N sequence

--- a/native/libcst/src/tokenizer/tests.rs
+++ b/native/libcst/src/tokenizer/tests.rs
@@ -618,6 +618,34 @@ fn test_split_fstring() {
 }
 
 #[test]
+fn test_fstring_escapes() {
+    let config = TokConfig {
+        split_fstring: true,
+        ..default_config()
+    };
+    assert_eq!(
+        tokenize_all("f'\\{{\\}}'", &config),
+        Ok(vec![
+            (TokType::FStringStart, "f'"),
+            (TokType::FStringString, "\\{{\\}}"),
+            (TokType::FStringEnd, "'"),
+        ])
+    );
+    assert_eq!(
+        tokenize_all(r#"f"regexp_like(path, '.*\{file_type}$')""#, &config),
+        Ok(vec![
+            (TokType::FStringStart, "f\""),
+            (TokType::FStringString, "regexp_like(path, '.*\\"),
+            (TokType::Op, "{"),
+            (TokType::Name, "file_type"),
+            (TokType::Op, "}"),
+            (TokType::FStringString, "$')"),
+            (TokType::FStringEnd, "\""),
+        ])
+    );
+}
+
+#[test]
 fn test_operator() {
     assert_eq!(
         tokenize_all("= == * ** **= -> . .. ...", &default_config()),

--- a/native/libcst/tests/fixtures/super_strings.py
+++ b/native/libcst/tests/fixtures/super_strings.py
@@ -26,3 +26,6 @@ _ = f"something {{**not** an expression}} {but(this._is)} {{and this isn't.}} en
 _(f"ok { expr = !r: aosidjhoi } end")
 
 print(f"{self.ERASE_CURRENT_LINE}{self._human_seconds(elapsed_time)} {percent:.{self.pretty_precision}f}% complete, {self.estimate_completion(elapsed_time, finished, left)} estimated for {left} files to go...")
+
+f'\{{\}}'
+f"regexp_like(path, '.*\{file_type}$')"

--- a/native/libcst/tests/fixtures/super_strings.py
+++ b/native/libcst/tests/fixtures/super_strings.py
@@ -29,3 +29,4 @@ print(f"{self.ERASE_CURRENT_LINE}{self._human_seconds(elapsed_time)} {percent:.{
 
 f'\{{\}}'
 f"regexp_like(path, '.*\{file_type}$')"
+f"\lfoo"


### PR DESCRIPTION
## Summary
When tokenizing f-strings, we should only skip characters that are allowed to be escaped ([spec](https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals))

## Test Plan

Added test cases.