### PR TITLE
don't use --no-build-isolation for free-threaded CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           # Install build-system.requires dependencies
           pip install setuptools setuptools-scm setuptools-rust wheel
           # Jupyter is annoying to install on free-threaded Python
-          pip install -e .[dev-without-jupyter] --no-build-isolation
+          pip install -e .[dev-without-jupyter]
       - name: Native Parser Tests
         # TODO: remove when native modules declare free-threaded support
         env:


### PR DESCRIPTION
It turns out this isn't necessary: https://github.com/ngoldbaum/LibCST/actions/runs/13838495891
