### PR TITLE
remove quotes around charset in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 root = true
 
 [*.{py,pyi,rs,toml,md}]
-charset = "utf-8"
+charset = utf-8
 end_of_line = lf
 indent_size = 4
 indent_style = space


### PR DESCRIPTION
## Summary
Neovim keeps throwing an error of being unable to parse `charset`, and upon checking https://editorconfig.org/ it indeed does seem correct not to have quotes around the value.
