### PR TITLE
Add new FilePathProvider

### DIFF
--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -226,6 +226,14 @@ We provide :class:`~libcst.metadata.ParentNodeProvider` for those use cases.
 .. autoclass:: libcst.metadata.ParentNodeProvider
    :no-undoc-members:
 
+File Path Metadata
+------------------
+This provides the absolute file path on disk for any module being visited.
+Requires an active :class:`~libcst.metadata.FullRepoManager` when using this provider.
+
+.. autoclass:: libcst.metadata.FilePathProvider
+   :no-undoc-members:
+
 Type Inference Metadata
 -----------------------
 `Type inference <https://en.wikipedia.org/wiki/Type_inference>`__ is to automatically infer

--- a/libcst/helpers/paths.py
+++ b/libcst/helpers/paths.py
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import os
 from contextlib import contextmanager
 from pathlib import Path

--- a/libcst/helpers/paths.py
+++ b/libcst/helpers/paths.py
@@ -1,0 +1,20 @@
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Generator
+
+from libcst._types import StrPath
+
+
+@contextmanager
+def chdir(path: StrPath) -> Generator[Path, None, None]:
+    """
+    Temporarily chdir to the given path, and then return to the previous path.
+    """
+    try:
+        path = Path(path).resolve()
+        cwd = os.getcwd()
+        os.chdir(path)
+        yield path
+    finally:
+        os.chdir(cwd)

--- a/libcst/helpers/tests/test_paths.py
+++ b/libcst/helpers/tests/test_paths.py
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from pathlib import Path
 from tempfile import TemporaryDirectory
 

--- a/libcst/helpers/tests/test_paths.py
+++ b/libcst/helpers/tests/test_paths.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from libcst.helpers.paths import chdir
+from libcst.testing.utils import UnitTest
+
+
+class PathsTest(UnitTest):
+    def test_chdir(self) -> None:
+        with TemporaryDirectory() as td:
+            tdp = Path(td).resolve()
+            inner = tdp / "foo" / "bar"
+            inner.mkdir(parents=True)
+
+            with self.subTest("string paths"):
+                cwd1 = Path.cwd()
+
+                with chdir(tdp.as_posix()) as path2:
+                    cwd2 = Path.cwd()
+                    self.assertEqual(tdp, cwd2)
+                    self.assertEqual(tdp, path2)
+
+                    with chdir(inner.as_posix()) as path3:
+                        cwd3 = Path.cwd()
+                        self.assertEqual(inner, cwd3)
+                        self.assertEqual(inner, path3)
+
+                    cwd4 = Path.cwd()
+                    self.assertEqual(tdp, cwd4)
+                    self.assertEqual(cwd2, cwd4)
+
+                cwd5 = Path.cwd()
+                self.assertEqual(cwd1, cwd5)
+
+            with self.subTest("pathlib objects"):
+                cwd1 = Path.cwd()
+
+                with chdir(tdp) as path2:
+                    cwd2 = Path.cwd()
+                    self.assertEqual(tdp, cwd2)
+                    self.assertEqual(tdp, path2)
+
+                    with chdir(inner) as path3:
+                        cwd3 = Path.cwd()
+                        self.assertEqual(inner, cwd3)
+                        self.assertEqual(inner, path3)
+
+                    cwd4 = Path.cwd()
+                    self.assertEqual(tdp, cwd4)
+                    self.assertEqual(cwd2, cwd4)
+
+                cwd5 = Path.cwd()
+                self.assertEqual(cwd1, cwd5)

--- a/libcst/metadata/__init__.py
+++ b/libcst/metadata/__init__.py
@@ -16,6 +16,7 @@ from libcst.metadata.expression_context_provider import (
     ExpressionContext,
     ExpressionContextProvider,
 )
