### PR TITLE
[ci] Fix pypi_upload workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,8 @@ jobs:
       CIBW_BUILD_VERBOSITY: 1
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         if: ${{ !contains(matrix.os, 'self-hosted') }}
         with:

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -18,6 +18,8 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Download binary wheels
         id: download
         uses: actions/download-artifact@v3


### PR DESCRIPTION
[ci] Fix pypi_upload workflow
pypi_upload has been broken since #810, because `actions/checkout` defaults to a shallow checkout that only checks out the revision triggering the workflow. This causes setuptools-scm to miss the most recent tag, causing the version to be detected as `0.1`.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Instagram/LibCST/pull/889).
* #890
* __->__ #889