### PR TITLE
Fix a minor grammar error in some docstrings.

### DIFF
--- a/libcst/_nodes/base.py
+++ b/libcst/_nodes/base.py
@@ -120,7 +120,7 @@ class CSTNode(ABC):
     def __init_subclass__(cls, **kwargs: Any) -> None:
         """
         HACK: Add our implementation of `__repr__`, `__hash__`, and `__eq__` to the
-        class's __dict__ to prevent dataclass from generating it's own `__repr__`,
+        class's __dict__ to prevent dataclass from generating its own `__repr__`,
         `__hash__`, and `__eq__`.
 
         The alternative is to require each implementation of a node to remember to add
@@ -152,7 +152,7 @@ class CSTNode(ABC):
         Compares the type annotations on a node's fields with those field's actual
         values at runtime. Raises a TypeError is a mismatch is found.
 
-        Only validates the current node, not any of it's children. For a recursive
+        Only validates the current node, not any of its children. For a recursive
         version, see :func:`validate_types_deep`.
 
         If you're using a static type checker (highly recommended), this is useless.


### PR DESCRIPTION
## Summary
Fix a minor grammar error in some docstrings.

it's means "it is". its is the possessive.

## Test Plan
No plan, this is a docstring change that is neutral in line count.
