### PR TITLE
AddImportsVisitor: add imports before the first non-import statement

### DIFF
--- a/libcst/codemod/visitors/_gather_imports.py
+++ b/libcst/codemod/visitors/_gather_imports.py
@@ -67,7 +67,9 @@ class GatherImportsVisitor(ContextAwareVisitor):
     def visit_Import(self, node: libcst.Import) -> None:
         # Track this import statement for later analysis.
         self.all_imports.append(node)
+        self._handle_Import(node)
 
+    def _handle_Import(self, node: libcst.Import) -> None:
         for name in node.names:
             alias = name.evaluated_alias
             imp = ImportItem(name.evaluated_name, alias=alias)
@@ -83,7 +85,9 @@ class GatherImportsVisitor(ContextAwareVisitor):
     def visit_ImportFrom(self, node: libcst.ImportFrom) -> None:
         # Track this import statement for later analysis.
         self.all_imports.append(node)
+        self._handle_ImportFrom(node)
 
+    def _handle_ImportFrom(self, node: libcst.ImportFrom) -> None:
         # Get the module we're importing as a string.
         module = get_absolute_module_from_package_for_import(
             self.context.full_package_name, node

--- a/libcst/codemod/visitors/_gather_imports.py
+++ b/libcst/codemod/visitors/_gather_imports.py
@@ -12,43 +12,9 @@ from libcst.codemod.visitors._imports import ImportItem
 from libcst.helpers import get_absolute_module_from_package_for_import
 
 
-class GatherImportsVisitor(ContextAwareVisitor):
+class _GatherImportsMixin(ContextAwareVisitor):
     """
-    Gathers all imports in a module and stores them as attributes on the instance.
-    Intended to be instantiated and passed to a :class:`~libcst.Module`
-    :meth:`~libcst.CSTNode.visit` method in order to gather up information about
-    imports on a module. Note that this is not a substitute for scope analysis or
-    qualified name support. Please see :ref:`libcst-scope-tutorial` for a more
-    robust way of determining the qualified name and definition for an arbitrary
-    node.
-
-    After visiting a module the following attributes will be populated:
-
-     module_imports
-      A sequence of strings representing modules that were imported directly, such as
-      in the case of ``import typing``. Each module directly imported but not aliased
-      will be included here.
-     object_mapping
-      A mapping of strings to sequences of strings representing modules where we
-      imported objects from, such as in the case of ``from typing import Optional``.
-      Each from import that was not aliased will be included here, where the keys of
-      the mapping are the module we are importing from, and the value is a
-      sequence of objects we are importing from the module.
-     module_aliases
-      A mapping of strings representing modules that were imported and aliased,
-      such as in the case of ``import typing as t``. Each module imported this
-      way will be represented as a key in this mapping, and the value will be
-      the local alias of the module.
-     alias_mapping
-      A mapping of strings to sequences of tuples representing modules where we
-      imported objects from and aliased using ``as`` syntax, such as in the case
-      of ``from typing import Optional as opt``. Each from import that was aliased
-      will be included here, where the keys of the mapping are the module we are
-      importing from, and the value is a tuple representing the original object
-      name and the alias.
-     all_imports
-      A collection of all :class:`~libcst.Import` and :class:`~libcst.ImportFrom`
-      statements that were encountered in the module.
+    A Mixin class for tracking visited imports.
     """
 
     def __init__(self, context: CodemodContext) -> None:
@@ -59,15 +25,8 @@ class GatherImportsVisitor(ContextAwareVisitor):
         # Track the aliased imports in this transform
         self.module_aliases: Dict[str, str] = {}
         self.alias_mapping: Dict[str, List[Tuple[str, str]]] = {}
-        # Track all of the imports found in this transform
-        self.all_imports: List[Union[libcst.Import, libcst.ImportFrom]] = []
         # Track the import for every symbol introduced into the module
         self.symbol_mapping: Dict[str, ImportItem] = {}
-
-    def visit_Import(self, node: libcst.Import) -> None:
-        # Track this import statement for later analysis.
-        self.all_imports.append(node)
-        self._handle_Import(node)
 
     def _handle_Import(self, node: libcst.Import) -> None:
         for name in node.names:
@@ -81,11 +40,6 @@ class GatherImportsVisitor(ContextAwareVisitor):
                 # Get the module we're importing as a string.
                 self.module_imports.add(name.evaluated_name)
                 self.symbol_mapping[name.evaluated_name] = imp
-
-    def visit_ImportFrom(self, node: libcst.ImportFrom) -> None:
-        # Track this import statement for later analysis.
-        self.all_imports.append(node)
-        self._handle_ImportFrom(node)
 
     def _handle_ImportFrom(self, node: libcst.ImportFrom) -> None:
         # Get the module we're importing as a string.
@@ -132,3 +86,58 @@ class GatherImportsVisitor(ContextAwareVisitor):
                 )
                 key = ia.evaluated_alias or ia.evaluated_name
                 self.symbol_mapping[key] = imp
