### PR TITLE
Don't gather dirs ending .py

### DIFF
--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -90,7 +90,10 @@ def gather_files(
             ret.extend(
                 str(p)
                 for p in Path(fd).rglob("*.py*")
-                if str(p).endswith("py") or (include_stubs and str(p).endswith("pyi"))
+                if Path.is_file(p)
+                and (
+                    str(p).endswith("py") or (include_stubs and str(p).endswith("pyi"))
+                )
             )
     return sorted(ret)
 

--- a/libcst/tests/test_e2e.py
+++ b/libcst/tests/test_e2e.py
@@ -48,6 +48,9 @@ class ToolE2ETest(TestCase):
             # File that should not be modified
             other = tmp / "other.py"
             other.touch()
+            # Just a dir named "dir.py", should be ignored
+            adir = tmp / "dir.py"
+            adir.mkdir()
 
             # Run command
             command_instance = PrintToPPrintCommand(CodemodContext())


### PR DESCRIPTION
## Summary

`codemod.gather_files` should not try to gather dirs those names ending with .py, only regular files
(the issue encountered in an actual codebase).

## Test Plan

libcst/tests/test_e2e.py updated