+from libcst.metadata.file_path_provider import FilePathProvider
 from libcst.metadata.full_repo_manager import FullRepoManager
 from libcst.metadata.name_provider import (
     FullyQualifiedNameProvider,
@@ -88,6 +89,7 @@ __all__ = [
     "TypeInferenceProvider",
     "FullRepoManager",
     "AccessorProvider",
+    "FilePathProvider",
     # Experimental APIs:
     "ExperimentalReentrantCodegenProvider",
     "CodegenPartial",

--- a/libcst/metadata/file_path_provider.py
+++ b/libcst/metadata/file_path_provider.py
@@ -14,9 +14,8 @@ class FilePathProvider(BatchableMetadataProvider[Collection[Path]]):
     """
     Provides the path to the current file on disk as metadata for the root
     :class:`~libcst.Module` node. Requires a :class:`~libcst.metadata.FullRepoManager`.
-    If an absolute path to the repo root is given, or file paths are absolute, then the
-    resulting metadata will contain absolute paths. Otherwise, the metadata will only
-    contain relative paths matching those given to the repo manager.
+    The returned path will always be resolved to an absolute path using
+    :func:`pathlib.Path.resolve`.
 
     Example usage:
 
@@ -36,7 +35,7 @@ class FilePathProvider(BatchableMetadataProvider[Collection[Path]]):
         >>> wrapper = mgr.get_metadata_wrapper_for_path("libcst/_types.py")
         >>> fqnames = wrapper.resolve(FilePathProvider)
         >>> {type(k): v for k, v in wrapper.resolve(FilePathProvider).items()}
-        {<class 'libcst._nodes.module.Module'>: PosixPath('libcst/_types.py')}
+        {<class 'libcst._nodes.module.Module'>: PosixPath('/home/user/libcst/_types.py')}
 
     """
 
@@ -44,7 +43,7 @@ class FilePathProvider(BatchableMetadataProvider[Collection[Path]]):
     def gen_cache(
         cls, root_path: Path, paths: List[str], timeout: Optional[int] = None
     ) -> Mapping[str, Path]:
-        cache = {path: root_path / path for path in paths}
+        cache = {path: (root_path / path).resolve() for path in paths}
         return cache
 
     def __init__(self, cache: Path) -> None:

--- a/libcst/metadata/file_path_provider.py
+++ b/libcst/metadata/file_path_provider.py
@@ -1,0 +1,56 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from pathlib import Path
+from typing import Collection, List, Mapping, Optional
+
+import libcst as cst
+from libcst.metadata.base_provider import BatchableMetadataProvider
+
+
+class FilePathProvider(BatchableMetadataProvider[Collection[Path]]):
+    """
+    Provides the path to the current file on disk as metadata for the root
+    :class:`~libcst.Module` node. Requires a :class:`~libcst.metadata.FullRepoManager`.
+    If an absolute path to the repo root is given, or file paths are absolute, then the
+    resulting metadata will contain absolute paths. Otherwise, the metadata will only
+    contain relative paths matching those given to the repo manager.
+
+    Example usage:
+
+    .. code:: python
+
+        class CustomVisitor(CSTVisitor):
+            METADATA_DEPENDENCIES = [FilePathProvider]
+
+            path: pathlib.Path
+
+            def visit_Module(self, node: libcst.Module) -> None:
+                self.path = self.get_metadata(FilePathProvider, node)
+
+    .. code::
+
+        >>> mgr = FullRepoManager(".", {"libcst/_types.py"}, {FilePathProvider})
+        >>> wrapper = mgr.get_metadata_wrapper_for_path("libcst/_types.py")
+        >>> fqnames = wrapper.resolve(FilePathProvider)
+        >>> {type(k): v for k, v in wrapper.resolve(FilePathProvider).items()}
+        {<class 'libcst._nodes.module.Module'>: PosixPath('libcst/_types.py')}
+
+    """
+
+    @classmethod
+    def gen_cache(
+        cls, root_path: Path, paths: List[str], timeout: Optional[int] = None
+    ) -> Mapping[str, Path]:
+        cache = {path: root_path / path for path in paths}
+        return cache
+
+    def __init__(self, cache: Path) -> None:
+        super().__init__(cache)
+        self.path: Path = cache
+
+    def visit_Module(self, node: cst.Module) -> Optional[bool]:
+        self.set_metadata(node, self.path)
+        return False

--- a/libcst/metadata/tests/test_file_path_provider.py
+++ b/libcst/metadata/tests/test_file_path_provider.py
@@ -1,0 +1,105 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Set
+
+import libcst
+from libcst._visitors import CSTVisitor
+from libcst.metadata import FilePathProvider, FullRepoManager, MetadataWrapper
+from libcst.testing.utils import UnitTest
+
+
+class FilePathProviderTest(UnitTest):
+    def setUp(self) -> None:
+        self.td = TemporaryDirectory()
+        self.tdp = Path(self.td.name).resolve()
+        self.addCleanup(self.td.cleanup)
+
+    def test_provider_cache(self) -> None:
+        pkg = self.tdp / "pkg"
+        pkg.mkdir()
+        files = [Path(pkg / name) for name in ("file1.py", "file2.py", "file3.py")]
+        [file.write_text("print('hello')\n") for file in files]
+
+        with self.subTest("absolute paths"):
+            repo_manager = FullRepoManager(
+                self.tdp, [f.as_posix() for f in files], {FilePathProvider}
+            )
+            repo_manager.resolve_cache()
+
+            expected = {
+                FilePathProvider: {f.as_posix(): f for f in files},
+            }
+            self.assertDictEqual(expected, repo_manager.cache)
+
+        with self.subTest("relative paths"):
+            repo_manager = FullRepoManager(
+                self.tdp,
+                [f.relative_to(self.tdp).as_posix() for f in files],
+                {FilePathProvider},
+            )
+            repo_manager.resolve_cache()
+
+            expected = {
+                FilePathProvider: {
+                    f.relative_to(self.tdp).as_posix(): f for f in files
+                },
+            }
+            self.assertDictEqual(expected, repo_manager.cache)
+
+    def test_visitor(self) -> None:
+        pkg = self.tdp / "pkg"
+        pkg.mkdir()
+        files = [Path(pkg / name) for name in ("file1.py", "file2.py", "file3.py")]
+        [file.write_text("print('hello')\n") for file in files]
+
+        seen: Set[Path] = set()
+
+        class FakeVisitor(CSTVisitor):
+            METADATA_DEPENDENCIES = [FilePathProvider]
+
+            def visit_Module(self, node: libcst.Module) -> None:
+                seen.add(self.get_metadata(FilePathProvider, node))
+
+        with self.subTest("absolute paths"):
+            seen.clear()
+            repo_manager = FullRepoManager(
+                self.tdp, [f.as_posix() for f in files], {FilePathProvider}
+            )
+            repo_manager.resolve_cache()
+
+            for file in files:
+                module = libcst.parse_module(file.read_bytes())
+                wrapper = MetadataWrapper(
+                    module, cache=repo_manager.get_cache_for_path(file.as_posix())
+                )
+                wrapper.visit(FakeVisitor())
+
+            expected = set(files)
+            self.assertSetEqual(expected, seen)
+
+        with self.subTest("relative paths"):
+            seen.clear()
+            repo_manager = FullRepoManager(
+                self.tdp,
+                [f.relative_to(self.tdp).as_posix() for f in files],
+                {FilePathProvider},
+            )
+            repo_manager.resolve_cache()
+
+            for file in files:
+                module = libcst.parse_module(file.read_bytes())
+                wrapper = MetadataWrapper(
+                    module,
+                    cache=repo_manager.get_cache_for_path(
+                        file.relative_to(self.tdp).as_posix()
+                    ),
+                )
+                wrapper.visit(FakeVisitor())
+
+            expected = set(files)
+            self.assertSetEqual(expected, seen)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #892

Caches file path information on the root `Module` node.
Resolves paths when caching, so they are always absolute paths.

Adds a new `chdir` helper to change working directory and automatically
revert to previous directory, which makes testing file paths with the
`"."` repo root easier.