### PR TITLE
FullyQualifiedNameProvider: Optionally consider pyproject.toml files when determining a file's module name and package

### DIFF
--- a/libcst/helpers/module.py
+++ b/libcst/helpers/module.py
@@ -5,7 +5,7 @@
 #
 from dataclasses import dataclass
 from itertools import islice
-from pathlib import PurePath
+from pathlib import Path
 from typing import List, Optional
 
 from libcst import Comment, EmptyLine, ImportFrom, Module
@@ -136,7 +136,18 @@ def calculate_module_and_package(
 ) -> ModuleNameAndPackage:
     # Given an absolute repo_root and an absolute filename, calculate the
     # python module name for the file.
-    relative_filename = PurePath(filename).relative_to(repo_root)
+    # But also look for pyproject.toml files, indicating nested packages in the repo.
+    abs_repo_root = Path(repo_root).resolve()
+    abs_filename = Path(filename).resolve()
+    package_root = abs_filename.parent
+    while package_root != abs_repo_root:
+        if (package_root / 'pyproject.toml').exists():
+            break
+        if package_root == package_root.parent:
+            break
+        package_root = package_root.parent
+
+    relative_filename = abs_filename.relative_to(package_root)
     relative_filename = relative_filename.with_suffix("")
 
     # handle special cases

--- a/libcst/helpers/module.py
+++ b/libcst/helpers/module.py
@@ -142,7 +142,7 @@ def calculate_module_and_package(
         abs_filename = Path(filename).resolve()
         package_root = abs_filename.parent
         while package_root != abs_repo_root:
-            if (package_root / 'pyproject.toml').exists():
+            if (package_root / "pyproject.toml").exists():
                 break
             if package_root == package_root.parent:
                 break

--- a/libcst/helpers/module.py
+++ b/libcst/helpers/module.py
@@ -5,7 +5,7 @@
 #
 from dataclasses import dataclass
 from itertools import islice
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import List, Optional
 
 from libcst import Comment, EmptyLine, ImportFrom, Module
@@ -132,22 +132,25 @@ class ModuleNameAndPackage:
 
 
 def calculate_module_and_package(
-    repo_root: StrPath, filename: StrPath
+    repo_root: StrPath, filename: StrPath, use_pyproject_toml: bool = False
 ) -> ModuleNameAndPackage:
     # Given an absolute repo_root and an absolute filename, calculate the
     # python module name for the file.
-    # But also look for pyproject.toml files, indicating nested packages in the repo.
-    abs_repo_root = Path(repo_root).resolve()
-    abs_filename = Path(filename).resolve()
-    package_root = abs_filename.parent
-    while package_root != abs_repo_root:
-        if (package_root / 'pyproject.toml').exists():
-            break
-        if package_root == package_root.parent:
-            break
-        package_root = package_root.parent
+    if use_pyproject_toml:
+        # But also look for pyproject.toml files, indicating nested packages in the repo.
+        abs_repo_root = Path(repo_root).resolve()
+        abs_filename = Path(filename).resolve()
+        package_root = abs_filename.parent
+        while package_root != abs_repo_root:
+            if (package_root / 'pyproject.toml').exists():
+                break
+            if package_root == package_root.parent:
+                break
+            package_root = package_root.parent
 
-    relative_filename = abs_filename.relative_to(package_root)
+        relative_filename = abs_filename.relative_to(package_root)
+    else:
+        relative_filename = PurePath(filename).relative_to(repo_root)
     relative_filename = relative_filename.with_suffix("")
 
     # handle special cases

--- a/libcst/helpers/tests/test_module.py
+++ b/libcst/helpers/tests/test_module.py
@@ -296,21 +296,18 @@ class ModuleTest(UnitTest):
                 },
             },
         }
+        repo_root = Path("/home/user/root").resolve()
+        fake_root = repo_root.parent.parent.parent
 
         def mock_exists(path: PurePath) -> bool:
-            parts = path.parts
+            parts = path.relative_to(fake_root).parts
             subtree = mock_tree
-            if path.is_absolute():
-                parts = parts[1:]
             for part in parts:
                 if (subtree := subtree.get(part)) is None:
                     return False
             return True
 
