### PR TITLE
Clear warnings for each file in codemod cli

### DIFF
--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -423,7 +423,7 @@ class Progress:
         operations still to do.
         """
 
-        if files_finished <= 0:
+        if files_finished <= 0 or elapsed_seconds == 0:
             # Technically infinite but calculating sounds better.
             return "[calculating]"
 

--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -22,6 +22,7 @@ from typing import Any, AnyStr, cast, Dict, List, Optional, Sequence, Union
 
 from libcst import parse_module, PartialParserConfig
 from libcst.codemod._codemod import Codemod
+from libcst.codemod._context import CodemodContext
 from libcst.codemod._dummy_pool import DummyPool
 from libcst.codemod._runner import (
     SkipFile,
@@ -246,33 +247,28 @@ def _execute_transform(  # noqa: C901
                 ),
             )
 
-        # Somewhat gross hack to provide the filename in the transform's context.
-        # We do this after the fork so that a context that was initialized with
-        # some defaults before calling parallel_exec_transform_with_prettyprint
-        # will be updated per-file.
-        # Clean the warnings as well, otherwise they will be
-        # passed from the previous file
-        transformer.context = replace(
-            transformer.context,
-            filename=filename,
-            scratch=deepcopy(scratch),
-            warnings=[],
-        )
-
         # determine the module and package name for this file
         try:
             module_name_and_package = calculate_module_and_package(
                 config.repo_root or ".", filename
             )
-            transformer.context = replace(
-                transformer.context,
-                full_module_name=module_name_and_package.name,
-                full_package_name=module_name_and_package.package,
-            )
+            mod_name = module_name_and_package.name
+            pkg_name = module_name_and_package.package
         except ValueError as ex:
             print(
                 f"Failed to determine module name for {filename}: {ex}", file=sys.stderr
             )
+            mod_name = None
+            pkg_name = None
+
+        # Apart from metadata_manager, every field of context should be reset per file
+        transformer.context = CodemodContext(
+            scratch=deepcopy(scratch),
+            filename=filename,
+            full_module_name=mod_name,
+            full_package_name=pkg_name,
+            metadata_manager=transformer.context.metadata_manager,
+        )
 
         # Run the transform, bail if we failed or if we aren't formatting code
         try:

--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -250,10 +250,13 @@ def _execute_transform(  # noqa: C901
         # We do this after the fork so that a context that was initialized with
         # some defaults before calling parallel_exec_transform_with_prettyprint
         # will be updated per-file.
+        # Clean the warnings as well, otherwise they will be
+        # passed from the previous file
         transformer.context = replace(
             transformer.context,
             filename=filename,
             scratch=deepcopy(scratch),
+            warnings=[],
         )
 
         # determine the module and package name for this file

--- a/libcst/codemod/tests/test_codemod_cli.py
+++ b/libcst/codemod/tests/test_codemod_cli.py
@@ -8,10 +8,12 @@
 import platform
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from unittest import skipIf
 
 from libcst._parser.entrypoints import is_native
+from libcst.codemod import CodemodTest
 from libcst.testing.utils import UnitTest
 
 
@@ -63,3 +65,31 @@ class TestCodemodCLI(UnitTest):
             stderr=subprocess.STDOUT,
         )
         assert "Finished codemodding 1 files!" in output
+
+    def test_warning_messages_several_files(self) -> None:
+        code = """
+        def baz() -> str:
+            return "{}: {}".format(*baz)
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p = Path(tmpdir)
+            (p / "mod1.py").write_text(CodemodTest.make_fixture_data(code))
+            (p / "mod2.py").write_text(CodemodTest.make_fixture_data(code))
+            (p / "mod3.py").write_text(CodemodTest.make_fixture_data(code))
+            output = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "libcst.tool",
+                    "codemod",
+                    "convert_format_to_fstring.ConvertFormatStringCommand",
+                    str(p),
+                ],
+                encoding="utf-8",
+                stderr=subprocess.PIPE,
+            )
+            # Each module will generate a warning, so we should get 3 warnings in total
+            self.assertIn(
+                "- 3 warnings were generated.",
+                output.stderr,
+            )


### PR DESCRIPTION
## Summary

