### PR TITLE
Switch default parser implementation to native

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,11 @@ jobs:
           working-directory: native
       - name: Build LibCST
         run: hatch env create
-      - name: Pure Tests
+      - name: Tests
         run: hatch run test
-      - name: Native Tests
+      - name: Pure Parser Tests
         env:
-          LIBCST_PARSER_TYPE: ${{ matrix.parser }}
+          LIBCST_PARSER_TYPE: pure
         run: hatch run test
 
   # Run linters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 1.0.0 - 2023-05-25
+
+The first major release of LibCST is essentially the same as 0.4.10, but using the
+newer, Rust-based parser implementation by default. The old, pure Python parser is
+scheduled for removal in the next (non-patch) release. Until then, it is available with
+the `LIBCST_PARSER_TYPE` environment variable set to `pure`.
+
+## Updated
+
+* Switch the default parser implementation to native by @zsol in https://github.com/Instagram/LibCST/pull/929
+
 # 0.4.10 - 2023-05-23
 
 ## New Contributors

--- a/libcst/_parser/entrypoints.py
+++ b/libcst/_parser/entrypoints.py
@@ -27,7 +27,7 @@ _DEFAULT_PARTIAL_PARSER_CONFIG: PartialParserConfig = PartialParserConfig()
 
 def is_native() -> bool:
     typ = os.environ.get("LIBCST_PARSER_TYPE")
-    return typ == "native"
+    return typ != "pure"
 
 
 def _parse(

--- a/native/libcst/README.md
+++ b/native/libcst/README.md
@@ -3,9 +3,8 @@
 A native extension to enable parsing of new Python grammar in LibCST.
 
 The extension is written in Rust, and exposed to Python using [PyO3](https://pyo3.rs/).
-This is packaged together with libcst, and can be imported from `libcst.native`. When
-the `LIBCST_PARSER_TYPE` environment variable is set to `native`, the LibCST APIs use
-this module for all parsing.
+This is packaged together with libcst, and can be imported from `libcst.native`. By default
+the LibCST APIs use this module for all parsing.
 
 Later on, the parser library might be packaged separately as 
 [a Rust crate](https://crates.io). Pull requests towards this are much appreciated.


### PR DESCRIPTION
The old parser is now only available using LIBCST_PARSER_TYPE=pure


