### PR TITLE
ci: update rust toolchain GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,7 @@ jobs:
       - name: Install hatch
         run: |
           pip install -U hatch
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.7.0
         with:
@@ -138,9 +136,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: rustfmt, clippy
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.7.0
@@ -179,11 +176,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
+          components: rustfmt
       - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
ci: update rust toolchain GHA

`actions-rs` is unmaintained
