### PR TITLE
[parser] bail on deeply nested expressions

### DIFF
--- a/libcst/_nodes/tests/test_binary_op.py
+++ b/libcst/_nodes/tests/test_binary_op.py
@@ -8,6 +8,7 @@ from typing import Any
 import libcst as cst
 from libcst import parse_expression
 from libcst._nodes.tests.base import CSTNodeTest
+from libcst._parser.entrypoints import is_native
 from libcst.metadata import CodeRange
 from libcst.testing.utils import data_provider
 
@@ -174,3 +175,18 @@ class BinaryOperationTest(CSTNodeTest):
     )
     def test_invalid(self, **kwargs: Any) -> None:
         self.assert_invalid(**kwargs)
+
+    @data_provider(
+        (
+            {
+                "code": '"a"' * 6000,
+                "parser": parse_expression,
+            },
+            {
+                "code": "[_" + " for _ in _" * 6000 + "]",
+                "parser": parse_expression,
+            },
+        )
+    )
+    def test_parse_error(self, **kwargs: Any) -> None:
+        self.assert_parses(**kwargs, expect_success=not is_native())

--- a/native/libcst/Cargo.toml
+++ b/native/libcst/Cargo.toml
@@ -30,7 +30,7 @@ trace = ["peg/trace"]
 
 [dependencies]
 paste = "1.0.4"
-pyo3 = { version = "0.16.5", optional = true }
+pyo3 = { version = "0.16", optional = true }
 thiserror = "1.0.23"
 peg = "0.8.0"
 chic = "1.2.2"


### PR DESCRIPTION
## Summary

When certain expressions are too deeply nested, the rust parser fails with a stack overflow (that manifests in a SEGV on *nix systems). Instead of crashing the entire process, fail early with a parse error.

## Test Plan
Added unit tests
