### PR TITLE
Fix type of `evaluated_value` on string to allow bytes

### DIFF
--- a/libcst/_nodes/expression.py
+++ b/libcst/_nodes/expression.py
@@ -700,7 +700,7 @@ class SimpleString(_BasePrefixedString):
             state.add_token(self.value)
 
     @property
-    def evaluated_value(self) -> str:
+    def evaluated_value(self) -> Union[str, bytes]:
         """
         Return an :func:`ast.literal_eval` evaluated str of :py:attr:`value`.
         """
@@ -1035,7 +1035,7 @@ class ConcatenatedString(BaseString):
             self.right._codegen(state)
 
     @property
-    def evaluated_value(self) -> Optional[str]:
+    def evaluated_value(self) -> Union[str, bytes, None]:
         """
         Return an :func:`ast.literal_eval` evaluated str of recursively concatenated :py:attr:`left` and :py:attr:`right`
         if and only if both :py:attr:`left` and :py:attr:`right` are composed by :class:`SimpleString` or :class:`ConcatenatedString`

--- a/libcst/_nodes/expression.py
+++ b/libcst/_nodes/expression.py
@@ -1049,7 +1049,11 @@ class ConcatenatedString(BaseString):
         right_val = right.evaluated_value
         if right_val is None:
             return None
-        return left_val + right_val
+        if isinstance(left_val, bytes) and isinstance(right_val, bytes):
+            return left_val + right_val
+        if isinstance(left_val, str) and isinstance(right_val, str):
+            return left_val + right_val
+        return None
 
 
 @add_slots

--- a/libcst/_nodes/statement.py
+++ b/libcst/_nodes/statement.py
@@ -1700,6 +1700,8 @@ def get_docstring_impl(
         evaluated_value = val.evaluated_value
     else:
         return None
+    if isinstance(evaluated_value, bytes):
+        return None
 
     if evaluated_value is not None and clean:
         return inspect.cleandoc(evaluated_value)

--- a/libcst/codegen/gen_matcher_classes.py
+++ b/libcst/codegen/gen_matcher_classes.py
@@ -265,7 +265,9 @@ def _get_raw_name(node: cst.CSTNode) -> Optional[str]:
     if isinstance(node, cst.Name):
         return node.value
     elif isinstance(node, cst.SimpleString):
-        return node.evaluated_value
+        evaluated_value = node.evaluated_value
+        if isinstance(evaluated_value, str):
+            return evaluated_value
     elif isinstance(node, cst.SubscriptElement):
         return _get_raw_name(node.slice)
     elif isinstance(node, cst.Index):

--- a/libcst/codemod/commands/strip_strings_from_types.py
+++ b/libcst/codemod/commands/strip_strings_from_types.py
@@ -44,8 +44,12 @@ class StripStringsCommand(VisitorBasedCodemodCommand):
         self, original_node: libcst.SimpleString, updated_node: libcst.SimpleString
     ) -> Union[libcst.SimpleString, libcst.BaseExpression]:
         AddImportsVisitor.add_needed_import(self.context, "__future__", "annotations")
+        evaluated_value = updated_node.evaluated_value
         # Just use LibCST to evaluate the expression itself, and insert that as the
         # annotation.
-        return parse_expression(
-            updated_node.evaluated_value, config=self.module.config_for_parsing
-        )
+        if isinstance(evaluated_value, str):
+            return parse_expression(
+                evaluated_value, config=self.module.config_for_parsing
+            )
+        else:
+            return updated_node

--- a/libcst/codemod/visitors/_gather_exports.py
+++ b/libcst/codemod/visitors/_gather_exports.py
@@ -140,6 +140,6 @@ class GatherExportsVisitor(ContextAwareVisitor):
     ) -> None:
         if self._in_assigned_export:
             name = node.evaluated_value
-            if name is None:
+            if not isinstance(name, str):
                 return
             self.explicit_exported_objects.add(name)


### PR DESCRIPTION
## Summary

This can return bytes if the string is a bytestring, e.g.:

    In [1]: import libcst as cst

    In [2]: cst.parse_expression('b"foo"').evaluated_value
    Out[2]: b'foo'