### PR TITLE
skip escaped backslash in rf-string

### DIFF
--- a/native/libcst/src/tokenizer/core/mod.rs
+++ b/native/libcst/src/tokenizer/core/mod.rs
@@ -973,8 +973,8 @@ impl<'t> TokState<'t> {
                 }
                 (Some('\\'), _) if is_raw_string => {
                     self.text_pos.next();
-                    if let Some('"' | '\'') = self.text_pos.peek() {
-                        // these aren't end of string markers, skip them
+                    // skip escaped end-of-string marker or backslash
+                    if let Some('"' | '\'' | '\\') = self.text_pos.peek() {
                         self.text_pos.next();
                     }
                 }

--- a/native/libcst/src/tokenizer/tests.rs
+++ b/native/libcst/src/tokenizer/tests.rs
@@ -529,6 +529,10 @@ fn test_string_prefix() {
         tokenize_all(r#"r"\"""#, &default_config()),
         Ok(vec![(TokType::String, r#"r"\"""#)]),
     );
+    assert_eq!(
+        tokenize_all(r#"r'\\'"#, &default_config()),
+        Ok(vec![(TokType::String, r#"r'\\'"#)]),
+    );
     let config = TokConfig {
         split_fstring: true,
         ..default_config()
@@ -547,6 +551,14 @@ fn test_string_prefix() {
             (TokType::FStringStart, "rf\""),
             (TokType::FStringString, r#"\""#),
             (TokType::FStringEnd, "\""),
+        ]),
+    );
+    assert_eq!(
+        tokenize_all(r#"rf'\\'"#, &config),
+        Ok(vec![
+            (TokType::FStringStart, "rf'"),
+            (TokType::FStringString, r#"\\"#),
+            (TokType::FStringEnd, "'"),
         ]),
     );
 }


### PR DESCRIPTION
## Summary
Fixes #917 
## Test Plan
Added the failing test case from #917, as well as one for a normal raw string to make sure behavior is consistent.