### PR TITLE
codemod/rename: Avoid duplicating import statements when the module name doesn't change

### DIFF
--- a/libcst/codemod/commands/rename.py
+++ b/libcst/codemod/commands/rename.py
@@ -128,28 +128,26 @@ class RenameCommand(VisitorBasedCodemodCommand):
             ):
                 # Might, be in use elsewhere in the code, so schedule a potential removal, and add another alias.
                 new_names.append(import_alias)
-                self.scheduled_removals.add(original_node)
-                new_names.append(
-                    cst.ImportAlias(
-                        name=cst.Name(
-                            value=self.gen_replacement_module(import_alias_full_name)
-                        )
-                    )
-                )
+                replacement_module = self.gen_replacement_module(import_alias_full_name)
                 self.bypass_import = True
+                if replacement_module != import_alias_name.value:
+                    self.scheduled_removals.add(original_node)
+                    new_names.append(
+                        cst.ImportAlias(name=cst.Name(value=replacement_module))
+                    )
             elif isinstance(
                 import_alias_name, cst.Attribute
             ) and self.old_name.startswith(import_alias_full_name + "."):
                 # Same idea as above.
                 new_names.append(import_alias)
-                self.scheduled_removals.add(original_node)
-                new_name_node: Union[
-                    cst.Attribute, cst.Name
-                ] = self.gen_name_or_attr_node(
-                    self.gen_replacement_module(import_alias_full_name)
-                )
-                new_names.append(cst.ImportAlias(name=new_name_node))
+                replacement_module = self.gen_replacement_module(import_alias_full_name)
                 self.bypass_import = True
+                if replacement_module != import_alias_full_name:
+                    self.scheduled_removals.add(original_node)
+                    new_name_node: Union[
+                        cst.Attribute, cst.Name
+                    ] = self.gen_name_or_attr_node(replacement_module)
+                    new_names.append(cst.ImportAlias(name=new_name_node))
             else:
                 new_names.append(import_alias)
 

--- a/libcst/codemod/commands/tests/test_rename.py
+++ b/libcst/codemod/commands/tests/test_rename.py
@@ -275,6 +275,38 @@ class TestRenameCommand(CodemodTest):
             new_name="a.b.module_3.Class_3",
         )
 
+    def test_import_same_module(self) -> None:
+        before = """
+            import logging
+            logging.warn(1)
+        """
+        after = """
+            import logging
+            logging.warning(1)
+        """
+        self.assertCodemod(
+            before,
+            after,
+            old_name="logging.warn",
+            new_name="logging.warning",
+        )
+
+    def test_import_same_dotted_module(self) -> None:
+        before = """
+            import a.b
+            a.b.warn(1)
+        """
+        after = """
+            import a.b
+            a.b.warning(1)
+        """
+        self.assertCodemod(
+            before,
+            after,
+            old_name="a.b.warn",
+            new_name="a.b.warning",
+        )
+
     def test_rename_local_variable(self) -> None:
         before = """
             x = 5


### PR DESCRIPTION
## Summary

When renaming within the same module (i.e. `logging.warn -> logging.warning`), make sure the codemod doesn't insert an extra `import logging` statement.

## Test Plan

Added unit tests