### PR TITLE
Fix get_qualified_names_for matching on prefixes of the given name

### DIFF
--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -560,7 +560,8 @@ class Scope(abc.ABC):
             if prefix in self:
                 assignments = self[prefix]
                 break
-            prefix = prefix[: prefix.rfind(".")]
+            idx = prefix.rfind(".")
+            prefix = None if idx == -1 else prefix[:idx]
 
         if not isinstance(node, str):
             for assignment in assignments:

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -1964,3 +1964,21 @@ class ScopeProviderTest(UnitTest):
         self.assertEqual(len(assignment.references), 1)
         references = list(assignment.references)
         self.assertTrue(references[0].is_annotation)
+
+    def test_prefix_match(self) -> None:
+        """Verify that a name doesn't overmatch on prefix"""
+        m, scopes = get_scope_metadata_provider(
+            """
+                def something():
+                    ...
+            """
+        )
+        scope = scopes[m]
+        self.assertEqual(
+            scope.get_qualified_names_for(cst.Name("something")),
+            {QualifiedName(name="something", source=QualifiedNameSource.LOCAL)},
+        )
+        self.assertEqual(
+            scope.get_qualified_names_for(cst.Name("something_else")),
+            set(),
+        )


### PR DESCRIPTION
## Summary
This prefix matching logic assumed there is always a '.' in the string, that is incorrect.

We noticed after releasing that a codemod is trying to insert new symbols and using `ScopeProvider.get_qualified_names_for` w/ the new name to prevent collisions.

See the new test for an example of how this would break.

## Test Plan
python -m unittest libcst.metadata.tests.test_scope_provider.ScopeProviderTest.test_prefix_match
