### PR TITLE
pin flake8 below 5.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 black==22.3.0
 coverage>=4.5.4
 fixit==0.1.1
-flake8>=3.7.8
+flake8>=3.7.8,<5
 git+https://github.com/jimmylai/sphinx.git@slots_type_annotation
 hypothesis>=4.36.0
 hypothesmith>=0.0.4


### PR DESCRIPTION
## Summary

flake8 5.0 breaks the fixit compatibility layer, see https://github.com/Instagram/Fixit/issues/222

## Test Plan

CI

