### PR TITLE
fix filepathprovider generic type

### DIFF
--- a/libcst/metadata/file_path_provider.py
+++ b/libcst/metadata/file_path_provider.py
@@ -10,7 +10,7 @@ import libcst as cst
 from libcst.metadata.base_provider import BatchableMetadataProvider
 
 
-class FilePathProvider(BatchableMetadataProvider[Collection[Path]]):
+class FilePathProvider(BatchableMetadataProvider[Path]):
     """
     Provides the path to the current file on disk as metadata for the root
     :class:`~libcst.Module` node. Requires a :class:`~libcst.metadata.FullRepoManager`.

--- a/libcst/metadata/file_path_provider.py
+++ b/libcst/metadata/file_path_provider.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from pathlib import Path
-from typing import Collection, List, Mapping, Optional
+from typing import List, Mapping, Optional
 
 import libcst as cst
 from libcst.metadata.base_provider import BatchableMetadataProvider


### PR DESCRIPTION
## Summary

The file path provider claims it provides a [collection of paths](https://github.com/Instagram/LibCST/blob/7ca5d7f1736c38b27dcdd41243343f2e2b5e1eb1/libcst/metadata/file_path_provider.py#L13) but in reality it provides a [single path](https://github.com/Instagram/LibCST/blob/7ca5d7f1736c38b27dcdd41243343f2e2b5e1eb1/libcst/metadata/file_path_provider.py#L45). This is a hole because gen_cache doesn't have great type annotations: [example](https://github.com/Instagram/LibCST/blob/7cb229d175b79cbf392a34ecb58e79686c73a82d/libcst/metadata/base_provider.py#L62).

## Test Plan
CI
