### PR TITLE
ci: use separate artifact names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,4 +57,4 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: wheelhouse/*.whl
-          name: wheels
+          name: wheels-${{matrix.os}}-${{matrix.vers}}

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -24,8 +24,9 @@ jobs:
         id: download
         uses: actions/download-artifact@v4
         with:
-          name: wheels
+          pattern: wheels-*
           path: wheelhouse
+          merge-multiple: true
       - uses: actions/setup-python@v5
         with:
           cache: pip


### PR DESCRIPTION
v4 of upload-artifacts have changed its behavior: artifacts can no longer be mutated after they're uploaded.
This PR creates a separate artifact per build job

