### PR TITLE
Remove reference to distutils

### DIFF
--- a/libcst/tool.py
+++ b/libcst/tool.py
@@ -10,11 +10,11 @@
 
 import argparse
 import dataclasses
-import distutils.spawn
 import importlib
 import inspect
 import os
 import os.path
+import shutil
 import sys
 import textwrap
 from abc import ABC, abstractmethod
@@ -375,10 +375,7 @@ def _find_and_load_config(proc_name: str) -> Dict[str, Any]:
 
     # Make sure that the formatter is findable.
     if config["formatter"]:
-        exe = (
-            distutils.spawn.find_executable(config["formatter"][0])
-            or config["formatter"][0]
-        )
+        exe = shutil.which(config["formatter"][0]) or config["formatter"][0]
         config["formatter"] = [os.path.abspath(exe), *config["formatter"][1:]]
 
     return config


### PR DESCRIPTION
Remove reference to distutils


Distutils has been removed in Python 3.12.

Tested by:
```
py -m libcst.tool codemod noop.NOOPCommand .\libcst\tool.py
Calculating full-repo metadata...
Executing codemod...
Finished codemodding 1 files!
 - Transformed 1 files successfully.
 - Skipped 0 files.
 - Failed to codemod 0 files.
 - 0 warnings were generated.
```

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Instagram/LibCST/pull/1099).
* #1100
* __->__ #1099