### PR TITLE
add free-threaded CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,51 @@ jobs:
           hatch run coverage combine .coverage.pure
           hatch run coverage report
 
+  # TODO:
+  # merge into regular CI once hatch has support for creating environments on
+  # the free-threaded build: https://github.com/pypa/hatch/issues/1931
+  free-threaded-tests:
+    name: "test (${{ matrix.os }}, 3.13t)"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      # TODO: update to tagged release when there is one
+      - uses: actions/setup-python@9e62be81b28222addecf85e47571213eb7680449
+        with:
+          cache: pip
+          cache-dependency-path: "pyproject.toml"
+          python-version: '3.13t'
+      - name: Build LibCST
+        run: |
+          # Install build-system.requires dependencies
+          pip install setuptools setuptools-scm setuptools-rust wheel
+          # Jupyter is annoying to install on free-threaded Python
+          pip install -e .[dev-without-jupyter] --no-build-isolation
+      - name: Native Parser Tests
+        # TODO: remove when native modules declare free-threaded support
+        env:
+          PYTHON_GIL: '0'
+        run: |
+          python -m coverage run -m libcst.tests
+      - name: Pure Parser Tests
+        env:
+          COVERAGE_FILE: .coverage.pure
+          LIBCST_PARSER_TYPE: pure
+        run: |
+          python -m coverage run -m libcst.tests
+      - name: Coverage
+        run: |
+          python -m coverage combine .coverage.pure
+          python -m coverage report
+
+
   # Run linters
   lint:
     runs-on: ubuntu-latest
@@ -110,6 +155,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.10", "3.13t"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -117,9 +163,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-      - uses: actions/setup-python@v5
+      # TODO: update to tagged release when there is one
+      - uses: actions/setup-python@9e62be81b28222addecf85e47571213eb7680449
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
       - name: test
         uses: actions-rs/cargo@v1
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,11 @@ dependencies = ["pyyaml>=5.2"]
 
 [project.optional-dependencies]
 dev = [
+    "libcst[dev-without-jupyter]",
+    "jupyter>=1.0.0",
+    "nbsphinx>=0.4.2",
+]
+dev-without-jupyter = [
     "black==24.8.0",
     "coverage[toml]>=4.5.4",
     "build>=0.10.0",
@@ -30,9 +35,7 @@ dev = [
     "Sphinx>=5.1.1",
     "hypothesis>=4.36.0",
     "hypothesmith>=0.0.4",
-    "jupyter>=1.0.0",
     "maturin>=1.7.0,<1.8",
-    "nbsphinx>=0.4.2",
     "prompt-toolkit>=2.0.9",
     "pyre-check==0.9.18; platform_system != 'Windows'",
     "setuptools_scm>=6.0.1",


### PR DESCRIPTION
xref #1242 

passes CI on my fork: https://github.com/ngoldbaum/LibCST/actions/runs/13817416645

Is adding `dev-without-jupyter` in `pyproject.toml` ok? It seemed like the cleanest way to handle avoiding jupyter. You could also split `dev` into `tests` and `docs` but I'm not sure how to sort the dependencies.

The windows 3.13t CI is pretty slow but I think most of that is just installing Python and once the cache populates it should be faster.

I'm pinning to an unreleased version of `setup-python` - hopefully Github does a release with free-threaded support soon.