### PR TITLE
Make readme example use python syntax highlighting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,9 @@ Example expression::
 
     1 + 2
 
-CST representation::
+CST representation:
+
+.. code-block:: python
 
     BinaryOperation(
         left=Integer(


### PR DESCRIPTION
## Summary

Marks the readme example as python code.

## Test Plan

Preview docs: https://github.com/Instagram/LibCST/blob/dfdd82756fa7785c13c1a1920c303dac30459fbd/README.rst