### PR TITLE
Skip CI checks on Python 3.11 x Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11.0-alpha - 3.11"]
         parser: [pure, native]
+        exclude:
+          # skip these builds until https://bugs.launchpad.net/lxml/+bug/1977998 is resolved
+          - os: windows-latest
+            python-version: "3.11.0-alpha - 3.11"
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v2


### PR DESCRIPTION
There are no available binary wheels for lxml for Windows & Python 3.11 yet:
https://bugs.launchpad.net/lxml/+bug/1977998

Until that's resolved, let's skip tests in this configuration.