-        with patch("pathlib.Path.exists", new=mock_exists), patch(
-            "pathlib.Path.resolve", new=lambda p: p
-        ):
-            repo_root = Path("/home/user/root")
+        with patch("pathlib.Path.exists", new=mock_exists):
             self.assertEqual(
                 calculate_module_and_package(
                     repo_root, repo_root / rel_path, use_pyproject_toml=True

--- a/libcst/helpers/tests/test_module.py
+++ b/libcst/helpers/tests/test_module.py
@@ -10,15 +10,15 @@ from unittest.mock import patch
 import libcst as cst
 from libcst.helpers.common import ensure_type
 from libcst.helpers.module import (
-    ModuleNameAndPackage,
     calculate_module_and_package,
     get_absolute_module_for_import,
     get_absolute_module_for_import_or_raise,
     get_absolute_module_from_package_for_import,
     get_absolute_module_from_package_for_import_or_raise,
     insert_header_comments,
+    ModuleNameAndPackage,
 )
-from libcst.testing.utils import UnitTest, data_provider
+from libcst.testing.utils import data_provider, UnitTest
 
 
 class ModuleTest(UnitTest):
@@ -257,11 +257,15 @@ class ModuleTest(UnitTest):
         (
             ("foo/foo/__init__.py", ModuleNameAndPackage("foo", "foo")),
             ("foo/foo/file.py", ModuleNameAndPackage("foo.file", "foo")),
-            ("foo/foo/sub/subfile.py", ModuleNameAndPackage("foo.sub.subfile", "foo.sub")),
+            (
+                "foo/foo/sub/subfile.py",
+                ModuleNameAndPackage("foo.sub.subfile", "foo.sub"),
+            ),
             ("libs/bar/bar/thing.py", ModuleNameAndPackage("bar.thing", "bar")),
         )
     )
-    def test_calculate_module_and_package_using_pyproject_toml(self,
+    def test_calculate_module_and_package_using_pyproject_toml(
+        self,
         rel_path: str,
         module_and_package: Optional[ModuleNameAndPackage],
     ) -> None:
@@ -277,7 +281,7 @@ class ModuleTest(UnitTest):
                                 "sub": {
                                     "subfile.py": "content",
                                 },
-                            }
+                            },
                         },
                         "libs": {
                             "bar": {
@@ -285,9 +289,9 @@ class ModuleTest(UnitTest):
                                 "bar": {
                                     "__init__.py": "content",
                                     "thing.py": "content",
-                                }
+                                },
                             }
-                        }
+                        },
                     },
                 },
             },
@@ -303,12 +307,16 @@ class ModuleTest(UnitTest):
                     return False
             return True
 
-        with patch("pathlib.Path.exists", new=mock_exists), patch("pathlib.Path.resolve", new=lambda p: p):
+        with patch("pathlib.Path.exists", new=mock_exists), patch(
+            "pathlib.Path.resolve", new=lambda p: p
+        ):
             repo_root = Path("/home/user/root")
             self.assertEqual(
-                calculate_module_and_package(repo_root, repo_root / rel_path, use_pyproject_toml=True), module_and_package
+                calculate_module_and_package(
+                    repo_root, repo_root / rel_path, use_pyproject_toml=True
+                ),
+                module_and_package,
             )
-
 
     @data_provider(
         (

--- a/libcst/helpers/tests/test_module.py
+++ b/libcst/helpers/tests/test_module.py
@@ -297,7 +297,7 @@ class ModuleTest(UnitTest):
             },
         }
         repo_root = Path("/home/user/root").resolve()
-        fake_root = repo_root.parent.parent.parent
+        fake_root: Path = repo_root.parent.parent.parent
 
         def mock_exists(path: PurePath) -> bool:
             parts = path.relative_to(fake_root).parts

--- a/libcst/helpers/tests/test_module.py
+++ b/libcst/helpers/tests/test_module.py
@@ -262,6 +262,10 @@ class ModuleTest(UnitTest):
                 ModuleNameAndPackage("foo.sub.subfile", "foo.sub"),
             ),
             ("libs/bar/bar/thing.py", ModuleNameAndPackage("bar.thing", "bar")),
+            (
+                "noproj/some/file.py",
+                ModuleNameAndPackage("noproj.some.file", "noproj.some"),
+            ),
         )
     )
     def test_calculate_module_and_package_using_pyproject_toml(
@@ -290,6 +294,11 @@ class ModuleTest(UnitTest):
                                     "__init__.py": "content",
                                     "thing.py": "content",
                                 },
