### PR TITLE
Add roundtrip tests from Python

### DIFF
--- a/libcst/_nodes/statement.py
+++ b/libcst/_nodes/statement.py
@@ -3071,10 +3071,10 @@ class MatchList(MatchSequence):
     patterns: Sequence[Union[MatchSequenceElement, MatchStar]]
 
     #: An optional left bracket. If missing, this is an open sequence pattern.
-    lbracket: Optional[LeftSquareBracket] = LeftSquareBracket.field()
+    lbracket: Optional[LeftSquareBracket] = None
 
     #: An optional left bracket. If missing, this is an open sequence pattern.
-    rbracket: Optional[RightSquareBracket] = RightSquareBracket.field()
+    rbracket: Optional[RightSquareBracket] = None
 
     #: Parenthesis at the beginning of the node
     lpar: Sequence[LeftParen] = ()

--- a/libcst/tests/test_roundtrip.py
+++ b/libcst/tests/test_roundtrip.py
@@ -1,0 +1,26 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from pathlib import Path
+from unittest import TestCase
+
+from libcst import parse_module
+from libcst._parser.entrypoints import is_native
+
+fixtures: Path = Path(__file__).parent.parent.parent / "native/libcst/tests/fixtures"
+
+
+class RoundTripTests(TestCase):
+    def test_clean_roundtrip(self) -> None:
+        if not is_native():
+            self.skipTest("pure python parser doesn't work with this")
+        self.assertTrue(fixtures.exists(), f"{fixtures} should exist")
+        files = list(fixtures.iterdir())
+        self.assertGreater(len(files), 0)
+        for file in files:
+            with self.subTest(file=str(file)):
+                src = file.read_text(encoding="utf-8")
+                mod = parse_module(src)
+                self.assertEqual(mod.code, src)

--- a/native/libcst/tests/fixtures/malicious_match.py
+++ b/native/libcst/tests/fixtures/malicious_match.py
@@ -36,4 +36,5 @@ match x:
     case Foo  |    Bar |  (  Baz):  pass
     case x,y  ,  * more   :pass
     case y.z: pass
+    case 1, 2: pass
 


### PR DESCRIPTION
Add roundtrip tests from Python





Our current roundtrip tests only excerise the Rust codepaths. This PR runs the same roundtrip scenarios but from Python.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Instagram/LibCST/pull/1098).
* __->__ #1098
* #1097