### PR TITLE
fix: __all__ references are not ignored

### DIFF
--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -958,7 +958,7 @@ class ScopeVisitor(cst.CSTVisitor):
                 name = name.decode("utf-8")
 
             access = Access(
-                cst.Name(name),
+                node,
                 self.scope,
                 is_annotation=False,
                 is_type_hint=False,

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -952,17 +952,10 @@ class ScopeVisitor(cst.CSTVisitor):
     ) -> bool:
         """Returns whether it successfully handled the string annotation"""
         if self.__in___all___stack[-1]:
-            name: str | bytes | None = None
+            name = node.evaluated_value
 
-            if isinstance(node, cst.SimpleString):
-                name = node.value
-
-            if isinstance(node, cst.ConcatenatedString):
-                name = node.evaluated_value
-
-            assert isinstance(name, str), f"Expected str, got {type(name)}"
-
-            name = name.replace('"', "")
+            if isinstance(name, bytes):
+                name = name.decode("utf-8")
 
             access = Access(
                 cst.Name(name),

--- a/libcst/metadata/scope_provider.py
+++ b/libcst/metadata/scope_provider.py
@@ -166,8 +166,8 @@ class BaseAssignment(abc.ABC):
         self.scope = scope
         self.__accesses = set()
 
-    def record_access(self, access: Access, bypass: bool | None = None) -> None:
-        if bypass or access.scope != self.scope or self._index < access._index:
+    def record_access(self, access: Access) -> None:
+        if access.scope != self.scope or self._index < access._index:
             self.__accesses.add(access)
 
     def record_accesses(self, accesses: Set[Access]) -> None:
@@ -971,9 +971,7 @@ class ScopeVisitor(cst.CSTVisitor):
                 is_type_hint=False,
             )
 
-            self.scope.record_access("__all__", access)
-            assignment = next(iter(self.scope.assignments["__all__"]))
-            assignment.record_access(access, True)
+            list(self.scope.assignments[name])[0].record_access(access)
 
             return True
 

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -2171,7 +2171,7 @@ class ScopeProviderTest(UnitTest):
                 class Outer:
                     class Nested:
                         pass
-                    
+
                     type Alias = Nested
 
                     def meth1[T: Nested](self): pass
@@ -2248,3 +2248,16 @@ class ScopeProviderTest(UnitTest):
         f_scope = scopes[inner_in_func_body]
         self.assertIn(inner_in_func_body.value, f_scope.accesses)
         self.assertEqual(list(f_scope.accesses)[0].referents, set())
+
+    def test___all___assignment(self) -> None:
+        m, scopes = get_scope_metadata_provider(
+            """
+            import a
+            import b
+
+            __all__ = ["a", "b"]
+            """
+        )
+        all_assignment = list(scopes[m]["__all__"])[0]
+        self.assertIsInstance(all_assignment, Assignment)
+        self.assertEqual(len(all_assignment.references), 2)

--- a/libcst/metadata/tests/test_scope_provider.py
+++ b/libcst/metadata/tests/test_scope_provider.py
@@ -2258,6 +2258,8 @@ class ScopeProviderTest(UnitTest):
             __all__ = ["a", "b"]
             """
         )
-        all_assignment = list(scopes[m]["__all__"])[0]
-        self.assertIsInstance(all_assignment, Assignment)
-        self.assertEqual(len(all_assignment.references), 2)
+        import_a_assignment = list(scopes[m]["a"])[0]
+        import_b_assignment = list(scopes[m]["b"])[0]
+
+        self.assertEqual(len(import_a_assignment.references), 1)
+        self.assertEqual(len(import_b_assignment.references), 1)


### PR DESCRIPTION
## Summary
Creating a `RemoveUnusedImports` transformer according to the docs does not properly handle the `__all__` variable.

## Test Plan
I added a test to `libcst/metadata/tests/test_scope_provider.py` that ensures the imports have references that target the strings in `__all__`.
