### PR TITLE
Fix generating invalid trailing commas in import statements

### DIFF
--- a/libcst/_nodes/statement.py
+++ b/libcst/_nodes/statement.py
@@ -1172,18 +1172,24 @@ class ImportAlias(CSTNode):
             comma=visit_sentinel(self, "comma", self.comma, visitor),
         )
 
-    def _codegen_impl(self, state: CodegenState, default_comma: bool = False) -> None:
+    def _codegen_impl(
+        self,
+        state: CodegenState,
+        default_comma: bool = False,
+        comma_is_valid: bool = True,
+    ) -> None:
         with state.record_syntactic_position(self):
             self.name._codegen(state)
             asname = self.asname
             if asname is not None:
                 asname._codegen(state)
 
-        comma = self.comma
-        if comma is MaybeSentinel.DEFAULT and default_comma:
-            state.add_token(", ")
-        elif isinstance(comma, Comma):
-            comma._codegen(state)
+        if comma_is_valid:
+            comma = self.comma
+            if default_comma and comma is MaybeSentinel.DEFAULT:
+                state.add_token(", ")
+            elif isinstance(comma, Comma):
+                comma._codegen(state)
 
     def _name(self, node: CSTNode) -> str:
         # Unrolled version of get_full_name_for_node to avoid circular imports.
@@ -1400,9 +1406,17 @@ class ImportFrom(BaseSmallStatement):
             if lpar is not None:
                 lpar._codegen(state)
             if isinstance(names, Sequence):
-                lastname = len(names) - 1
+                has_parens = self.rpar is not None
+                last_i = len(names) - 1
                 for i, name in enumerate(names):
-                    name._codegen(state, default_comma=(i != lastname))
+                    is_last = i == last_i
+                    name._codegen(
+                        state,
+                        # Unless we're wrappend in parens we can't output a trailing
+                        # comma because that would be invalid code
+                        comma_is_valid=has_parens or not is_last,
+                        default_comma=not is_last,
+                    )
             if isinstance(names, ImportStar):
                 names._codegen(state)
             rpar = self.rpar

--- a/libcst/_nodes/tests/test_import.py
+++ b/libcst/_nodes/tests/test_import.py
@@ -403,7 +403,7 @@ class ImportFromCreateTest(CSTNodeTest):
                 ),
                 "code": "from foo import bar, baz",
             },
-            # Trailing comma
+            # Trailing comma is stripped if no parens (to avoid generating invalid code)
             {
                 "node": cst.ImportFrom(
                     module=cst.Name("foo"),
@@ -412,8 +412,22 @@ class ImportFromCreateTest(CSTNodeTest):
                         cst.ImportAlias(cst.Name("baz"), comma=cst.Comma()),
                     ),
                 ),
-                "code": "from foo import bar,baz,",
+                "code": "from foo import bar,baz",
                 "expected_position": CodeRange((1, 0), (1, 23)),
+            },
+            # Trailing comma is preserved if there are parens
+            {
+                "node": cst.ImportFrom(
+                    module=cst.Name("foo"),
+                    names=(
+                        cst.ImportAlias(cst.Name("bar"), comma=cst.Comma()),
+                        cst.ImportAlias(cst.Name("baz"), comma=cst.Comma()),
+                    ),
+                    lpar=cst.LeftParen(),
+                    rpar=cst.RightParen(),
+                ),
+                "code": "from foo import (bar,baz,)",
+                "expected_position": CodeRange((1, 0), (1, 26)),
             },
             # Star import statement
             {


### PR DESCRIPTION
## Summary

Fixes #532

## Test Plan

Unit tests added/tweaked for this case, also the remove imports codemod tests serve as an integration test.

