### PR TITLE
Support whitespace after ParamSlash

### DIFF
--- a/libcst/_nodes/tests/test_funcdef.py
+++ b/libcst/_nodes/tests/test_funcdef.py
@@ -1874,6 +1874,36 @@ class FunctionDefParserTest(CSTNodeTest):
                 ),
                 "code": "def foo(bar, baz, /): pass\n",
             },
+            # Positional only params with whitespace after but no comma
+            {
+                "node": cst.FunctionDef(
+                    cst.Name("foo"),
+                    cst.Parameters(
+                        posonly_params=(
+                            cst.Param(
+                                cst.Name("bar"),
+                                star="",
+                                comma=cst.Comma(
+                                    whitespace_after=cst.SimpleWhitespace(" ")
+                                ),
+                            ),
+                            cst.Param(
+                                cst.Name("baz"),
+                                star="",
+                                comma=cst.Comma(
+                                    whitespace_after=cst.SimpleWhitespace(" ")
+                                ),
+                            ),
+                        ),
+                        posonly_ind=cst.ParamSlash(
+                            whitespace_after=cst.SimpleWhitespace(" ")
+                        ),
+                    ),
+                    cst.SimpleStatementSuite((cst.Pass(),)),
+                ),
+                "code": "def foo(bar, baz, / ): pass\n",
+                "native_only": True,
+            },
             # Typed positional only params
             {
                 "node": cst.FunctionDef(
@@ -2089,7 +2119,9 @@ class FunctionDefParserTest(CSTNodeTest):
             },
         )
     )
-    def test_valid_38(self, node: cst.CSTNode, code: str) -> None:
+    def test_valid_38(self, node: cst.CSTNode, code: str, **kwargs: Any) -> None:
+        if not is_native() and kwargs.get("native_only", False):
+            self.skipTest("disabled for pure python parser")
         self.validate_node(node, code, _parse_statement_force_38)
 
     @data_provider(

--- a/libcst/_nodes/tests/test_lambda.py
+++ b/libcst/_nodes/tests/test_lambda.py
@@ -30,6 +30,22 @@ class LambdaCreationTest(CSTNodeTest):
                 ),
                 "code": "lambda bar, baz, /: 5",
             },
