### PR TITLE
Update Sphinx to 5.1.1

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,7 +71,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ black==22.6.0
 coverage>=4.5.4
 fixit==0.1.1
 flake8>=3.7.8,<5
-git+https://github.com/jimmylai/sphinx.git@slots_type_annotation
+Sphinx>=5.1.1
 hypothesis>=4.36.0
 hypothesmith>=0.0.4
 jupyter>=1.0.0


### PR DESCRIPTION
This pull request should fix #747.

I have tried to build document of LibCST with Sphinx 5.1.1 locally. It works fine and smoothly. The only trivial change we need to make to accommodate is to specify the `language` setting to non-`None` value in `conf.py`.
