### PR TITLE
Draft: ci: build wheels for musllinux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       CIBW_BEFORE_ALL_MACOS: "rustup target add aarch64-apple-darwin x86_64-apple-darwin"
       CIBW_BEFORE_ALL_WINDOWS: "rustup target add x86_64-pc-windows-msvc i686-pc-windows-msvc"
       CIBW_ENVIRONMENT: 'PATH="$PATH:$HOME/.cargo/bin" LIBCST_NO_LOCAL_SCHEME=$LIBCST_NO_LOCAL_SCHEME'
-      CIBW_SKIP: "cp27-* cp34-* cp35-* pp* *-win32 *-win_arm64 *-musllinux_*"
+      CIBW_SKIP: "cp27-* cp34-* cp35-* pp* *-win32 *-win_arm64"
       CIBW_ARCHS_LINUX: auto aarch64
       CIBW_BUILD_VERBOSITY: 1
     steps:


### PR DESCRIPTION
## Summary

Allow CIBW to build wheels with -msullinux tags.

Alpine CIs could greatly benefit from having `libcst` available.

Closes #962

