### PR TITLE
Fix: relative imports from '' package are not allowed

### DIFF
--- a/libcst/helpers/module.py
+++ b/libcst/helpers/module.py
@@ -90,7 +90,7 @@ def get_absolute_module_from_package(
     if num_dots == 0:
         # This is an absolute import, so the module is correct.
         return module_name
-    if current_package is None:
+    if current_package is None or current_package == "":
         # We don't actually have the current module available, so we can't compute
         # the absolute module from relative.
         return None

--- a/libcst/helpers/tests/test_module.py
+++ b/libcst/helpers/tests/test_module.py
@@ -115,6 +115,9 @@ class ModuleTest(UnitTest):
             ("x/y/z/__init__.py", "from a.b import c", "a.b"),
             # Relative import that can't be resolved due to missing module.
             (None, "from ..w import c", None),
+            # Attempted relative import with no known parent package
+            ("__init__.py", "from .y import z", None),
+            ("x.py", "from .y import z", None),
             # Relative import that goes past the module level.
             ("x.py", "from ...y import z", None),
             ("x/y/z.py", "from ... import c", None),


### PR DESCRIPTION
## Summary
When we resolve a relative import from root package "", we get the import prefixed by "."
However, this kind of imports are not allowed and cpython throws an error:
```
/Users/michaelpo/PycharmProjects/pythonProject/venv/bin/python /Users/michaelpo/PycharmProjects/pythonProject/main.py 
Traceback (most recent call last):
  File "/Users/michaelpo/PycharmProjects/pythonProject/main.py", line 2, in <module>
    from .l1 import l1_func
ImportError: attempted relative import with no known parent package

Process finished with exit code 1
```

## Test Plan
Unit tests
