### PR TITLE
ci: skip musllinux builds for unsupported archs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       CIBW_BEFORE_ALL_MACOS: "rustup target add aarch64-apple-darwin x86_64-apple-darwin"
       CIBW_BEFORE_ALL_WINDOWS: "rustup target add x86_64-pc-windows-msvc i686-pc-windows-msvc"
       CIBW_ENVIRONMENT: 'PATH="$PATH:$HOME/.cargo/bin" LIBCST_NO_LOCAL_SCHEME=$LIBCST_NO_LOCAL_SCHEME'
-      CIBW_SKIP: "cp27-* cp34-* cp35-* pp* *-win32 *-win_arm64"
+      CIBW_SKIP: "cp27-* cp34-* cp35-* pp* *-win32 *-win_arm64 *-musllinux_i686 *-musllinux_ppc64le *-musllinux_s390x *-musllinux_armv7l"
       CIBW_ARCHS_LINUX: auto aarch64
       CIBW_BUILD_VERBOSITY: 1
     steps:


### PR DESCRIPTION
See #1243. CI started failing after pulling that change into `main`.

## Summary

This fixes current CI failures by skipping Musl builds for `i686`, `ppc64le`, `s390x`, and `armv7le` architectures.

The failures are due to Rust ecosystem having only partial support / not having tool chains for these architectures. For the list of supported archs and tiers of support, see:

https://doc.rust-lang.org/nightly/rustc/platform-support.html

The architectures skipped here are either, from the Rust PoV:

- Tier-2 support without host tools.
- Tier-3 support without host tools.