### PR TITLE
Ignore common virtualenv names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ libcst/_version.py
 .hypothesis/
 .python-version
 target/
+venv/
+.venv/


### PR DESCRIPTION
## Summary

Adds `venv/` and `.venv/` to the gitignore list, so that common
virtualenv names aren't seen as changes to commit.

## Test Plan

Created virtualenv named `venv`; `git status` was clean.

