### PR TITLE
Add setuptools-rust to build requirements in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
     },
     test_suite="libcst",
     python_requires=">=3.7",
-    setup_requires=["setuptools_scm"],
+    setup_requires=["setuptools-rust", "setuptools_scm"],
     install_requires=[dep.strip() for dep in open("requirements.txt").readlines()],
     extras_require={
         "dev": [


### PR DESCRIPTION
## Summary

Hoping this resolves the CI failures on 3.11



## Test Plan

CI
