### PR TITLE
Fix Literal parse error in RemoveImportsVisitor

### DIFF
--- a/libcst/codemod/visitors/tests/test_gather_string_annotation_names.py
+++ b/libcst/codemod/visitors/tests/test_gather_string_annotation_names.py
@@ -80,3 +80,14 @@ class TestGatherNamesFromStringAnnotationsVisitor(UnitTest):
             visitor.names,
             {"api", "api.http_exceptions", "api.http_exceptions.HttpException"},
         )
+
+    def test_literals(self) -> None:
+        visitor = self.gather_names(
+            """
+            from typing import Literal
+            a: Literal["in"]
+            b: list[Literal["1x"]]
+            c: Literal["Any"]
+            """
+        )
+        self.assertEqual(visitor.names, set())


### PR DESCRIPTION
`GatherNamesFromStringAnnotationsVisitor`, which is called by `GatherUnusedImportsVisitor`, which is called by `RemoveImportsVisitor`, attempts to parse any string contained in an annotation as if it were Python code. This behavior was added in https://github.com/Instagram/LibCST/pull/353 with the goal of parsing type names wrapped in strings.

However, not all strings occurring inside annotations can or should be interpreted that way. For example:
```python
from typing import Literal

a: Literal["in"]
b: list[Literal["1x"]]
c: Literal["Any"]
```

`a` and `b` will cause a `ParserSyntaxError`, while `c` will be incorrectly treated as a mention of the symbol `Any`.

This PR makes two changes to `GatherNamesFromStringAnnotationsVisitor`:
- Anything inside a `Literal` is ignored.
  - This fixes all of the above examples.
- Failures to parse a string inside an annotation as Python code are simply ignored.
  - This will take care of any other usages of non-code strings inside an annotation.


Fixes:
- https://github.com/Instagram/LibCST/issues/924
- https://github.com/pydantic/bump-pydantic/issues/124
- https://github.com/pydantic/bump-pydantic/issues/115