### PR TITLE
fix PEP 604 union annotations in decorators

### DIFF
--- a/libcst/matchers/tests/test_decorators.py
+++ b/libcst/matchers/tests/test_decorators.py
@@ -998,7 +998,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
 
 
 class MatchersUnionDecoratorsTest(UnitTest):
-    @skipIf(sys.version_info < (3, 10), "new union syntax not available")
+    @skipIf(bool(sys.version_info < (3, 10)), "new union syntax not available")
     def test_init_with_new_union_annotation(self) -> None:
         class TransformerWithUnionReturnAnnotation(m.MatcherDecoratableTransformer):
             @m.leave(m.ImportFrom(module=m.Name(value="typing")))

--- a/libcst/matchers/tests/test_decorators.py
+++ b/libcst/matchers/tests/test_decorators.py
@@ -3,10 +3,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import sys
 from ast import literal_eval
 from textwrap import dedent
 from typing import List, Set
-from unittest.mock import Mock
+from unittest import skipIf
 
 import libcst as cst
 import libcst.matchers as m
@@ -996,22 +997,14 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
         self.assertEqual(visitor.visits, ['"baz"'])
 
 
-# This is meant to simulate `cst.ImportFrom | cst.RemovalSentinel` in py3.10
-FakeUnionClass: Mock = Mock()
-setattr(FakeUnionClass, "__name__", "Union")
-setattr(FakeUnionClass, "__module__", "types")
-FakeUnion: Mock = Mock()
-FakeUnion.__class__ = FakeUnionClass
-FakeUnion.__args__ = [cst.ImportFrom, cst.RemovalSentinel]
-
-
 class MatchersUnionDecoratorsTest(UnitTest):
+    @skipIf(sys.version_info < (3, 10), "new union syntax not available")
     def test_init_with_new_union_annotation(self) -> None:
         class TransformerWithUnionReturnAnnotation(m.MatcherDecoratableTransformer):
             @m.leave(m.ImportFrom(module=m.Name(value="typing")))
             def test(
                 self, original_node: cst.ImportFrom, updated_node: cst.ImportFrom
-            ) -> FakeUnion:
+            ) -> cst.ImportFrom | cst.RemovalSentinel:
                 pass
 
         # assert that init (specifically _check_types on return annotation) passes


### PR DESCRIPTION
## Summary

This fixes the bug that #429 was intended to fix. Unfortunately the name checked for in that PR (`types.Union`) is not what was actually merged in Python 3.10 (`types.UnionType`) so that fix is not effective in 3.10. Here we instead use an `isinstance` check against the real imported `types.UnionType` (with fallback for earlier Python versions). And update the test to use a real PEP 604 union (skipping on Python versions before 3.10) for better fidelity to reality than the mock that was previously used.

## Test Plan

`python -m unittest libcst.matchers.tests.test_decorators` passes in both a 3.8 and a 3.10 virtualenv.