### PR TITLE
Fix spelling and grammar in some comments

### DIFF
--- a/libcst/codemod/commands/convert_type_comments.py
+++ b/libcst/codemod/commands/convert_type_comments.py
@@ -706,7 +706,7 @@ class ConvertTypeComments(VisitorBasedCodemodCommand):
     #     able to extract type information. This is done via mutable state and the
     #     usual visitor pattern.
     # (B) we also manually reach down to the first statement inside of the
-    #     funciton body and aggressively strip type comments from leading
+    #     function body and aggressively strip type comments from leading
     #     whitespaces
     #
     # PEP 484 underspecifies how to apply type comments to (non-static)

--- a/libcst/codemod/commands/convert_type_comments.py
+++ b/libcst/codemod/commands/convert_type_comments.py
@@ -786,7 +786,7 @@ class ConvertTypeComments(VisitorBasedCodemodCommand):
         self,
         node: cst.FunctionDef,
     ) -> None:
-        "Turn off aggressive type comment removal when we've leaved the header."
+        "Turn off aggressive type comment removal when we've left the header."
         self.aggressively_strip_type_comments = False
 
     def leave_IndentedBlock(


### PR DESCRIPTION
I found this when I was looking at what tooling I could adapt to understanding `dmypy suggest` outputs (which look a lot like type comments!)

