### PR TITLE
ci: upgrade to cibuildwheel 2.16.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
         run: >-
           echo LIBCST_NO_LOCAL_SCHEME=1 >> $GITHUB_ENV
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.16.5
       - uses: actions/upload-artifact@v4
         with:
           path: wheelhouse/*.whl


### PR DESCRIPTION
ci: upgrade to cibuildwheel 2.16.5

This fixes wheel build failures on Windows.
