### PR TITLE
Ensure current Python interpreter is used for subprocesses

### DIFF
--- a/libcst/codegen/generate.py
+++ b/libcst/codegen/generate.py
@@ -69,7 +69,7 @@ def codegen_visitors() -> None:
         # Now, see if the file we generated causes any import errors
         # by attempting to run codegen again in a new process.
         subprocess.check_call(
-            ["python3", "-m", "libcst.codegen.gen_visitor_functions"],
+            [sys.executable, "-m", "libcst.codegen.gen_visitor_functions"],
             cwd=base,
             stdout=subprocess.DEVNULL,
         )

--- a/libcst/codemod/tests/test_codemod_cli.py
+++ b/libcst/codemod/tests/test_codemod_cli.py
@@ -7,6 +7,7 @@
 
 import platform
 import subprocess
+import sys
 from pathlib import Path
 from unittest import skipIf
 
@@ -20,7 +21,7 @@ class TestCodemodCLI(UnitTest):
     def test_codemod_formatter_error_input(self) -> None:
         rlt = subprocess.run(
             [
-                "python",
+                sys.executable,
                 "-m",
                 "libcst.tool",
                 "codemod",


### PR DESCRIPTION
One spot used `python`, the other used `python3` – `sys.executable` is known to be correct.