+
+
+class GatherImportsVisitor(_GatherImportsMixin):
+    """
+    Gathers all imports in a module and stores them as attributes on the instance.
+    Intended to be instantiated and passed to a :class:`~libcst.Module`
+    :meth:`~libcst.CSTNode.visit` method in order to gather up information about
+    imports on a module. Note that this is not a substitute for scope analysis or
+    qualified name support. Please see :ref:`libcst-scope-tutorial` for a more
+    robust way of determining the qualified name and definition for an arbitrary
+    node.
+
+    After visiting a module the following attributes will be populated:
+
+     module_imports
+      A sequence of strings representing modules that were imported directly, such as
+      in the case of ``import typing``. Each module directly imported but not aliased
+      will be included here.
+     object_mapping
+      A mapping of strings to sequences of strings representing modules where we
+      imported objects from, such as in the case of ``from typing import Optional``.
+      Each from import that was not aliased will be included here, where the keys of
+      the mapping are the module we are importing from, and the value is a
+      sequence of objects we are importing from the module.
+     module_aliases
+      A mapping of strings representing modules that were imported and aliased,
+      such as in the case of ``import typing as t``. Each module imported this
+      way will be represented as a key in this mapping, and the value will be
+      the local alias of the module.
+     alias_mapping
+      A mapping of strings to sequences of tuples representing modules where we
+      imported objects from and aliased using ``as`` syntax, such as in the case
+      of ``from typing import Optional as opt``. Each from import that was aliased
+      will be included here, where the keys of the mapping are the module we are
+      importing from, and the value is a tuple representing the original object
+      name and the alias.
+     all_imports
+      A collection of all :class:`~libcst.Import` and :class:`~libcst.ImportFrom`
+      statements that were encountered in the module.
+    """
+
+    def __init__(self, context: CodemodContext) -> None:
+        super().__init__(context)
+        # Track all of the imports found in this transform
+        self.all_imports: List[Union[libcst.Import, libcst.ImportFrom]] = []
+
+    def visit_Import(self, node: libcst.Import) -> None:
+        # Track this import statement for later analysis.
+        self.all_imports.append(node)
+        self._handle_Import(node)
+
+    def visit_ImportFrom(self, node: libcst.ImportFrom) -> None:
+        # Track this import statement for later analysis.
+        self.all_imports.append(node)
+        self._handle_ImportFrom(node)

--- a/libcst/codemod/visitors/tests/test_add_imports.py
+++ b/libcst/codemod/visitors/tests/test_add_imports.py
@@ -974,3 +974,55 @@ class TestAddImportsCodemod(CodemodTest):
         """
 
         self.assertCodemod(before, after, [ImportItem("c", None, None)])
+
+    def test_do_not_add_existing(self) -> None:
+        """
+        Should not add the new object import at existing import since it's not at the top
+        """
+
+        before = """
+            '''docstring'''
+            e()
+            import a
+            import b
+            from c import f
+        """
+
+        after = """
+            '''docstring'''
+            from c import e
+
+            e()
+            import a
+            import b
+            from c import f
+        """
+
+        self.assertCodemod(before, after, [ImportItem("c", "e", None)])
+
+    def test_add_existing_at_top(self) -> None:
+        """
+        Should add new import at exisitng from import at top
+        """
+
+        before = """
+            '''docstring'''
+            from c import d
+            e()
+            import a
+            import b
+            from c import f
+        """
+
+        after = """
+            '''docstring'''
+            from c import e, x, d
+            e()
+            import a
+            import b
+            from c import f
+        """
+
+        self.assertCodemod(
+            before, after, [ImportItem("c", "x", None), ImportItem("c", "e", None)]
+        )

--- a/libcst/codemod/visitors/tests/test_add_imports.py
+++ b/libcst/codemod/visitors/tests/test_add_imports.py
@@ -923,3 +923,54 @@ class TestAddImportsCodemod(CodemodTest):
                 full_module_name="a.b.foobar", full_package_name="a.b"
             ),
         )
+
+    def test_add_at_first_block(self) -> None:
+        """
+        Should add the import only at the end of the first import block.
+        """
+
+        before = """
+            import a
+            import b
+
+            e()
+
+            import c
+            import d
+        """
+
+        after = """
+            import a
+            import b
+            import e
+
+            e()
+
+            import c
+            import d
+        """
+
+        self.assertCodemod(before, after, [ImportItem("e", None, None)])
+
+    def test_add_no_import_block_before_statement(self) -> None:
+        """
+        Should add the import before the call.
+        """
+
+        before = """
+            '''docstring'''
+            e()
+            import a
+            import b
+        """
+
+        after = """
+            '''docstring'''
+            import c
+
+            e()
+            import a
+            import b
+        """
+
+        self.assertCodemod(before, after, [ImportItem("c", None, None)])


### PR DESCRIPTION
## Summary
Proposed fix for #1023. It changes `AddImportsVisitor` so it only considers adding new imports after/at the first import block before any other statements, if any.

## Test Plan
Added a few tests to `test_add_imports.py`

