### PR TITLE
installing rustc/cargo for mybinder demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ libcst/_version.py
 target/
 venv/
 .venv/
+.idea/

--- a/apt.txt
+++ b/apt.txt
@@ -1,0 +1,2 @@
+rustc
+cargo


### PR DESCRIPTION


## Summary

when we switch to the rust compiler by default, mybinder stop working, as reported in https://github.com/Instagram/LibCST/issues/1054 this is because the binder docker image does not have a rust compiler or tools, this install them by using the apt.txt file


## Test Plan

if you go to https://mybinder.org/v2/gh/aleivag/LibCST/fix-binder?filepath=docs/source/tutorial.ipynb you'll see this works

