### PR TITLE
Make rust build deterministic

### DIFF
--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -4,3 +4,8 @@ members = [
     "libcst",
     "libcst_derive",
 ]
+
+# needed for reproducible builds from some hard-to-grasp issue in rust or LLVM
+# = https://github.com/rust-lang/rust/issues/128675
+[profile.release]
+lto = "off"


### PR DESCRIPTION
## Summary

We disable LTO and use `codegen-units = 1` for deterministic build results of the rust code.
See https://reproducible-builds.org/ for why this is good.

https://github.com/rust-lang/rust/issues/128675 states that the default `codegen-units = 16` should be deterministic, but here it clearly is not.

## Test Plan

