### PR TITLE
Mention codemod -x flag in docs

### DIFF
--- a/docs/source/codemods_tutorial.rst
+++ b/docs/source/codemods_tutorial.rst
@@ -135,15 +135,17 @@ replaces any string which matches our string command-line argument with a consta
 It also takes care of adding the import required for the constant to be defined properly.
 
 Cool! Let's look at the command-line help for this codemod. Let's assume you saved it
-as ``constant_folding.py`` inside ``libcst.codemod.commands``. You can get help for the
+as ``constant_folding.py``. You can get help for the
 codemod by running the following command::
 
-    python3 -m libcst.tool codemod constant_folding.ConvertConstantCommand --help
+    python3 -m libcst.tool codemod -x constant_folding.ConvertConstantCommand --help
 
 Notice that along with the default arguments, the ``--string`` and ``--constant``
 arguments are present in the help, and the command-line description has been updated
 with the codemod's description string. You'll notice that the codemod also shows up
 on ``libcst.tool list``.
+
+And ``-x`` flag allows to load any module as a codemod in addition to the standard ones.
 
 ----------------
 Testing Codemods


### PR DESCRIPTION
## Summary

After https://github.com/Instagram/LibCST/pull/879 got implemented, we can assume that most user codemods are loaded in this way instead of editing the LibCST source (it would be just pip installed). So `-x` flag is very important and should be mentioned in docs. 

I am open to suggestions on how to improve the wording and also mention the built-in codemods and `libcst.tool list` better.

## Test Plan

#shipit (just docs)