### PR TITLE
Cache the scope name prefix to prevent scope traversal in a tight loop

### DIFF
--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -217,24 +217,12 @@ class Assignment(BaseAssignment):
         return self.__index
 
     def get_qualified_names_for(self, full_name: str) -> Set[QualifiedName]:
-        scope = self.scope
-        name_prefixes = []
-        while scope:
-            if isinstance(scope, ClassScope):
-                name_prefixes.append(scope.name)
-            elif isinstance(scope, FunctionScope):
-                name_prefixes.append(f"{scope.name}.<locals>")
-            elif isinstance(scope, ComprehensionScope):
-                name_prefixes.append("<comprehension>")
-            elif not isinstance(scope, (GlobalScope, BuiltinScope)):
-                raise Exception(f"Unexpected Scope: {scope}")
-
-            scope = scope.parent if scope.parent != scope else None
-
-        parts = [*reversed(name_prefixes)]
-        if full_name:
-            parts.append(full_name)
-        return {QualifiedName(".".join(parts), QualifiedNameSource.LOCAL)}
+        return {
+            QualifiedName(
+                ".".join(filter(None, [self.scope._name_prefix, full_name])),
+                QualifiedNameSource.LOCAL,
+            )
+        }
 
 
 # even though we don't override the constructor.
@@ -409,6 +397,7 @@ class Scope(abc.ABC):
     _assignment_count: int
     _accesses_by_name: MutableMapping[str, Set[Access]]
     _accesses_by_node: MutableMapping[cst.CSTNode, Set[Access]]
+    _name_prefix: str
 
     def __init__(self, parent: "Scope") -> None:
         super().__init__()
@@ -418,6 +407,7 @@ class Scope(abc.ABC):
         self._assignment_count = 0
         self._accesses_by_name = defaultdict(set)
         self._accesses_by_node = defaultdict(set)
+        self._name_prefix = ""
 
     def record_assignment(self, name: str, node: cst.CSTNode) -> None:
         target = self._find_assignment_target(name)
@@ -667,6 +657,7 @@ class LocalScope(Scope, abc.ABC):
         self.name = name
         self.node = node
         self._scope_overwrites = {}
+        self._name_prefix = self._make_name_prefix()
 
     def record_global_overwrite(self, name: str) -> None:
         self._scope_overwrites[name] = self.globals
@@ -694,6 +685,9 @@ class LocalScope(Scope, abc.ABC):
             return self._assignments[name]
         else:
             return self.parent._getitem_from_self_or_parent(name)
+
+    def _make_name_prefix(self) -> str:
+        return ".".join(filter(None, [self.parent._name_prefix, self.name, "<locals>"]))
 
 
 # even though we don't override the constructor.
@@ -741,6 +735,9 @@ class ClassScope(LocalScope):
         """
         return self.parent._contains_in_self_or_parent(name)
 
+    def _make_name_prefix(self) -> str:
+        return ".".join(filter(None, [self.parent._name_prefix, self.name]))
+
 
 # even though we don't override the constructor.
 class ComprehensionScope(LocalScope):
@@ -755,7 +752,9 @@ class ComprehensionScope(LocalScope):
     # TODO: Assignment expressions (Python 3.8) will complicate ComprehensionScopes,
     # and will require us to handle such assignments as non-local.
     # https://www.python.org/dev/peps/pep-0572/#scope-of-the-target
-    pass
+
+    def _make_name_prefix(self) -> str:
+        return ".".join(filter(None, [self.parent._name_prefix, "<comprehension>"]))
 
 
 # Generates dotted names from an Attribute or Name node:

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -657,6 +657,7 @@ class LocalScope(Scope, abc.ABC):
         self.name = name
         self.node = node
         self._scope_overwrites = {}
+        # pyre-fixme[4]: Attribute `_name_prefix` of class `LocalScope` has type `str` but no type is specified.
         self._name_prefix = self._make_name_prefix()
 
     def record_global_overwrite(self, name: str) -> None:


### PR DESCRIPTION
## Summary

We don't need to recompute this name prefix every time we try to lookup a qualified name for a node. This value is immutable when the scope is constructed.

### Context

There is a certain type of file that causes the scope provider to take an extraordinary amount of time.

These files tend to fit a specific pattern:
 - very long and machine generated
 - access and assignment to the same variable repeatedly in the same scope

Here is an example: https://github.com/FreeOpcUa/python-opcua/blob/0.98.11/opcua/server/standard_address_space/standard_address_space_part9.py

I've been running these w/ yappi to figure out where the scope provider might be improved.

## Test Plan

Previously this file would take ~70 seconds on my laptop (Apple M1 Pro, 32GB RAM). Now it takes ~30 seconds. 

Here is the top hits from yappi (sorted by tsub) before and after:

### Before
```
Clock type: WALL
Ordered by: tsub, desc

name                                                                                                  ncall                 tsub      ttot      tavg      
scope_provider.py:219 Assignment.get_qualified_names_for                                              15449687              88.09841  300.4678  0.000019
abc.py:137 __instancecheck__                                                                          153150594             66.41100  120.6396  0.000001
scope_provider.py:518 FunctionScope.get_qualified_names_for                                           210892                23.33361  391.2841  0.001855
<string>:1 QualifiedName.__hash__                                                                     20731299              11.22755  38.06354  0.000002
enum.py:610 QualifiedNameSource.__hash__                                                              20731299              10.38797  14.70056  0.000001
scope_provider.py:168 <setcomp>                                                                       2234                  9.668366  17.53884  0.007851
scope_provider.py:555 <setcomp>                                                                       24085                 8.870387  121.0159  0.005025
```

### After
```

Clock type: WALL
Ordered by: tsub, desc

name                                                                                                  ncall                 tsub      ttot      tavg      
scope_provider.py:219 Assignment.get_qualified_names_for                                              15449687              26.64612  68.59105  0.000004
scope_provider.py:508 FunctionScope.get_qualified_names_for                                           210892                21.89870  155.3687  0.000737
abc.py:137 __instancecheck__                                                                          29553100              12.04560  24.11363  0.000001
<string>:1 QualifiedName.__hash__                                                                     20731299              10.47574  36.66161  0.000002
enum.py:610 QualifiedNameSource.__hash__                                                              20731299              9.950157  14.42594  0.000001
scope_provider.py:168 <setcomp>                                                                       2234                  9.336415  17.21738  0.007707
```