### PR TITLE
Fix the bug that the use of formatter in codemods has undetermined target Python version, resulting in hard-to-reason-with behavior

### DIFF
--- a/libcst/codemod/tests/test_codemod_cli.py
+++ b/libcst/codemod/tests/test_codemod_cli.py
@@ -6,7 +6,6 @@
 
 
 import subprocess
-import sys
 from pathlib import Path
 
 from libcst._parser.entrypoints import is_native

--- a/libcst/codemod/tests/test_codemod_cli.py
+++ b/libcst/codemod/tests/test_codemod_cli.py
@@ -22,13 +22,16 @@ class TestCodemodCLI(UnitTest):
                 "libcst.tool",
                 "codemod",
                 "remove_unused_imports.RemoveUnusedImportsCommand",
+                # `ArgumentParser.parse_known_args()`'s behavior dictates that options
+                # need to go after instead of before the codemod command identifier.
+                "--python-version",
+                "3.6",
                 str(Path(__file__).parent / "codemod_formatter_error_input.py.txt"),
             ],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        version = sys.version_info
-        if version[0] == 3 and version[1] == 6 and not is_native():
+        if not is_native():
             self.assertIn(
                 "ParserSyntaxError: Syntax Error @ 14:11.",
                 rlt.stderr.decode("utf-8"),

--- a/libcst/tool.py
+++ b/libcst/tool.py
@@ -31,6 +31,7 @@ from libcst import (
     PartialParserConfig,
 )
 from libcst._nodes.deep_equals import deep_equals
+from libcst._parser.parso.utils import parse_version_string
 from libcst.codemod import (
     CodemodCommand,
     CodemodContext,
@@ -537,6 +538,17 @@ def _codemod_impl(proc_name: str, command_args: List[str]) -> int:  # noqa: C901
         ]
     }
     command_instance = command_class(CodemodContext(), **codemod_args)
+
+    # Sepcify target version for black formatter
+    if os.path.basename(config["formatter"][0]) in ("black", "black.exe"):
+
+        parsed_version = parse_version_string(args.python_version)
+
+        config["formatter"] = [
+            config["formatter"][0],
+            "--target-version",
+            f"py{parsed_version.major}{parsed_version.minor}",
+        ] + config["formatter"][1:]
 
     # Special case for allowing stdin/stdout. Note that this does not allow for
     # full-repo metadata since there is no path.


### PR DESCRIPTION
This PR tries to fix the bug manifesting in #769. In summary, we specify that the black formatter should use the same target Python version which libcst itself uses.