### PR TITLE
Raise informative exception when metadata is unresolved in a metadata-based match

### DIFF
--- a/libcst/matchers/_matcher_base.py
+++ b/libcst/matchers/_matcher_base.py
@@ -581,8 +581,11 @@ class MatchMetadata(_BaseMetadataMatcher):
     """
     Matcher that looks up the metadata on the current node using the provided
     metadata provider and compares the value on the node against the value provided
-    to :class:`MatchMetadata`. If the metadata value does not exist for a particular
-    node, :class:`MatchMetadata` will always be considered not a match.
+    to :class:`MatchMetadata`.
+    If the metadata provider is unresolved, a :class:`LookupError` exeption will be
+    raised and ask you to provide a :class:`~libcst.metadata.MetadataWrapper`.
+    If the metadata value does not exist for a particular node, :class:`MatchMetadata`
+    will be considered not a match.
 
     For example, to match against any function call which has one parameter which
     is used in a load expression context::
@@ -664,8 +667,10 @@ class MatchMetadataIfTrue(_BaseMetadataMatcher):
     Matcher that looks up the metadata on the current node using the provided
     metadata provider and passes it to a callable which can inspect the metadata
     further, returning ``True`` if the matcher should be considered a match.
+    If the metadata provider is unresolved, a :class:`LookupError` exeption will be
+    raised and ask you to provide a :class:`~libcst.metadata.MetadataWrapper`.
     If the metadata value does not exist for a particular node,
-    :class:`MatchMetadataIfTrue` will always be considered not a match.
+    :class:`MatchMetadataIfTrue` will be considered not a match.
 
     For example, to match against any arg whose qualified name might be
     ``typing.Dict``::

--- a/libcst/matchers/_matcher_base.py
+++ b/libcst/matchers/_matcher_base.py
@@ -1523,8 +1523,10 @@ def _matches(
 def _construct_metadata_fetcher_null() -> Callable[
     [meta.ProviderT, libcst.CSTNode], object
 ]:
-    def _fetch(*args: object, **kwargs: object) -> object:
-        return _METADATA_MISSING_SENTINEL
+    def _fetch(provider: meta.ProviderT, node: libcst.CSTNode) -> NoReturn:
+        raise LookupError(
+            f"{provider.__name__} is not resolved; did you forget a MetadataWrapper?"
+        )
 
     return _fetch
 
@@ -1547,7 +1549,7 @@ def _construct_metadata_fetcher_wrapper(
         if provider not in metadata:
             metadata[provider] = wrapper.resolve(provider)
 
-        node_metadata = metadata.get(provider, {}).get(node, _METADATA_MISSING_SENTINEL)
+        node_metadata = metadata[provider].get(node, _METADATA_MISSING_SENTINEL)
         if isinstance(node_metadata, LazyValue):
             node_metadata = node_metadata()
 

--- a/libcst/matchers/tests/test_findall.py
+++ b/libcst/matchers/tests/test_findall.py
@@ -103,14 +103,17 @@ class MatchersFindAllTest(UnitTest):
             ],
         )
 
-        # Test that failing to provide metadata leads to no match
-        booleans = findall(
-            wrapper.module,
-            m.MatchMetadata(
-                meta.ExpressionContextProvider, meta.ExpressionContext.STORE
-            ),
-        )
-        self.assertNodeSequenceEqual(booleans, [])
+        # Test that failing to provide metadata leads to raising an informative exception
+        with self.assertRaises(
+            LookupError,
+            msg="ExpressionContextProvider is not resolved; did you forget a MetadataWrapper?",
+        ):
+            booleans = findall(
+                wrapper.module,
+                m.MatchMetadata(
+                    meta.ExpressionContextProvider, meta.ExpressionContext.STORE
+                ),
+            )
 
     def test_findall_with_visitors(self) -> None:
         # Find all assignments in a tree

--- a/libcst/matchers/tests/test_matchers_with_metadata.py
+++ b/libcst/matchers/tests/test_matchers_with_metadata.py
@@ -366,13 +366,14 @@ class MatchersMetadataTest(UnitTest):
             )
         )
 
-    def test_lambda_metadata_matcher_with_no_metadata(self) -> None:
+    def test_lambda_metadata_matcher_with_unresolved_metadata(self) -> None:
         # Match on qualified name provider
         module = cst.parse_module(
             "from typing import List\n\ndef foo() -> None: pass\n"
         )
         functiondef = cst.ensure_type(module.body[1], cst.FunctionDef)
 
+        # Test that when the metadata is unresolved, raise an informative exception.
         with self.assertRaises(
             LookupError,
             msg="QualifiedNameProvider is not resolved; did you forget a MetadataWrapper?",
@@ -388,6 +389,25 @@ class MatchersMetadataTest(UnitTest):
                     )
                 ),
             )
+
+    def test_lambda_metadata_matcher_with_no_metadata(self) -> None:
+        class VoidProvider(meta.BatchableMetadataProvider[object]):
+            """A dummy metadata provider"""
+
+        module = cst.parse_module(
+            "from typing import List\n\ndef foo() -> None: pass\n"
+        )
+        wrapper = cst.MetadataWrapper(module)
+        functiondef = cst.ensure_type(wrapper.module.body[1], cst.FunctionDef)
+
+        # Test that when the node has no corresponding metadata, there is no match.
+        self.assertFalse(
+            matches(
+                functiondef,
+                m.FunctionDef(name=m.MatchMetadataIfTrue(VoidProvider, lambda _: True)),
+                metadata_resolver=wrapper,
+            )
+        )
 
     def test_lambda_metadata_matcher_operators(self) -> None:
         # Match on qualified name provider

--- a/libcst/matchers/tests/test_matchers_with_metadata.py
+++ b/libcst/matchers/tests/test_matchers_with_metadata.py
@@ -373,7 +373,10 @@ class MatchersMetadataTest(UnitTest):
         )
         functiondef = cst.ensure_type(module.body[1], cst.FunctionDef)
 
-        self.assertFalse(
+        with self.assertRaises(
+            LookupError,
+            msg="QualifiedNameProvider is not resolved; did you forget a MetadataWrapper?",
+        ):
             matches(
                 functiondef,
                 m.FunctionDef(
@@ -385,7 +388,6 @@ class MatchersMetadataTest(UnitTest):
                     )
                 ),
             )
-        )
 
     def test_lambda_metadata_matcher_operators(self) -> None:
         # Match on qualified name provider


### PR DESCRIPTION
I also tuned the related unit test to accommodate this change.

This PR closes #526.