### PR TITLE
Fix problematic doc build, due to the new builder image provided by readthedocs doesn't has the `graphviz-dev` package pre-installed any more

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,8 @@ build:
   tools:
     python: "3"
     rust: "1.55"
+  apt_packages:
+    - graphviz
 
 python:
    install:


### PR DESCRIPTION
This pull request should fix #725.

The reason we should choose the [`graphviz` package](https://packages.ubuntu.com/jammy/graphviz), instead of other packages whose package names also contain the `graphviz` keywords, is because it's [officially endorsed](https://graphviz.org/download/#linux).