+                            }
+                        },
+                        "noproj": {
+                            "some": {
+                                "file.py": "content",
                             }
                         },
                     },

--- a/libcst/helpers/tests/test_module.py
+++ b/libcst/helpers/tests/test_module.py
@@ -253,7 +253,18 @@ class ModuleTest(UnitTest):
             calculate_module_and_package(repo_root, filename), module_and_package
         )
 
-    def test_calculate_module_and_package_using_pyproject_toml(self) -> None:
+    @data_provider(
+        (
+            ("foo/foo/__init__.py", ModuleNameAndPackage("foo", "foo")),
+            ("foo/foo/file.py", ModuleNameAndPackage("foo.file", "foo")),
+            ("foo/foo/sub/subfile.py", ModuleNameAndPackage("foo.sub.subfile", "foo.sub")),
+            ("libs/bar/bar/thing.py", ModuleNameAndPackage("bar.thing", "bar")),
+        )
+    )
+    def test_calculate_module_and_package_using_pyproject_toml(self,
+        rel_path: str,
+        module_and_package: Optional[ModuleNameAndPackage],
+    ) -> None:
         mock_tree = {
             "home": {
                 "user": {
@@ -295,16 +306,7 @@ class ModuleTest(UnitTest):
         with patch("pathlib.Path.exists", new=mock_exists), patch("pathlib.Path.resolve", new=lambda p: p):
             repo_root = Path("/home/user/root")
             self.assertEqual(
-                calculate_module_and_package(repo_root, repo_root / "foo/foo/__init__.py", use_pyproject_toml=True), ModuleNameAndPackage("foo", "foo")
-            )
-            self.assertEqual(
-                calculate_module_and_package(repo_root, repo_root / "foo/foo/file.py", use_pyproject_toml=True), ModuleNameAndPackage("foo.file", "foo")
-            )
-            self.assertEqual(
-                calculate_module_and_package(repo_root, repo_root / "foo/foo/sub/subfile.py", use_pyproject_toml=True), ModuleNameAndPackage("foo.sub.subfile", "foo.sub")
-            )
-            self.assertEqual(
-                calculate_module_and_package(repo_root, repo_root / "libs/bar/bar/thing.py", use_pyproject_toml=True), ModuleNameAndPackage("bar.thing", "bar")
+                calculate_module_and_package(repo_root, repo_root / rel_path, use_pyproject_toml=True), module_and_package
             )
 
 

--- a/libcst/helpers/tests/test_module.py
+++ b/libcst/helpers/tests/test_module.py
@@ -300,7 +300,7 @@ class ModuleTest(UnitTest):
         def mock_exists(path: PurePath) -> bool:
             parts = path.parts
             subtree = mock_tree
-            if parts[0] == "/":
+            if path.is_absolute():
                 parts = parts[1:]
             for part in parts:
                 if (subtree := subtree.get(part)) is None:

--- a/libcst/helpers/tests/test_module.py
+++ b/libcst/helpers/tests/test_module.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 #
 from pathlib import Path, PurePath
-from typing import Optional
+from typing import Any, Optional
 from unittest.mock import patch
 
 import libcst as cst
@@ -265,7 +265,7 @@ class ModuleTest(UnitTest):
         rel_path: str,
         module_and_package: Optional[ModuleNameAndPackage],
     ) -> None:
-        mock_tree = {
+        mock_tree: dict[str, Any] = {
             "home": {
                 "user": {
                     "root": {

--- a/libcst/metadata/base_provider.py
+++ b/libcst/metadata/base_provider.py
@@ -6,7 +6,6 @@
 from pathlib import Path
 from types import MappingProxyType
 from typing import (
-    TYPE_CHECKING,
     Generic,
     List,
     Mapping,
@@ -14,19 +13,23 @@ from typing import (
     Optional,
     Protocol,
     Type,
+    TYPE_CHECKING,
     TypeVar,
     Union,
 )
 
 from libcst._batched_visitor import BatchableCSTVisitor
-from libcst._metadata_dependent import _T as _MetadataT
-from libcst._metadata_dependent import _UNDEFINED_DEFAULT, LazyValue, MetadataDependent
+from libcst._metadata_dependent import (
+    _T as _MetadataT,
+    _UNDEFINED_DEFAULT,
+    LazyValue,
+    MetadataDependent,
+)
 from libcst._visitors import CSTVisitor
 
 if TYPE_CHECKING:
     from libcst._nodes.base import CSTNode
-    from libcst._nodes.module import Module
-    from libcst._nodes.module import _ModuleSelfT as _ModuleT
+    from libcst._nodes.module import _ModuleSelfT as _ModuleT, Module
     from libcst.metadata.wrapper import MetadataWrapper
 
 
@@ -39,7 +42,12 @@ MaybeLazyMetadataT = Union[LazyValue[_ProvidedMetadataT], _ProvidedMetadataT]
 
 class GenCacheMethod(Protocol):
     def __call__(
-        self, root_path: Path, paths: List[str], *, timeout: Optional[int] = None, use_pyproject_toml: bool = False
+        self,
+        root_path: Path,
+        paths: List[str],
+        *,
+        timeout: Optional[int] = None,
+        use_pyproject_toml: bool = False,
     ) -> Mapping[str, object]:
         ...
 

--- a/libcst/metadata/base_provider.py
+++ b/libcst/metadata/base_provider.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import (
     TYPE_CHECKING,
-    Callable,
     Generic,
     List,
     Mapping,

--- a/libcst/metadata/base_provider.py
+++ b/libcst/metadata/base_provider.py
@@ -40,7 +40,7 @@ MaybeLazyMetadataT = Union[LazyValue[_ProvidedMetadataT], _ProvidedMetadataT]
 
 class GenCacheMethod(Protocol):
     def __call__(
-        self, root_path: Path, paths: List[str], *, timeout: Optional[int] = None
+        self, root_path: Path, paths: List[str], *, timeout: Optional[int] = None, use_pyproject_toml: bool = False
     ) -> Mapping[str, object]:
         ...
 

--- a/libcst/metadata/file_path_provider.py
+++ b/libcst/metadata/file_path_provider.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from pathlib import Path
-from typing import List, Mapping, Optional
+from typing import Any, List, Mapping, Optional
 
 import libcst as cst
 from libcst.metadata.base_provider import BatchableMetadataProvider
@@ -41,7 +41,7 @@ class FilePathProvider(BatchableMetadataProvider[Path]):
 
     @classmethod
     def gen_cache(
-        cls, root_path: Path, paths: List[str], timeout: Optional[int] = None
+        cls, root_path: Path, paths: List[str], **kwargs: Any
     ) -> Mapping[str, Path]:
         cache = {path: (root_path / path).resolve() for path in paths}
         return cache

--- a/libcst/metadata/file_path_provider.py
+++ b/libcst/metadata/file_path_provider.py
@@ -39,9 +39,9 @@ class FilePathProvider(BatchableMetadataProvider[Path]):
 
     """
 
-    @staticmethod
+    @classmethod
     def gen_cache(
-        root_path: Path, paths: List[str], **kwargs: Any
+        cls, root_path: Path, paths: List[str], **kwargs: Any
     ) -> Mapping[str, Path]:
         cache = {path: (root_path / path).resolve() for path in paths}
         return cache

--- a/libcst/metadata/file_path_provider.py
+++ b/libcst/metadata/file_path_provider.py
@@ -39,9 +39,9 @@ class FilePathProvider(BatchableMetadataProvider[Path]):
 
     """
 
-    @classmethod
+    @staticmethod
     def gen_cache(
-        cls, root_path: Path, paths: List[str], **kwargs: Any
+        root_path: Path, paths: List[str], **kwargs: Any
     ) -> Mapping[str, Path]:
         cache = {path: (root_path / path).resolve() for path in paths}
         return cache

--- a/libcst/metadata/full_repo_manager.py
+++ b/libcst/metadata/full_repo_manager.py
@@ -5,7 +5,7 @@
 
 
 from pathlib import Path
-from typing import Collection, Dict, List, Mapping, TYPE_CHECKING
+from typing import TYPE_CHECKING, Collection, Dict, List, Mapping
 
 import libcst as cst
 from libcst._types import StrPath
@@ -65,7 +65,7 @@ class FullRepoManager:
                 handler = provider.gen_cache
                 if handler:
                     cache[provider] = handler(
-                        self.root_path, self._paths, self._timeout
+                        self.root_path, self._paths, timeout=self._timeout
                     )
             self._cache = cache
 

--- a/libcst/metadata/full_repo_manager.py
+++ b/libcst/metadata/full_repo_manager.py
@@ -5,7 +5,7 @@
 
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Collection, Dict, List, Mapping
+from typing import Collection, Dict, List, Mapping, TYPE_CHECKING
 
 import libcst as cst
 from libcst._types import StrPath
@@ -67,7 +67,10 @@ class FullRepoManager:
                 handler = provider.gen_cache
                 if handler:
                     cache[provider] = handler(
-                        self.root_path, self._paths, timeout=self._timeout, use_pyproject_toml=self._use_pyproject_toml
+                        self.root_path,
+                        self._paths,
+                        timeout=self._timeout,
+                        use_pyproject_toml=self._use_pyproject_toml,
                     )
             self._cache = cache
 

--- a/libcst/metadata/full_repo_manager.py
+++ b/libcst/metadata/full_repo_manager.py
@@ -22,6 +22,7 @@ class FullRepoManager:
         paths: Collection[str],
         providers: Collection["ProviderT"],
         timeout: int = 5,
+        use_pyproject_toml: bool = False,
     ) -> None:
         """
         Given project root directory with pyre and watchman setup, :class:`~libcst.metadata.FullRepoManager`
@@ -38,6 +39,7 @@ class FullRepoManager:
         self.root_path: Path = Path(repo_root_dir)
         self._cache: Dict["ProviderT", Mapping[str, object]] = {}
         self._timeout = timeout
+        self._use_pyproject_toml = use_pyproject_toml
         self._providers = providers
         self._paths: List[str] = list(paths)
 
@@ -65,7 +67,7 @@ class FullRepoManager:
                 handler = provider.gen_cache
                 if handler:
                     cache[provider] = handler(
-                        self.root_path, self._paths, timeout=self._timeout
+                        self.root_path, self._paths, timeout=self._timeout, use_pyproject_toml=self._use_pyproject_toml
                     )
             self._cache = cache
 

--- a/libcst/metadata/name_provider.py
+++ b/libcst/metadata/name_provider.py
@@ -106,9 +106,9 @@ class FullyQualifiedNameProvider(BatchableMetadataProvider[Collection[QualifiedN
 
     METADATA_DEPENDENCIES = (QualifiedNameProvider,)
 
-    @staticmethod
+    @classmethod
     def gen_cache(
-        root_path: Path, paths: List[str], *, use_pyproject_toml: bool = False, **kwargs: Any
+        cls, root_path: Path, paths: List[str], *, use_pyproject_toml: bool = False, **kwargs: Any
     ) -> Mapping[str, ModuleNameAndPackage]:
         cache = {path: calculate_module_and_package(root_path, path, use_pyproject_toml=use_pyproject_toml) for path in paths}
         return cache

--- a/libcst/metadata/name_provider.py
+++ b/libcst/metadata/name_provider.py
@@ -108,9 +108,9 @@ class FullyQualifiedNameProvider(BatchableMetadataProvider[Collection[QualifiedN
 
     @staticmethod
     def gen_cache(
-        root_path: Path, paths: List[str], *, **kwargs: Any
+        root_path: Path, paths: List[str], *, use_pyproject_toml: bool = False, **kwargs: Any
     ) -> Mapping[str, ModuleNameAndPackage]:
-        cache = {path: calculate_module_and_package(root_path, path) for path in paths}
+        cache = {path: calculate_module_and_package(root_path, path, use_pyproject_toml=use_pyproject_toml) for path in paths}
         return cache
 
     def __init__(self, cache: ModuleNameAndPackage) -> None:

--- a/libcst/metadata/name_provider.py
+++ b/libcst/metadata/name_provider.py
@@ -106,9 +106,9 @@ class FullyQualifiedNameProvider(BatchableMetadataProvider[Collection[QualifiedN
 
     METADATA_DEPENDENCIES = (QualifiedNameProvider,)
 
-    @classmethod
+    @staticmethod
     def gen_cache(
-        cls, root_path: Path, paths: List[str], **kwargs: Any
+        root_path: Path, paths: List[str], *, **kwargs: Any
     ) -> Mapping[str, ModuleNameAndPackage]:
         cache = {path: calculate_module_and_package(root_path, path) for path in paths}
         return cache

--- a/libcst/metadata/name_provider.py
+++ b/libcst/metadata/name_provider.py
@@ -9,9 +9,13 @@ from typing import Any, Collection, List, Mapping, Optional, Union
 
 import libcst as cst
 from libcst._metadata_dependent import LazyValue, MetadataDependent
-from libcst.helpers.module import ModuleNameAndPackage, calculate_module_and_package
+from libcst.helpers.module import calculate_module_and_package, ModuleNameAndPackage
 from libcst.metadata.base_provider import BatchableMetadataProvider
-from libcst.metadata.scope_provider import QualifiedName, QualifiedNameSource, ScopeProvider
+from libcst.metadata.scope_provider import (
+    QualifiedName,
+    QualifiedNameSource,
+    ScopeProvider,
+)
 
 
 class QualifiedNameProvider(BatchableMetadataProvider[Collection[QualifiedName]]):
@@ -108,9 +112,19 @@ class FullyQualifiedNameProvider(BatchableMetadataProvider[Collection[QualifiedN
 
     @classmethod
     def gen_cache(
-        cls, root_path: Path, paths: List[str], *, use_pyproject_toml: bool = False, **kwargs: Any
+        cls,
+        root_path: Path,
+        paths: List[str],
+        *,
+        use_pyproject_toml: bool = False,
+        **kwargs: Any,
     ) -> Mapping[str, ModuleNameAndPackage]:
-        cache = {path: calculate_module_and_package(root_path, path, use_pyproject_toml=use_pyproject_toml) for path in paths}
+        cache = {
+            path: calculate_module_and_package(
+                root_path, path, use_pyproject_toml=use_pyproject_toml
+            )
+            for path in paths
+        }
         return cache
 
     def __init__(self, cache: ModuleNameAndPackage) -> None:

--- a/libcst/metadata/name_provider.py
+++ b/libcst/metadata/name_provider.py
@@ -5,17 +5,13 @@
 
 import dataclasses
 from pathlib import Path
-from typing import Collection, List, Mapping, Optional, Union
+from typing import Any, Collection, List, Mapping, Optional, Union
 
 import libcst as cst
 from libcst._metadata_dependent import LazyValue, MetadataDependent
-from libcst.helpers.module import calculate_module_and_package, ModuleNameAndPackage
+from libcst.helpers.module import ModuleNameAndPackage, calculate_module_and_package
 from libcst.metadata.base_provider import BatchableMetadataProvider
-from libcst.metadata.scope_provider import (
-    QualifiedName,
-    QualifiedNameSource,
-    ScopeProvider,
-)
+from libcst.metadata.scope_provider import QualifiedName, QualifiedNameSource, ScopeProvider
 
 
 class QualifiedNameProvider(BatchableMetadataProvider[Collection[QualifiedName]]):
@@ -112,7 +108,7 @@ class FullyQualifiedNameProvider(BatchableMetadataProvider[Collection[QualifiedN
 
     @classmethod
     def gen_cache(
-        cls, root_path: Path, paths: List[str], timeout: Optional[int] = None
+        cls, root_path: Path, paths: List[str], **kwargs: Any
     ) -> Mapping[str, ModuleNameAndPackage]:
         cache = {path: calculate_module_and_package(root_path, path) for path in paths}
         return cache

--- a/libcst/metadata/tests/test_metadata_wrapper.py
+++ b/libcst/metadata/tests/test_metadata_wrapper.py
@@ -49,7 +49,7 @@ class MetadataWrapperTest(UnitTest):
         self.assertNotEqual(hash(mw2), hash(mw3))
 
     @staticmethod
-    def ignore_args(*args: object, **kwargs: object) -> tuple[Any, ...]:
+    def ignore_args(*args: object, **kwargs: object) -> tuple[object, ...]:
         return (args, kwargs)
 
     def test_metadata_cache(self) -> None:

--- a/libcst/metadata/tests/test_metadata_wrapper.py
+++ b/libcst/metadata/tests/test_metadata_wrapper.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
-from typing import Any, Optional
+from typing import Optional
 from unittest.mock import Mock
 
 import libcst as cst

--- a/libcst/metadata/tests/test_metadata_wrapper.py
+++ b/libcst/metadata/tests/test_metadata_wrapper.py
@@ -8,7 +8,11 @@ from typing import Any, Optional
 from unittest.mock import Mock
 
 import libcst as cst
-from libcst.metadata import BatchableMetadataProvider, MetadataWrapper, VisitorMetadataProvider
+from libcst.metadata import (
+    BatchableMetadataProvider,
+    MetadataWrapper,
+    VisitorMetadataProvider,
+)
 from libcst.testing.utils import UnitTest
 
 

--- a/libcst/metadata/tests/test_metadata_wrapper.py
+++ b/libcst/metadata/tests/test_metadata_wrapper.py
@@ -46,7 +46,7 @@ class MetadataWrapperTest(UnitTest):
 
     @staticmethod
     def ignore_args(*args: object, **kwargs: object) -> Any:
-        pass
+        return (args, kwargs)
 
     def test_metadata_cache(self) -> None:
         class DummyMetadataProvider(BatchableMetadataProvider[None]):

--- a/libcst/metadata/tests/test_metadata_wrapper.py
+++ b/libcst/metadata/tests/test_metadata_wrapper.py
@@ -4,15 +4,11 @@
 # LICENSE file in the root directory of this source tree.
 
 
-from typing import Optional
+from typing import Any, Optional
 from unittest.mock import Mock
 
 import libcst as cst
-from libcst.metadata import (
-    BatchableMetadataProvider,
-    MetadataWrapper,
-    VisitorMetadataProvider,
-)
+from libcst.metadata import BatchableMetadataProvider, MetadataWrapper, VisitorMetadataProvider
 from libcst.testing.utils import UnitTest
 
 
@@ -48,9 +44,13 @@ class MetadataWrapperTest(UnitTest):
         self.assertNotEqual(hash(mw1), hash(mw3))
         self.assertNotEqual(hash(mw2), hash(mw3))
 
+    @staticmethod
+    def ignore_args(*args: object, **kwargs: object) -> Any:
+        pass
+
     def test_metadata_cache(self) -> None:
         class DummyMetadataProvider(BatchableMetadataProvider[None]):
-            gen_cache = tuple
+            gen_cache = self.ignore_args
 
         m = cst.parse_module("pass")
         mw = MetadataWrapper(m)
@@ -60,7 +60,7 @@ class MetadataWrapperTest(UnitTest):
             mw.resolve(DummyMetadataProvider)
 
         class SimpleCacheMetadataProvider(BatchableMetadataProvider[object]):
-            gen_cache = tuple
+            gen_cache = self.ignore_args
 
             def __init__(self, cache: object) -> None:
                 super().__init__(cache)

--- a/libcst/metadata/tests/test_metadata_wrapper.py
+++ b/libcst/metadata/tests/test_metadata_wrapper.py
@@ -45,7 +45,7 @@ class MetadataWrapperTest(UnitTest):
         self.assertNotEqual(hash(mw2), hash(mw3))
 
     @staticmethod
-    def ignore_args(*args: object, **kwargs: object) -> Any:
+    def ignore_args(*args: object, **kwargs: object) -> tuple[Any, ...]:
         return (args, kwargs)
 
     def test_metadata_cache(self) -> None:

--- a/libcst/metadata/tests/test_name_provider.py
+++ b/libcst/metadata/tests/test_name_provider.py
@@ -54,7 +54,7 @@ def get_fully_qualified_names(file_path: str, module_str: str) -> Set[QualifiedN
         cst.parse_module(dedent(module_str)),
         cache={
             FullyQualifiedNameProvider: FullyQualifiedNameProvider.gen_cache(
-                Path(""), [file_path], None
+                Path(""), [file_path], timeout=None
             ).get(file_path, "")
         },
     )

--- a/libcst/metadata/tests/test_name_provider.py
+++ b/libcst/metadata/tests/test_name_provider.py
@@ -20,7 +20,7 @@ from libcst.metadata import (
 )
 from libcst.metadata.full_repo_manager import FullRepoManager
 from libcst.metadata.name_provider import FullyQualifiedNameVisitor
-from libcst.testing.utils import data_provider, UnitTest
+from libcst.testing.utils import UnitTest, data_provider
 
 
 class QNameVisitor(cst.CSTVisitor):

--- a/libcst/metadata/tests/test_name_provider.py
+++ b/libcst/metadata/tests/test_name_provider.py
@@ -20,7 +20,7 @@ from libcst.metadata import (
 )
 from libcst.metadata.full_repo_manager import FullRepoManager
 from libcst.metadata.name_provider import FullyQualifiedNameVisitor
-from libcst.testing.utils import UnitTest, data_provider
+from libcst.testing.utils import data_provider, UnitTest
 
 
 class QNameVisitor(cst.CSTVisitor):

--- a/libcst/metadata/type_inference_provider.py
+++ b/libcst/metadata/type_inference_provider.py
@@ -52,7 +52,11 @@ class TypeInferenceProvider(BatchableMetadataProvider[str]):
 
     @classmethod
     def gen_cache(
-        cls, root_path: Path, paths: List[str], timeout: Optional[int] = None, **kwargs: Any
+        cls,
+        root_path: Path,
+        paths: List[str],
+        timeout: Optional[int] = None,
+        **kwargs: Any,
     ) -> Mapping[str, object]:
         params = ",".join(f"path='{root_path / path}'" for path in paths)
         cmd_args = ["pyre", "--noninteractive", "query", f"types({params})"]

--- a/libcst/metadata/type_inference_provider.py
+++ b/libcst/metadata/type_inference_provider.py
@@ -51,8 +51,6 @@ class TypeInferenceProvider(BatchableMetadataProvider[str]):
     METADATA_DEPENDENCIES = (PositionProvider,)
 
     @staticmethod
-    # pyre-fixme[40]: Static method `gen_cache` cannot override a non-static method
-    #  defined in `cst.metadata.base_provider.BaseMetadataProvider`.
     def gen_cache(
         root_path: Path, paths: List[str], timeout: Optional[int] = None, **kwargs: Any
     ) -> Mapping[str, object]:

--- a/libcst/metadata/type_inference_provider.py
+++ b/libcst/metadata/type_inference_provider.py
@@ -6,7 +6,7 @@
 import json
 import subprocess
 from pathlib import Path
-from typing import Dict, List, Mapping, Optional, Sequence, Tuple, TypedDict
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, TypedDict
 
 import libcst as cst
 from libcst._position import CodePosition, CodeRange
@@ -54,7 +54,7 @@ class TypeInferenceProvider(BatchableMetadataProvider[str]):
     # pyre-fixme[40]: Static method `gen_cache` cannot override a non-static method
     #  defined in `cst.metadata.base_provider.BaseMetadataProvider`.
     def gen_cache(
-        root_path: Path, paths: List[str], timeout: Optional[int]
+        root_path: Path, paths: List[str], timeout: Optional[int] = None, **kwargs: Any
     ) -> Mapping[str, object]:
         params = ",".join(f"path='{root_path / path}'" for path in paths)
         cmd_args = ["pyre", "--noninteractive", "query", f"types({params})"]

--- a/libcst/metadata/type_inference_provider.py
+++ b/libcst/metadata/type_inference_provider.py
@@ -50,9 +50,9 @@ class TypeInferenceProvider(BatchableMetadataProvider[str]):
 
     METADATA_DEPENDENCIES = (PositionProvider,)
 
-    @staticmethod
+    @classmethod
     def gen_cache(
-        root_path: Path, paths: List[str], timeout: Optional[int] = None, **kwargs: Any
+        cls, root_path: Path, paths: List[str], timeout: Optional[int] = None, **kwargs: Any
     ) -> Mapping[str, object]:
         params = ",".join(f"path='{root_path / path}'" for path in paths)
         cmd_args = ["pyre", "--noninteractive", "query", f"types({params})"]


### PR DESCRIPTION
When determining the module name and package for a source file, LibCST currently takes the file name relative to the repository root. With this change, it will instead look for the closest directory containing a `pyproject.toml` file in the file's ancestors, and consider the file name relative to that directory.

This gives correct module and package names when processing a repository containing multiple packages. For files that are not covered by a `pyproject.toml`, the search ends with the given repository root, thus retaining the old behavior.