### PR TITLE
Fix bug in MatchMapping class

### DIFF
--- a/libcst/_nodes/statement.py
+++ b/libcst/_nodes/statement.py
@@ -3239,7 +3239,7 @@ class MatchMapping(MatchPattern):
     rpar: Sequence[RightParen] = ()
 
     def _validate(self) -> None:
-        if isinstance(self.trailing_comma, Comma) and self.rest is not None:
+        if isinstance(self.trailing_comma, Comma) and self.rest is None:
             raise CSTValidationError("Cannot have a trailing comma without **rest")
         super(MatchMapping, self)._validate()
 


### PR DESCRIPTION
This pull request fixes a bug in the MatchMapping class where a trailing comma was allowed without the presence of the **rest parameter. The bug was causing an error in the validation process. This PR ensures that a trailing comma is only allowed when the **rest parameter is present.

Reproduction:
```py
import libcst as cst


cst.parse_module(r"""
match x:
    case {
        "a": a,
        **rest,
    }:
        print(a)
""")

```