### PR TITLE
use trusted publishing for pypi

### DIFF
--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -16,6 +16,8 @@ jobs:
     name: Upload wheels to pypi
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -46,14 +48,10 @@ jobs:
         if: github.event_name == 'push'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
           packages-dir: ${{ steps.download.outputs.download-path }}
       - name: Publish distribution 📦 to PyPI
         if: github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: ${{ steps.download.outputs.download-path }}


### PR DESCRIPTION

## Summary
This PR removes the hardcoded access token for pypi from the workflow.
## Test Plan
Run publishing to test.pypi.org in a non-final version of this PR.
