### PR TITLE
Upgrade rust to version 1.70 in readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ build:
   os: ubuntu-20.04
   tools:
     python: "3"
-    rust: "1.55"
+    rust: "1.70"
   apt_packages:
     - graphviz
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools-rust"]
+requires = ["setuptools", "setuptools-scm", "setuptools-rust", "wheel"]
 
 [project]
 name = "libcst"


### PR DESCRIPTION
## Summary

Readthedocs builds are currently failing because the libcst wheel fails
to build, hitting an error when trying to get rust dependencies:

```
running build_rust
  Updating crates.io index
error: failed to select a version for the requirement `regex = "=1.9.3"`
candidate versions found which didn't match: 1.8.4, 1.8.3, 1.8.2, ...
location searched: crates.io index
required by package `libcst v1.1.0 (/home/docs/checkouts/readthedocs.org/user_builds/libcst/checkouts/latest/native/libcst)`
error: `cargo metadata --manifest-path native/libcst/Cargo.toml --format-version 1` failed with code 101
```

Assuming this is related to current configuration requesting rust v1.55,
rather than 1.70 that is currently offered.

## Test Plan

Look at CI builds on RTD
