### PR TITLE
Update pyproject.toml for Python 3.12 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel", "setuptools-rust"]
 
 [project]
 name = "libcst"
-description = "A concrete syntax tree with AST-like properties for Python 3.8, 3.9, 3.10, 3.11, and 3.12 programs."
+description = "A concrete syntax tree with AST-like properties for Python 3.0 through 3.12 programs."
 readme = "README.rst"
 dynamic = ["version"]
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel", "setuptools-rust"]
 
 [project]
 name = "libcst"
-description = "A concrete syntax tree with AST-like properties for Python 3.5, 3.6, 3.7, 3.8, 3.9, and 3.10 programs."
+description = "A concrete syntax tree with AST-like properties for Python 3.8, 3.9, 3.10, 3.11, and 3.12 programs."
 readme = "README.rst"
 dynamic = ["version"]
 license = { file = "LICENSE" }
@@ -14,6 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 requires-python = ">=3.8"
 dependencies = [


### PR DESCRIPTION
Add 3.12 classifier and update description to correctly reflect supported Python versions
