### PR TITLE
convert_type_comments now preserves comments following type comments

### DIFF
--- a/libcst/codemod/commands/convert_type_comments.py
+++ b/libcst/codemod/commands/convert_type_comments.py
@@ -126,6 +126,19 @@ def _is_type_comment(comment: Optional[cst.Comment]) -> bool:
     return True
 
 
+def _strip_type_comment(comment: Optional[cst.Comment]) -> Optional[cst.Comment]:
+    """
+    Remove the type comment while keeping any following comments.
+    """
+    if not _is_type_comment(comment):
+        return comment
+    assert comment is not None
+    idx = comment.value.find("#", 1)
+    if idx < 0:
+        return None
+    return comment.with_changes(value=comment.value[idx:])
+
+
 class _FailedToApplyAnnotation:
     pass
 
@@ -504,6 +517,9 @@ class ConvertTypeComments(VisitorBasedCodemodCommand):
         self,
         node: cst.TrailingWhitespace,
     ) -> cst.TrailingWhitespace:
+        trailing_comment = _strip_type_comment(node.comment)
+        if trailing_comment is not None:
+            return node.with_changes(comment=trailing_comment)
         return node.with_changes(
             whitespace=cst.SimpleWhitespace(
                 ""

--- a/libcst/codemod/commands/tests/test_convert_type_comments.py
+++ b/libcst/codemod/commands/tests/test_convert_type_comments.py
@@ -28,6 +28,15 @@ class TestConvertTypeCommentsBase(CodemodTest):
 
 
 class TestConvertTypeComments_AssignForWith(TestConvertTypeCommentsBase):
+    def test_preserves_trailing_comment(self) -> None:
+        before = """
+            y = 5  # type: int  # foo
+        """
+        after = """
+            y: int = 5  # foo
+        """
+        self.assertCodemod39Plus(before, after)
+
     def test_convert_assignments(self) -> None:
         before = """
             y = 5  # type: int


### PR DESCRIPTION
## Summary

Prior to this PR convert_type_comments codemod stripped any comments following a type comment. So, for example,

    y = 5  # type: int  # foo

was converted to

    y: int = 5

instead of

    y: int = 5  # foo

The PR changes the codemod to preserve any such comments.

## Test Plan

Added a new test case.
