### PR TITLE
fix certain matchers breaking under multiprocessing by initializing them late

### DIFF
--- a/libcst/matchers/_visitors.py
+++ b/libcst/matchers/_visitors.py
@@ -270,20 +270,22 @@ def _check_types(
             )
 
 
-def _gather_matchers(obj: object) -> Set[BaseMatcherNode]:
-    visit_matchers: Set[BaseMatcherNode] = set()
+def _gather_matchers(obj: object) -> Dict[BaseMatcherNode, Optional[cst.CSTNode]]:
+    """
+    Set of gating matchers that we need to track and evaluate. We use these
+    in conjunction with the call_if_inside and call_if_not_inside decorators
+    to determine whether to call a visit/leave function.
+    """
 
-    for func in dir(obj):
-        try:
-            for matcher in getattr(getattr(obj, func), VISIT_POSITIVE_MATCHER_ATTR, []):
-                visit_matchers.add(cast(BaseMatcherNode, matcher))
-            for matcher in getattr(getattr(obj, func), VISIT_NEGATIVE_MATCHER_ATTR, []):
-                visit_matchers.add(cast(BaseMatcherNode, matcher))
-        except Exception:
-            # This could be a caculated property, and calling getattr() evaluates it.
-            # We have no control over the implementation detail, so if it raises, we
-            # should not crash.
-            pass
+    visit_matchers: Dict[BaseMatcherNode, Optional[cst.CSTNode]] = {}
+
+    for attr_name in dir(obj):
+        if not is_property(obj, attr_name):
+            func = getattr(obj, attr_name)
+            for matcher in getattr(func, VISIT_POSITIVE_MATCHER_ATTR, []):
+                visit_matchers[cast(BaseMatcherNode, matcher)] = None
+            for matcher in getattr(func, VISIT_NEGATIVE_MATCHER_ATTR, []):
+                visit_matchers[cast(BaseMatcherNode, matcher)] = None
 
     return visit_matchers
 
@@ -445,12 +447,7 @@ class MatcherDecoratableTransformer(CSTTransformer):
 
     def __init__(self) -> None:
         CSTTransformer.__init__(self)
-        # List of gating matchers that we need to track and evaluate. We use these
-        # in conjuction with the call_if_inside and call_if_not_inside decorators
-        # to determine whether or not to call a visit/leave function.
-        self._matchers: Dict[BaseMatcherNode, Optional[cst.CSTNode]] = {
-            m: None for m in _gather_matchers(self)
-        }
+        self.__matchers: Optional[Dict[BaseMatcherNode, Optional[cst.CSTNode]]] = None
         # Mapping of matchers to functions. If in the course of visiting the tree,
         # a node matches one of these matchers, the corresponding function will be
         # called as if it was a visit_* method.
@@ -482,6 +479,16 @@ class MatcherDecoratableTransformer(CSTTransformer):
             expected_param_count=2,
             expected_none_return=False,
         )
+
+    @property
+    def _matchers(self) -> Dict[BaseMatcherNode, Optional[cst.CSTNode]]:
+        if self.__matchers is None:
+            self.__matchers = _gather_matchers(self)
+        return self.__matchers
+
+    @_matchers.setter
+    def _matchers(self, value: Dict[BaseMatcherNode, Optional[cst.CSTNode]]) -> None:
+        self.__matchers = value
 
     def on_visit(self, node: cst.CSTNode) -> bool:
         # First, evaluate any matchers that we have which we are not inside already.
@@ -657,12 +664,7 @@ class MatcherDecoratableVisitor(CSTVisitor):
 
     def __init__(self) -> None:
         CSTVisitor.__init__(self)
-        # List of gating matchers that we need to track and evaluate. We use these
-        # in conjuction with the call_if_inside and call_if_not_inside decorators
-        # to determine whether or not to call a visit/leave function.
-        self._matchers: Dict[BaseMatcherNode, Optional[cst.CSTNode]] = {
-            m: None for m in _gather_matchers(self)
-        }
+        self.__matchers: Optional[Dict[BaseMatcherNode, Optional[cst.CSTNode]]] = None
         # Mapping of matchers to functions. If in the course of visiting the tree,
         # a node matches one of these matchers, the corresponding function will be
         # called as if it was a visit_* method.
@@ -689,6 +691,16 @@ class MatcherDecoratableVisitor(CSTVisitor):
             expected_param_count=1,
             expected_none_return=True,
         )
+
+    @property
+    def _matchers(self) -> Dict[BaseMatcherNode, Optional[cst.CSTNode]]:
+        if self.__matchers is None:
+            self.__matchers = _gather_matchers(self)
+        return self.__matchers
+
+    @_matchers.setter
+    def _matchers(self, value: Dict[BaseMatcherNode, Optional[cst.CSTNode]]) -> None:
+        self.__matchers = value
 
     def on_visit(self, node: cst.CSTNode) -> bool:
         # First, evaluate any matchers that we have which we are not inside already.


### PR DESCRIPTION
Support matcher decorators with multiprocessing on Windows/macOS.

See issue #1181 for more context.

## Summary

- Call `_gather_matchers` later in the code (first time when it's needed) to ensure we initialize them in a process AFTER the "fork".
- Proactively check if attributes are not properties instead of trying to evaluate them and suppressing all errors.

## Test Plan

### Before
```
> hatch run python -m unittest libcst.codemod.tests.test_codemod_cli.TestCodemodCLI.test_matcher_decorators_multiprocessing

FAILED (failures=1)
```

### After
```
> hatch run python -m unittest libcst.codemod.tests.test_codemod_cli.TestCodemodCLI.test_matcher_decorators_multiprocessing     
.
----------------------------------------------------------------------
Ran 1 test in 0.973s

OK
```