### PR TITLE
Upgrade pyre-check to 0.9.18

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ jupyter>=1.0.0
 maturin>=0.8.3,<0.14
 nbsphinx>=0.4.2
 prompt-toolkit>=2.0.9
-pyre-check==0.9.9; platform_system != "Windows"
+pyre-check==0.9.18; platform_system != "Windows"
 setuptools_scm>=6.0.1
 sphinx-rtd-theme>=0.4.3
 ufmt==2.0.1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Current version 0.9.9 was unable to install correctly on M1 Mac with
Python 3.10