### PR TITLE
Fix bug when `TypeOf` is one of options in `OneOf` / `AllOf`

### DIFF
--- a/libcst/matchers/_matcher_base.py
+++ b/libcst/matchers/_matcher_base.py
@@ -226,7 +226,7 @@ class OneOf(Generic[_MatcherT], BaseMatcherNode):
         for option in options:
             if isinstance(option, AllOf):
                 raise Exception("Cannot use AllOf and OneOf in combination!")
-            elif isinstance(option, OneOf):
+            elif isinstance(option, (OneOf, TypeOf)):
                 actual_options.extend(option.options)
             else:
                 actual_options.append(option)

--- a/libcst/matchers/_matcher_base.py
+++ b/libcst/matchers/_matcher_base.py
@@ -302,6 +302,8 @@ class AllOf(Generic[_MatcherT], BaseMatcherNode):
         for option in options:
             if isinstance(option, OneOf):
                 raise Exception("Cannot use AllOf and OneOf in combination!")
+            elif isinstance(option, TypeOf):
+                raise Exception("Cannot use AllOf and TypeOf in combination!")
             elif isinstance(option, AllOf):
                 actual_options.extend(option.options)
             else:

--- a/libcst/matchers/tests/test_matchers.py
+++ b/libcst/matchers/tests/test_matchers.py
@@ -291,6 +291,13 @@ class MatchersMatcherTest(UnitTest):
         self.assertTrue(
             matches(cst.Name("True"), m.OneOf(m.Name("True"), m.Name("False")))
         )
+        # Match when one of the option is a TypeOf
+        self.assertTrue(
+            matches(
+                cst.Name("True"),
+                m.OneOf(m.TypeOf(m.Name, m.NameItem)("True"), m.Name("False")),
+            )
+        )
         # Match any assignment that assigns a value of True or False to an
         # unspecified target.
         self.assertTrue(


### PR DESCRIPTION
This PR should fix #528.

I also added unit test, to prevent regression.