### PR TITLE
[AddImportsVisitor] Docstring Check Only for the Top Element of the Body

### DIFF
--- a/libcst/codemod/visitors/_add_imports.py
+++ b/libcst/codemod/visitors/_add_imports.py
@@ -283,7 +283,7 @@ class AddImportsVisitor(ContextAwareTransformer):
         # original tree but break up the statements of the modified tree. If we
         # change this assumption in this visitor, we will have to change this code.
         for i, statement in enumerate(orig_module.body):
-            if m.matches(
+            if i == 0 and m.matches(
                 statement, m.SimpleStatementLine(body=[m.Expr(value=m.SimpleString())])
             ):
                 statement_before_import_location = import_add_location = 1

--- a/libcst/codemod/visitors/tests/test_add_imports.py
+++ b/libcst/codemod/visitors/tests/test_add_imports.py
@@ -892,8 +892,8 @@ class TestAddImportsCodemod(CodemodTest):
             ),
         )
 
-    def test_import_in_docstring_module_with_docstring_not_as_the_top_line(
-        self
+    def test_import_in_module_with_standalone_string_not_a_docstring(
+        self,
     ) -> None:
         """
         The import should be added after the __future__ imports.

--- a/libcst/codemod/visitors/tests/test_add_imports.py
+++ b/libcst/codemod/visitors/tests/test_add_imports.py
@@ -891,3 +891,36 @@ class TestAddImportsCodemod(CodemodTest):
                 full_module_name="a.b.foobar", full_package_name="a.b"
             ),
         )
+
+    def test_import_in_docstring_module_with_docstring_not_as_the_top_line(
+        self
+    ) -> None:
+        """
+        The import should be added after the __future__ imports.
+        """
+        before = """
+            from __future__ import annotations
+            from __future__ import division
+
+            '''docstring.'''
+            def func():
+                pass
+        """
+        after = """
+            from __future__ import annotations
+            from __future__ import division
+            import typing
+
+            '''docstring.'''
+            def func():
+                pass
+        """
+
+        self.assertCodemod(
+            before,
+            after,
+            [ImportItem("typing", None, None)],
+            context_override=CodemodContext(
+                full_module_name="a.b.foobar", full_package_name="a.b"
+            ),
+        )


### PR DESCRIPTION
## Summary
Refer https://github.com/Instagram/LibCST/pull/343#issuecomment-1367622138
Instead of checking for docstring for all the elements of the body, this PR only keeps the check for the 0th element since our objective is to only honor the module docstrings.

The reason I am asking for this, I found a case in one of the repositories where the docstrings were written outside the function like how we have in Java, obviously, this is unconventional and unpythonic, but my only concern is why are we checking for docstrings which are not module docstrings?

Consider a case
```
from __future__ import annotations
from __future__ import division

import abc
from xyz import def

"""Some docstring"""
def some_func():
    pass
```    
Let's say we are trying to add an import `from typing import List`, the final code after applying the add imports tranformation will look like
```
from __future__ import annotations
from typing import List
from __future__ import division

import abc
from xyz import def

"""Some docstring"""
def some_func():
    pass
```
This is because the docstring is a part of the body of the module and when the for loop reached there, it set the import_add_location to 1, which should not have been the case
And this will break the code because all the `from __future__ imports` must occur at the beginning of the file

## Test Plan
Added a Testcase.
