### PR TITLE
Fix parsing of parenthesized empty tuples

### DIFF
--- a/native/libcst/src/nodes/expression.rs
+++ b/native/libcst/src/nodes/expression.rs
@@ -999,7 +999,6 @@ pub struct Tuple<'a> {
 impl<'r, 'a> Inflate<'a> for DeflatedTuple<'r, 'a> {
     type Inflated = Tuple<'a>;
     fn inflate(self, config: &Config<'a>) -> Result<Self::Inflated> {
-        dbg!(&self);
         let lpar = self.lpar.inflate(config)?;
         let len = self.elements.len();
         let elements = self

--- a/native/libcst/src/nodes/expression.rs
+++ b/native/libcst/src/nodes/expression.rs
@@ -999,6 +999,7 @@ pub struct Tuple<'a> {
 impl<'r, 'a> Inflate<'a> for DeflatedTuple<'r, 'a> {
     type Inflated = Tuple<'a>;
     fn inflate(self, config: &Config<'a>) -> Result<Self::Inflated> {
+        dbg!(&self);
         let lpar = self.lpar.inflate(config)?;
         let len = self.elements.len();
         let elements = self
@@ -1007,12 +1008,7 @@ impl<'r, 'a> Inflate<'a> for DeflatedTuple<'r, 'a> {
             .enumerate()
             .map(|(idx, el)| el.inflate_element(config, idx + 1 == len))
             .collect::<Result<Vec<_>>>()?;
-        let rpar = if !elements.is_empty() {
-            // rpar only has whitespace if elements is non empty
-            self.rpar.inflate(config)?
-        } else {
-            vec![Default::default()]
-        };
+        let rpar = self.rpar.inflate(config)?;
         Ok(Self::Inflated {
             elements,
             lpar,

--- a/native/libcst/tests/fixtures/tuple_shenanigans.py
+++ b/native/libcst/tests/fixtures/tuple_shenanigans.py
@@ -4,6 +4,8 @@
 # alright here we go.
 
 ()
+(())
+(((())), ())
 ( # evil >:)
   # evil >:(
 ) # ...


### PR DESCRIPTION
Review stack (1/2) [Next](https://github.com/Instagram/LibCST/pull/713)
* #712
* #713
----

## Summary
Don't drop rpars from empty tuples during inflate. In fact that elements check isn't necessary anymore, since inflation happens separately from parsing now: the whitespace between an empty pair of parenthesis has already been consumed during lpar inflation.

Fixes #711.

## Test Plan

Added roundtrip tests.
