### PR TITLE
[ci] Remove deprecated ::set-output directive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           matrix=$(jq --arg ref "${{ github.ref }}" \
             'map(select(.on_ref_regex as $pat | $pat == null or ($ref | test($pat))) | del(.on_ref_regex))' \
             .github/build-matrix.json)
-          echo ::set-output name=matrix::{\"include\":$(echo $matrix)}\"
+          echo matrix={\"include\":$(echo $matrix)}\" >> $GITHUB_OUTPUT
 
   build:
     name: Build wheels on ${{ join(matrix.os, '/') }}/${{ matrix.vers }}


### PR DESCRIPTION

## Summary
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Test Plan

CI
