### PR TITLE
Add validation for If node

### DIFF
--- a/libcst/_nodes/statement.py
+++ b/libcst/_nodes/statement.py
@@ -599,7 +599,12 @@ class If(BaseCompoundStatement):
     #: The whitespace appearing after the test expression but before the colon.
     whitespace_after_test: SimpleWhitespace = SimpleWhitespace.field("")
 
-    # TODO: _validate
+    def _validate(self) -> None:
+        if (
+            self.whitespace_before_test.empty
+            and not self.test._safe_to_use_with_word_operator(ExpressionPosition.RIGHT)
+        ):
+            raise CSTValidationError("Must have at least one space after 'if' keyword.")
 
     def _visit_and_replace_children(self, visitor: CSTVisitorT) -> "If":
         return If(

--- a/libcst/_nodes/tests/test_if.py
+++ b/libcst/_nodes/tests/test_if.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any
+from typing import Any, Callable
 
 import libcst as cst
 from libcst import parse_statement
@@ -129,3 +129,21 @@ class IfTest(CSTNodeTest):
     )
     def test_valid(self, **kwargs: Any) -> None:
         self.validate_node(**kwargs)
+
+    @data_provider(
+        (
+            # Validate whitespace handling
+            (
+                lambda: cst.If(
+                    cst.Name("conditional"),
+                    cst.SimpleStatementSuite((cst.Pass(),)),
+                    whitespace_before_test=cst.SimpleWhitespace(""),
+                ),
+                "Must have at least one space after 'if' keyword.",
+            ),
+        )
+    )
+    def test_invalid(
+        self, get_node: Callable[[], cst.CSTNode], expected_re: str
+    ) -> None:
+        self.assert_invalid(get_node, expected_re)


### PR DESCRIPTION
Don't allow no space no parentheses after `if`.

## Summary


There should be a validation for `If` node similar to others such as `While` or `Assert` to not allow generating incorrect code.
There is even a TODO left for that reason.

Let me know if there should be other validations for `If`.

## Test Plan

### Before:

With the current version of LibCST it is possible to generate the code like this with an `If` node followed by `Name('x')` without space:
```python
ifx:
    pass
```
which isn't correct Syntax. 

The new test fails:
```python
======================================================================
FAIL: test_invalid_0 (libcst._nodes.tests.test_if.IfTest.test_invalid_0)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "libcst\testing\utils.py", line 88, in new_test
    return member(self, *data)
           ^^^^^^^^^^^^^^^^^^^
  File "libcst\_nodes\tests\test_if.py", line 149, in test_invalid
    self.assert_invalid(get_node, expected_re)
  File "libcst\_nodes\tests\base.py", line 95, in assert_invalid
    with self.assertRaisesRegex(cst.CSTValidationError, expected_re):
AssertionError: CSTValidationError not raised

```

### After:
Attempting to generate incorrect code raises an exception preventing it:
```
libcst._nodes.base.CSTValidationError: Must have at least one space after 'if' keyword.
```

The new test passes:
```python
----------------------------------------------------------------------
Ran 2076 tests in 62.315s

OK (skipped=18, expected failures=2)
```