+            # Test basic positional only params with extra trailing whitespace
+            {
+                "node": cst.Lambda(
+                    cst.Parameters(
+                        posonly_params=(
+                            cst.Param(cst.Name("bar")),
+                            cst.Param(cst.Name("baz")),
+                        ),
+                        posonly_ind=cst.ParamSlash(
+                            whitespace_after=cst.SimpleWhitespace(" ")
+                        ),
+                    ),
+                    cst.Integer("5"),
+                ),
+                "code": "lambda bar, baz, / : 5",
+            },
             # Test basic positional params
             (
                 cst.Lambda(

--- a/libcst/_typed_visitor.py
+++ b/libcst/_typed_visitor.py
@@ -4308,6 +4308,14 @@ class CSTTypedBaseFunctions:
         pass
 
     @mark_no_op
+    def visit_ParamSlash_whitespace_after(self, node: "ParamSlash") -> None:
+        pass
+
+    @mark_no_op
+    def leave_ParamSlash_whitespace_after(self, node: "ParamSlash") -> None:
+        pass
+
+    @mark_no_op
     def visit_ParamStar(self, node: "ParamStar") -> Optional[bool]:
         pass
 

--- a/libcst/matchers/__init__.py
+++ b/libcst/matchers/__init__.py
@@ -11955,6 +11955,12 @@ class ParamSlash(BaseMatcherNode):
     comma: Union[
         CommaMatchType, DoNotCareSentinel, OneOf[CommaMatchType], AllOf[CommaMatchType]
     ] = DoNotCare()
+    whitespace_after: Union[
+        BaseParenthesizableWhitespaceMatchType,
+        DoNotCareSentinel,
+        OneOf[BaseParenthesizableWhitespaceMatchType],
+        AllOf[BaseParenthesizableWhitespaceMatchType],
+    ] = DoNotCare()
     metadata: Union[
         MetadataMatchType,
         DoNotCareSentinel,

--- a/native/libcst/src/nodes/expression.rs
+++ b/native/libcst/src/nodes/expression.rs
@@ -999,7 +999,6 @@ pub struct Tuple<'a> {
 impl<'r, 'a> Inflate<'a> for DeflatedTuple<'r, 'a> {
     type Inflated = Tuple<'a>;
     fn inflate(self, config: &Config<'a>) -> Result<Self::Inflated> {
-        dbg!(&self);
         let lpar = self.lpar.inflate(config)?;
         let len = self.elements.len();
         let elements = self

--- a/native/libcst/src/nodes/expression.rs
+++ b/native/libcst/src/nodes/expression.rs
@@ -999,6 +999,7 @@ pub struct Tuple<'a> {
 impl<'r, 'a> Inflate<'a> for DeflatedTuple<'r, 'a> {
     type Inflated = Tuple<'a>;
     fn inflate(self, config: &Config<'a>) -> Result<Self::Inflated> {
+        dbg!(&self);
         let lpar = self.lpar.inflate(config)?;
         let len = self.elements.len();
         let elements = self
@@ -1007,12 +1008,7 @@ impl<'r, 'a> Inflate<'a> for DeflatedTuple<'r, 'a> {
             .enumerate()
             .map(|(idx, el)| el.inflate_element(config, idx + 1 == len))
             .collect::<Result<Vec<_>>>()?;
-        let rpar = if !elements.is_empty() {
-            // rpar only has whitespace if elements is non empty
-            self.rpar.inflate(config)?
-        } else {
-            vec![Default::default()]
-        };
+        let rpar = self.rpar.inflate(config)?;
         Ok(Self::Inflated {
             elements,
             lpar,

--- a/native/libcst/src/parser/grammar.rs
+++ b/native/libcst/src/parser/grammar.rs
@@ -367,19 +367,19 @@ parser! {
             }
 
         rule slash_no_default() -> (Vec<Param<'input, 'a>>, ParamSlash<'input, 'a>)
-            = a:param_no_default()+ slash:lit("/") com:comma() {
-                    (a, ParamSlash { comma: Some(com)})
+            = a:param_no_default()+ tok:lit("/") com:comma() {
+                    (a, ParamSlash { comma: Some(com), tok })
             }
-            / a:param_no_default()+ slash:lit("/") &lit(")") {
-                (a, ParamSlash { comma: None })
+            / a:param_no_default()+ tok:lit("/") &lit(")") {
+                (a, ParamSlash { comma: None, tok })
             }
 
         rule slash_with_default() -> (Vec<Param<'input, 'a>>, ParamSlash<'input, 'a>)
-            = a:param_no_default()* b:param_with_default()+ slash:lit("/") c:comma() {
-                (concat(a, b), ParamSlash { comma: Some(c) })
+            = a:param_no_default()* b:param_with_default()+ tok:lit("/") c:comma() {
+                (concat(a, b), ParamSlash { comma: Some(c), tok })
             }
-            / a:param_no_default()* b:param_with_default()+ slash:lit("/") &lit(")") {
-                (concat(a, b), ParamSlash { comma: None })
+            / a:param_no_default()* b:param_with_default()+ tok:lit("/") &lit(")") {
+                (concat(a, b), ParamSlash { comma: None, tok })
             }
 
         rule star_etc() -> StarEtc<'input, 'a>
@@ -1056,19 +1056,19 @@ parser! {
             }
 
         rule lambda_slash_no_default() -> (Vec<Param<'input, 'a>>, ParamSlash<'input, 'a>)
-            = a:lambda_param_no_default()+ slash:lit("/") com:comma() {
-                (a, ParamSlash { comma: Some(com) } )
+            = a:lambda_param_no_default()+ tok:lit("/") com:comma() {
+                (a, ParamSlash { comma: Some(com), tok } )
             }
-            / a:lambda_param_no_default()+ slash:lit("/") &lit(":") {
-                (a, ParamSlash { comma: None })
+            / a:lambda_param_no_default()+ tok:lit("/") &lit(":") {
+                (a, ParamSlash { comma: None, tok })
             }
 
         rule lambda_slash_with_default() -> (Vec<Param<'input, 'a>>, ParamSlash<'input, 'a>)
-            = a:lambda_param_no_default()* b:lambda_param_with_default()+ slash:lit("/") c:comma(){
-                (concat(a, b), ParamSlash { comma: Some(c) })
+            = a:lambda_param_no_default()* b:lambda_param_with_default()+ tok:lit("/") c:comma(){
+                (concat(a, b), ParamSlash { comma: Some(c), tok })
             }
-            / a:lambda_param_no_default()* b:lambda_param_with_default()+ slash:lit("/") &lit(":") {
-                (concat(a, b), ParamSlash { comma: None })
+            / a:lambda_param_no_default()* b:lambda_param_with_default()+ tok:lit("/") &lit(":") {
+                (concat(a, b), ParamSlash { comma: None, tok })
             }
 
         rule lambda_star_etc() -> StarEtc<'input, 'a>

--- a/native/libcst/tests/fixtures/fun_with_func_defs.py
+++ b/native/libcst/tests/fixtures/fun_with_func_defs.py
@@ -1,4 +1,6 @@
 def f(a, /,): pass
+def f(a, / ,): pass
+def f(a, / ): pass
 def f(a, /, c, d, e): pass
 def f(a, /, c, *, d, e): pass
 def f(a, /, c, *, d, e, **kwargs): pass
@@ -24,6 +26,10 @@ def f(a, /, c, d, e):
 def f(a, /, c, *, d, e):
     pass
 
+def foo(a, *
+    , bar):
+    pass
+
 
 def f(
     a,
@@ -42,6 +48,11 @@ def f(
     /,
 ):
     pass
+
+def say_hello(
+    self, user: str, /
+):
+    print('Hello ' + user)
 
 
 def f(a=1, /, b=2, c=4):

--- a/native/libcst/tests/fixtures/tuple_shenanigans.py
+++ b/native/libcst/tests/fixtures/tuple_shenanigans.py
@@ -4,6 +4,8 @@
 # alright here we go.
 
 ()
+(())
+(((())), ())
 ( # evil >:)
   # evil >:(
 ) # ...


### PR DESCRIPTION
Review stack (2/2) [Prev](https://github.com/Instagram/LibCST/pull/712)
* #712
* #713
----

## Summary
This PR introduces a new `whitespace_after` field to `ParamSlash` to represent whitespace after the `/` in signatures. Parsing for this new field is implemented in the native parser (enabled with `LIBCST_PARSER_TYPE=native` env var currently), but not the old pure python one.

Fixes #679.

## Test Plan

Added roundtrip and unit tests.
