### PR TITLE
expression: fix SimpleString's quote method

### DIFF
--- a/libcst/_nodes/expression.py
+++ b/libcst/_nodes/expression.py
@@ -656,14 +656,20 @@ class SimpleString(_BasePrefixedString):
         if len(quote) == 2:
             # Let's assume this is an empty string.
             quote = quote[:1]
-        elif len(quote) == 6:
-            # Let's assume this is an empty triple-quoted string.
+        elif 3 < len(quote) <= 6:
+            # Let's assume this can be one of the following:
+            # >>> """"foo"""
+            # '"foo'
+            # >>> """""bar"""
+            # '""bar'
+            # >>> """"""
+            # ''
             quote = quote[:3]
 
         if len(quote) not in {1, 3}:
             # We shouldn't get here due to construction validation logic,
             # but handle the case anyway.
-            raise Exception("Invalid string {self.value}")
+            raise Exception(f"Invalid string {self.value}")
 
         # pyre-ignore We know via the above validation that we will only
         # ever return one of the four string literals.

--- a/libcst/_nodes/tests/test_simple_string.py
+++ b/libcst/_nodes/tests/test_simple_string.py
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import libcst as cst

--- a/libcst/_nodes/tests/test_simple_string.py
+++ b/libcst/_nodes/tests/test_simple_string.py
@@ -1,0 +1,26 @@
+import unittest
+
+import libcst as cst
+
+
+class TestSimpleString(unittest.TestCase):
+    def test_quote(self) -> None:
+        test_cases = [
+            ('"a"', '"'),
+            ("'b'", "'"),
+            ('""', '"'),
+            ("''", "'"),
+            ('"""c"""', '"""'),
+            ("'''d'''", "'''"),
+            ('""""e"""', '"""'),
+            ("''''f'''", "'''"),
+            ('"""""g"""', '"""'),
+            ("'''''h'''", "'''"),
+            ('""""""', '"""'),
+            ("''''''", "'''"),
+        ]
+
+        for s, expected_quote in test_cases:
+            simple_string = cst.SimpleString(s)
+            actual = simple_string.quote
+            self.assertEqual(expected_quote, actual)


### PR DESCRIPTION
## Summary

Fix https://github.com/Instagram/LibCST/issues/636

```
>>> from libcst import *
>>> m = parse_module('''""""foo"""''')
>>> m.body[0].body[0].value.raw_value
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\zsolz\projects\libcst\libcst\_nodes\expression.py", line 682, in raw_value
    quote_len = len(self.quote)
  File "C:\Users\zsolz\projects\libcst\libcst\_nodes\expression.py", line 666, in quote
    raise Exception("Invalid string {self.value}")
Exception: Invalid string {self.value}
```

## Test Plan

1. Unit test
2. Manual test

```
>>> from libcst import *
>>> m = parse_module('''""""foo"""''')
>>> m.body[0].body[0].value.raw_value
'"foo'
```

