### PR TITLE
Allow `Element::codegen` to be used by external users

### DIFF
--- a/native/libcst/src/nodes/expression.rs
+++ b/native/libcst/src/nodes/expression.rs
@@ -937,7 +937,7 @@ pub enum Element<'a> {
 }
 
 impl<'a> Element<'a> {
-    fn codegen(
+    pub fn codegen(
         &self,
         state: &mut CodegenState<'a>,
         default_comma: bool,


### PR DESCRIPTION
The `Codegen` trait is `pub`, but users wanting to explicitly perform codegen for `Element` had to copy-paste this part of the code.

(See also D52275507.)

