### PR TITLE
Use new setup-python caching actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,13 +43,9 @@ jobs:
       - uses: actions/setup-python@v4
         if: ${{ !contains(matrix.os, 'self-hosted') }}
         with:
+          cache: pip
+          cache-dependency-path: "**/requirements*.txt"
           python-version: "3.10"
-      - uses: actions/cache@v3
-        id: cache
-        if: ${{ !contains(matrix.os, 'self-hosted') }}
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'setup.py') }}
       - name: Rust Cache
         if: ${{ !contains(matrix.os, 'self-hosted') }}
         uses: Swatinem/rust-cache@v1.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
+          cache: pip
+          cache-dependency-path: "**/requirements*.txt"
           python-version: ${{ matrix.python-version }}
-      - uses: actions/cache@v3
-        id: cache
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'setup.py') }}
       - name: Install Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           pip install --upgrade --upgrade-strategy eager build -r requirements.txt -r requirements-dev.txt
       - if: ${{ matrix.parser == 'native' }}
@@ -55,14 +51,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
+          cache: pip
+          cache-dependency-path: "**/requirements*.txt"
           python-version: "3.10"
-      - uses: actions/cache@v3
-        id: cache
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'setup.py') }}
       - name: Install Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           pip install --upgrade --upgrade-strategy eager build -r requirements.txt -r requirements-dev.txt
       - run: flake8
@@ -78,14 +70,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
+          cache: pip
+          cache-dependency-path: "**/requirements*.txt"
           python-version: "3.10"
-      - uses: actions/cache@v3
-        id: cache
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'setup.py') }}
       - name: Install Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           pip install --upgrade --upgrade-strategy eager build -r requirements.txt -r requirements-dev.txt
       - name: Make sure Pyre uses the working copy
@@ -102,14 +90,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
+          cache: pip
+          cache-dependency-path: "**/requirements*.txt"
           python-version: "3.10"
-      - uses: actions/cache@v3
-        id: cache
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'setup.py') }}
       - name: Install Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           pip install --upgrade --upgrade-strategy eager build -r requirements.txt -r requirements-dev.txt
       - name: Generate Coverage
@@ -134,14 +118,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
+          cache: pip
+          cache-dependency-path: "**/requirements*.txt"
           python-version: "3.10"
-      - uses: actions/cache@v3
-        id: cache
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'setup.py') }}
       - name: Install Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           pip install --upgrade --upgrade-strategy eager build -r requirements.txt -r requirements-dev.txt
       - uses: ts-graphviz/setup-graphviz@v1
@@ -172,6 +152,8 @@ jobs:
           working-directory: native
       - uses: actions/setup-python@v4
         with:
+          cache: pip
+          cache-dependency-path: "**/requirements*.txt"
           python-version: "3.10"
       - name: test
         uses: actions-rs/cargo@v1

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -26,14 +26,10 @@ jobs:
           path: wheelhouse
       - uses: actions/setup-python@v4
         with:
+          cache: pip
+          cache-dependency-path: "**/requirements*.txt"
           python-version: "3.10"
-      - uses: actions/cache@v3
-        id: cache
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'setup.py') }}
       - name: Install Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           pip install --upgrade --upgrade-strategy eager build -r requirements.txt -r requirements-dev.txt
       - name: Disable scmtools local scheme


### PR DESCRIPTION
## Summary

With the latest setup-python actions, there is a better caching
mechanism available that also requires less setup, and provides better
fallback behavior that should help avoid the random CI failures that
have been happening on 3.11 for setuptools-rust. This ensures that we
install the necessary dependencies before attempting to build the
package or run tests, while still enabling speedups in best case
scenario when requirements files haven't changed.

See the upstream readme for details:
https://github.com/actions/setup-python#caching-packages-dependencies

## Test Plan

CI
