### PR TITLE
Update for Pyo3 0.23

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -506,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.22.2"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831e8e819a138c36e212f3af3fd9eeffed6bf1510a805af35b0edee5ffa59433"
+checksum = "57fe09249128b3173d092de9523eaa75136bf7ba85e0d69eca241c7939c933cc"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -524,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.2"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e8730e591b14492a8945cdff32f089250b05f5accecf74aeddf9e8272ce1fa8"
+checksum = "1cd3927b5a78757a0d71aa9dff669f903b1eb64b54142a9bd9f757f8fde65fd7"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -534,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.2"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e97e919d2df92eb88ca80a037969f44e5e70356559654962cbb3316d00300c6"
+checksum = "dab6bb2102bd8f991e7749f130a70d05dd557613e39ed2deeee8e9ca0c4d548d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -544,9 +544,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.2"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb57983022ad41f9e683a599f2fd13c3664d7063a3ac5714cae4b7bee7d3f206"
+checksum = "91871864b353fd5ffcb3f91f2f703a22a9797c91b9ab497b1acac7b07ae509c7"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -556,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.2"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec480c0c51ddec81019531705acac51bcdbeae563557c982aa8263bb96880372"
+checksum = "43abc3b80bc20f3facd86cd3c60beed58c3e2aa26213f3cda368de39c60a27e4"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/native/libcst/Cargo.toml
+++ b/native/libcst/Cargo.toml
@@ -36,7 +36,7 @@ trace = ["peg/trace"]
 
 [dependencies]
 paste = "1.0.15"
-pyo3 = { version = "0.22", optional = true }
+pyo3 = { version = "0.23", optional = true }
 thiserror = "1.0.63"
 peg = "0.8.4"
 chic = "1.2.2"

--- a/native/libcst/src/nodes/expression.rs
+++ b/native/libcst/src/nodes/expression.rs
@@ -2536,7 +2536,7 @@ mod py {
             match self {
                 Self::Starred(s) => s.try_into_py(py),
                 Self::Simple { value, comma } => {
-                    let libcst = PyModule::import_bound(py, "libcst")?;
+                    let libcst = PyModule::import(py, "libcst")?;
                     let kwargs = [
                         Some(("value", value.try_into_py(py)?)),
                         comma
@@ -2548,7 +2548,7 @@ mod py {
                     .filter(|x| x.is_some())
                     .map(|x| x.as_ref().unwrap())
                     .collect::<Vec<_>>()
-                    .into_py_dict_bound(py);
+                    .into_py_dict(py)?;
                     Ok(libcst
                         .getattr("Element")
                         .expect("no Element found in libcst")
@@ -2572,7 +2572,7 @@ mod py {
                     whitespace_before_colon,
                     ..
                 } => {
-                    let libcst = PyModule::import_bound(py, "libcst")?;
+                    let libcst = PyModule::import(py, "libcst")?;
                     let kwargs = [
                         Some(("key", key.try_into_py(py)?)),
                         Some(("value", value.try_into_py(py)?)),
@@ -2593,7 +2593,7 @@ mod py {
                     .filter(|x| x.is_some())
                     .map(|x| x.as_ref().unwrap())
                     .collect::<Vec<_>>()
-                    .into_py_dict_bound(py);
+                    .into_py_dict(py)?;
                     Ok(libcst
                         .getattr("DictElement")
                         .expect("no Element found in libcst")

--- a/native/libcst/src/nodes/traits.rs
+++ b/native/libcst/src/nodes/traits.rs
@@ -118,7 +118,7 @@ impl<'a, T: Inflate<'a>> Inflate<'a> for Vec<T> {
 }
 #[cfg(feature = "py")]
 pub mod py {
-    use pyo3::{types::PyAny, types::PyTuple, IntoPy, PyObject, PyResult, Python};
+    use pyo3::{types::PyTuple, IntoPyObjectExt, PyObject, PyResult, Python};
 
     // TODO: replace with upstream implementation once
     // https://github.com/PyO3/pyo3/issues/1813 is resolved
@@ -135,7 +135,7 @@ pub mod py {
 
     impl TryIntoPy<PyObject> for bool {
         fn try_into_py(self, py: Python) -> PyResult<PyObject> {
-            Ok(self.into_py(py))
+            self.into_py_any(py)
         }
     }
 
@@ -170,28 +170,13 @@ pub mod py {
                 .map(|x| x.try_into_py(py))
                 .collect::<PyResult<Vec<_>>>()?
                 .into_iter();
-            Ok(PyTuple::new_bound(py, converted).into())
-        }
-    }
-
-    impl TryIntoPy<PyObject> for PyTuple {
-        fn try_into_py(self, py: Python) -> PyResult<PyObject> {
-            Ok(self.into_py(py))
+            PyTuple::new(py, converted).unwrap().into_py_any(py)
         }
     }
 
     impl<'a> TryIntoPy<PyObject> for &'a str {
         fn try_into_py(self, py: Python) -> PyResult<PyObject> {
-            Ok(self.into_py(py))
-        }
-    }
-
-    impl<T> TryIntoPy<PyObject> for &'_ T
-    where
-        T: AsRef<PyAny>,
-    {
-        fn try_into_py(self, py: Python) -> PyResult<PyObject> {
-            Ok(self.into_py(py))
+            self.into_py_any(py)
         }
     }
 }

--- a/native/libcst/src/nodes/traits.rs
+++ b/native/libcst/src/nodes/traits.rs
@@ -170,7 +170,7 @@ pub mod py {
                 .map(|x| x.try_into_py(py))
                 .collect::<PyResult<Vec<_>>>()?
                 .into_iter();
-            PyTuple::new(py, converted).unwrap().into_py_any(py)
+            PyTuple::new(py, converted)?.into_py_any(py)
         }
     }
 


### PR DESCRIPTION
## Summary

Updates the native library to use PyO3 0.23. This is the first step towards declaring support for the free-threaded interpreter.

I could have gone further in ripping out `TryIntoPy` in favor of `IntoPyObject`. If you'd prefer not to leave this project in a state with an unnecessary wrapper trait I'm happy to implement that, I just wanted to make the smallest possible working diff.

## Test Plan

This passes the tests for me locally. Let's see if CI spots and issues.
