### PR TITLE
`libcst.tool`: add support Python 3.9, 3.10, 3.11, 3.12 and 3.13

### DIFF
--- a/libcst/_parser/types/config.py
+++ b/libcst/_parser/types/config.py
@@ -44,7 +44,7 @@ class AutoConfig(Enum):
 
 
 # This list should be kept in sorted order.
-KNOWN_PYTHON_VERSION_STRINGS = ["3.0", "3.1", "3.3", "3.5", "3.6", "3.7", "3.8"]
+KNOWN_PYTHON_VERSION_STRINGS = ["3.0", "3.1", "3.3"] + [f"3.{v}" for v in range(5, 14)]
 
 
 @add_slots


### PR DESCRIPTION
Currently, running e.g. `libcst.tool codemod --python-version=3.9 ...` will raise a `ValueError` with the message:

```
ValueError: LibCST can only parse code using one of the following versions of Python's grammar: 3.0, 3.1, 3.3, 3.5, 3.6, 3.7, 3.8. More versions may be supported by future releases.
```

This adds the missing supported python version strings.
