### PR TITLE
rename: fix renaming toplevel names

### DIFF
--- a/libcst/codemod/commands/rename.py
+++ b/libcst/codemod/commands/rename.py
@@ -347,7 +347,7 @@ class RenameCommand(VisitorBasedCodemodCommand):
                     module_as_name[0] + ".", module_as_name[1] + ".", 1
                 )
 
-        if original_name == self.old_mod_or_obj:
+        if self.old_module and original_name == self.old_mod_or_obj:
             return self.new_mod_or_obj
         elif original_name == self.old_name:
             return (

--- a/libcst/codemod/commands/tests/test_rename.py
+++ b/libcst/codemod/commands/tests/test_rename.py
@@ -850,3 +850,25 @@ class TestRenameCommand(CodemodTest):
             z.c(z.c.d)
         """
         self.assertCodemod(before, after, old_name="a.b.c", new_name="z.c")
+
+    def test_push_down_toplevel_names(self) -> None:
+        before = """
+            import foo
+            foo.baz()
+        """
+        after = """
+            import quux.foo
+            quux.foo.baz()
+        """
+        self.assertCodemod(before, after, old_name="foo", new_name="quux.foo")
+
+    def test_push_down_toplevel_names_with_asname(self) -> None:
+        before = """
+            import foo as bar
+            bar.baz()
+        """
+        after = """
+            import quux.foo
+            quux.foo.baz()
+        """
+        self.assertCodemod(before, after, old_name="foo", new_name="quux.foo")


### PR DESCRIPTION

For toplevel module names imported via `import foo`, the rename codemod would fail to change these. This PR fixes that.
