### PR TITLE
Replace distutils.spawn.find_executable with shutil.which to support setuptools-less environments

### DIFF
--- a/libcst/tool.py
+++ b/libcst/tool.py
@@ -10,11 +10,11 @@
 
 import argparse
 import dataclasses
-import distutils.spawn
 import importlib
 import inspect
 import os
 import os.path
+import shutil
 import sys
 import textwrap
 from abc import ABC, abstractmethod
@@ -376,7 +376,7 @@ def _find_and_load_config(proc_name: str) -> Dict[str, Any]:
     # Make sure that the formatter is findable.
     if config["formatter"]:
         exe = (
-            distutils.spawn.find_executable(config["formatter"][0])
+            shutil.which(config["formatter"][0])
             or config["formatter"][0]
         )
         config["formatter"] = [os.path.abspath(exe), *config["formatter"][1:]]


### PR DESCRIPTION
## Summary

One of the changes that came with Python 3.12 is that `setuptools` is not installed in a new virtual environment anymore (change introduced in https://github.com/python/cpython/issues/95299). This means that `distutils` which was also removed in 3.12, can not be imported. To reproduce:

```sh
$ python3.12 -m venv tst
$ source tst/bin/activate
$ pip install libcst
$ python -m libcst.tool -h
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/tmp/tst/lib64/python3.12/site-packages/libcst/tool.py", line 13, in <module>
    import distutils.spawn
ModuleNotFoundError: No module named 'distutils'
```
The proposed changes replace the single usage of `distutils`, namely `distutils.spawn.find_executable`, with `shutil.which` that does the same thing.

An alternative could be making `setuptools` a runtime dependency, but IMO it is an overkill just for the single function access.

## Test Plan

Not sure about this - should I add tests for the cli tool itself? Looks like the affected code isn't tested yet, and `setuptools` is pulled by `setuptools-rust` in the development environment automatically so `distutils` is always available in the test run. Although I think it can be circumvented by monkeypatching certain imports in selected tests.