### PR TITLE
Fix parsing list matchers without explicit brackets

### DIFF
--- a/libcst/_nodes/statement.py
+++ b/libcst/_nodes/statement.py
@@ -3071,10 +3071,10 @@ class MatchList(MatchSequence):
     patterns: Sequence[Union[MatchSequenceElement, MatchStar]]
 
     #: An optional left bracket. If missing, this is an open sequence pattern.
-    lbracket: Optional[LeftSquareBracket] = LeftSquareBracket.field()
+    lbracket: Optional[LeftSquareBracket] = None
 
     #: An optional left bracket. If missing, this is an open sequence pattern.
-    rbracket: Optional[RightSquareBracket] = RightSquareBracket.field()
+    rbracket: Optional[RightSquareBracket] = None
 
     #: Parenthesis at the beginning of the node
     lpar: Sequence[LeftParen] = ()

--- a/native/libcst/tests/fixtures/malicious_match.py
+++ b/native/libcst/tests/fixtures/malicious_match.py
@@ -36,4 +36,5 @@ match x:
     case Foo  |    Bar |  (  Baz):  pass
     case x,y  ,  * more   :pass
     case y.z: pass
+    case 1, 2: pass
 


### PR DESCRIPTION
Fix parsing list matchers without explicit brackets


```
match a:
  case 1, 2: pass
```

This is parsed correctly by the grammar, but the default values of `MatchList.lbracket` and `MatchList.rbracket` are inconsistent between Python and Rust, causing the above snippet to round-trip (from Python) to:
```
match a:
  case [1, 2]: pass
```

Fixes #1096.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Instagram/LibCST/pull/1097).
* #1098
* __->__ #1097