### PR TITLE
Add codemod to rename typing aliases of builtins

### DIFF
--- a/libcst/codemod/commands/rename.py
+++ b/libcst/codemod/commands/rename.py
@@ -328,7 +328,7 @@ class RenameCommand(VisitorBasedCodemodCommand):
         # If bypass_import is False, we know that no import statements were directly renamed, and the fact
         # that we have any `self.scheduled_removals` tells us we encountered a matching `old_name` in the code.
         if not self.bypass_import and self.scheduled_removals:
-            if self.new_module:
+            if self.new_module and self.new_module != "builtins":
                 new_obj: Optional[str] = (
                     self.new_mod_or_obj.split(".")[0] if self.new_mod_or_obj else None
                 )

--- a/libcst/codemod/commands/rename_typing_generic_aliases.py
+++ b/libcst/codemod/commands/rename_typing_generic_aliases.py
@@ -1,0 +1,31 @@
+from functools import partial
+from typing import cast, Generator
+
+from libcst.codemod import Codemod, MagicArgsCodemodCommand
+from libcst.codemod.commands.rename import RenameCommand
+
+
+class RenameTypingGenericAliases(MagicArgsCodemodCommand):
+    DESCRIPTION: str = (
+        "Rename typing module aliases of builtin generics in Python 3.9+, for example: `typing.List` -> `list`"
+    )
+
+    MAPPING: dict[str, str] = {
+        "typing.List": "builtins.list",
+        "typing.Tuple": "builtins.tuple",
+        "typing.Dict": "builtins.dict",
+        "typing.FrozenSet": "builtins.frozenset",
+        "typing.Set": "builtins.set",
+        "typing.Type": "builtins.type",
+    }
+
+    def get_transforms(self) -> Generator[type[Codemod], None, None]:
+        for from_type, to_type in self.MAPPING.items():
+            yield cast(
+                type[Codemod],
+                partial(
+                    RenameCommand,
+                    old_name=from_type,
+                    new_name=to_type,
+                ),
+            )

--- a/libcst/codemod/commands/rename_typing_generic_aliases.py
+++ b/libcst/codemod/commands/rename_typing_generic_aliases.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# pyre-strict
 from functools import partial
 from typing import cast, Generator
 

--- a/libcst/codemod/commands/tests/test_rename.py
+++ b/libcst/codemod/commands/tests/test_rename.py
@@ -28,6 +28,19 @@ class TestRenameCommand(CodemodTest):
 
         self.assertCodemod(before, after, old_name="foo.bar", new_name="baz.qux")
 
+    def test_rename_to_builtin(self) -> None:
+        before = """
+            from typing import List
+            x: List[int] = []
+        """
+        after = """
+            x: list[int] = []
+        """
+
+        self.assertCodemod(
+            before, after, old_name="typing.List", new_name="builtins.list"
+        )
+
     def test_rename_name_asname(self) -> None:
         before = """
             from foo import bar as bla

--- a/libcst/codemod/commands/tests/test_rename_typing_generic_aliases.py
+++ b/libcst/codemod/commands/tests/test_rename_typing_generic_aliases.py
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# pyre-strict
+
+from libcst.codemod import CodemodTest
+from libcst.codemod.commands.rename_typing_generic_aliases import RenameTypingGenericAliases
+
+
+class TestRenameCommand(CodemodTest):
+    TRANSFORM = RenameTypingGenericAliases
+
+    def test_rename_typing_generic_alias(self) -> None:
+        before = """
+            from typing import List, Set, Dict, FrozenSet, Tuple
+            x: List[int] = []
+            y: Set[int] = set()
+            z: Dict[str, int] = {}
+            a: FrozenSet[str] = frozenset()
+            b: Tuple[int, str] = (1, "hello")
+        """
+        after = """
+            x: list[int] = []
+            y: set[int] = set()
+            z: dict[str, int] = {}
+            a: frozenset[str] = frozenset()
+            b: tuple[int, str] = (1, "hello")
+        """
+        self.assertCodemod(before, after)

--- a/libcst/codemod/commands/tests/test_rename_typing_generic_aliases.py
+++ b/libcst/codemod/commands/tests/test_rename_typing_generic_aliases.py
@@ -6,7 +6,9 @@
 # pyre-strict
 
 from libcst.codemod import CodemodTest
-from libcst.codemod.commands.rename_typing_generic_aliases import RenameTypingGenericAliases
+from libcst.codemod.commands.rename_typing_generic_aliases import (
+    RenameTypingGenericAliases,
+)
 
 
 class TestRenameCommand(CodemodTest):


### PR DESCRIPTION
## Summary

This PR adds a codemod for Python 3.9+ that updates references like `typing.List` to just `list`. It includes all the builtins that have an alias in the typing module.

We can also do the same thing for some non-builtin types in the collections module (the full list is in https://peps.python.org/pep-0585/#implementation) but I'm not sure if that should be a separate codemod or added to this one.

I also had to update the RenameCommand to avoid adding imports if the new name is a builtin.

## Test Plan

hatch run python -m unittest libcst.codemod.commands.tests.test_rename
hatch run python -m unittest libcst.codemod.commands.tests.test_rename_typing_generic_aliases