Original idea belongs to @jschavesr. I am just resubmitting his abandoned [PR](https://github.com/Instagram/LibCST/pull/665).
Fixes the issue: https://github.com/Instagram/LibCST/issues/1183

Context warning messages were not being cleaned between files, so warnings from one files could be passed to other files in the context. Because of that warnings were being shown wrongly in the summary and the total number of warnings was wrong as well.

I also [encountered ](https://github.com/Instagram/LibCST/actions/runs/10231310110/job/28307117717?pr=1184)another error in Windows CI. Seems like codemodding small files happens faster than the timer counts more than zero (probably less precision on Windows). So fixing that, too.

```python
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "D:\a\LibCST\LibCST\libcst\tool.py", line 689, in <module>
    main(os.environ.get("LIBCST_TOOL_COMMAND_NAME", "libcst.tool"), sys.argv[1:])
  File "D:\a\LibCST\LibCST\libcst\tool.py", line 684, in main
    return lookup.get(args.action or None, _invalid_command)(proc_name, command_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\a\LibCST\LibCST\libcst\tool.py", line 420, in _codemod_impl
    result = parallel_exec_transform_with_prettyprint(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\a\LibCST\LibCST\libcst\codemod\_cli.py", line 659, in parallel_exec_transform_with_prettyprint
    progress.print(successes + failures + skips)
  File "D:\a\LibCST\LibCST\libcst\codemod\_cli.py", line 398, in print
    f"{self.ERASE_CURRENT_LINE}{self._human_seconds(elapsed_time)} {percent:.{self.pretty_precision}f}% complete, {self.estimate_completion(elapsed_time, finished, left)} estimated for {left} files to go...",
                                                                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\a\LibCST\LibCST\libcst\codemod\_cli.py", line 430, in estimate_completion
    fps = files_finished / elapsed_seconds
          ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
ZeroDivisionError: float division by zero
```

## Test Plan

### Before:

Running `convert_format_to_fstring.ConvertFormatStringCommand` on three files with identical contents:
```python
def baz() -> str:
    return "{}: {}".format(*baz)
```
All three are the same, so they should get one warning each.
But instead every following file gets more warnings copied from previous files:
```shell
LibCST> python -m libcst.tool codemod convert_format_to_fstring.ConvertFormatStringCommand tmp
Calculating full-repo metadata...
Executing codemod...
Codemodding tmp\mod1.py
WARNING: Unsupported field_name 0 in format() call
Successfully codemodded tmp\mod1.py with warnings

Codemodding tmp\mod2.py
WARNING: Unsupported field_name 0 in format() call
WARNING: Unsupported field_name 0 in format() call
Successfully codemodded tmp\mod2.py with warnings

Codemodding tmp\mod3.py
WARNING: Unsupported field_name 0 in format() call
WARNING: Unsupported field_name 0 in format() call
WARNING: Unsupported field_name 0 in format() call
Successfully codemodded tmp\mod3.py with warnings

Finished codemodding 3 files!
 - Transformed 3 files successfully.
 - Skipped 0 files.
 - Failed to codemod 0 files.
 - 6 warnings were generated.
```

The new test fails:

```python
FAIL: test_warning_messages_several_files (libcst.codemod.tests.test_codemod_cli.TestCodemodCLI.test_warning_messages_several_files)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "libcst\codemod\tests\test_codemod_cli.py", line 92, in test_warning_messages_several_files
    self.assertIn(
AssertionError: '- 3 warnings were generated.' not found in "Calculating full-repo metadata... ... \n - 6 warnings were generated.\n"
```

### After:

Each file generates one warning correctly:
```shell
LibCST> python -m libcst.tool codemod convert_format_to_fstring.ConvertFormatStringCommand tmp
Calculating full-repo metadata...
Executing codemod...
Codemodding tmp\mod1.py
WARNING: Unsupported field_name 0 in format() call
Successfully codemodded tmp\mod1.py with warnings

Codemodding tmp\mod2.py
WARNING: Unsupported field_name 0 in format() call
Successfully codemodded tmp\mod2.py with warnings

Codemodding tmp\mod3.py
WARNING: Unsupported field_name 0 in format() call
Successfully codemodded tmp\mod3.py with warnings

Finished codemodding 3 files!
 - Transformed 3 files successfully.
 - Skipped 0 files.
 - Failed to codemod 0 files.
 - 3 warnings were generated.
```

And the new test passes.
