### PR TITLE
ci: enable macos intel wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ jobs:
     env:
       SCCACHE_VERSION: 0.2.13
       GITHUB_WORKSPACE: "${{github.workspace}}"
-      MACOSX_DEPLOYMENT_TARGET: "10.12"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -26,6 +25,10 @@ jobs:
           cache: pip
           cache-dependency-path: "pyproject.toml"
           python-version: "3.12"
+      - name: Set MACOSX_DEPLOYMENT_TARGET for Intel MacOS
+        if: matrix.os == 'macos-13'
+        run: >-
+          echo MACOSX_DEPLOYMENT_TARGET=10.13 >> $GITHUB_ENV
       - name: Disable scmtools local scheme
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: >-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set MACOSX_DEPLOYMENT_TARGET for Intel MacOS
         if: matrix.os == 'macos-13'
         run: >-
-          echo MACOSX_DEPLOYMENT_TARGET=10.13 >> $GITHUB_ENV
+          echo MACOSX_DEPLOYMENT_TARGET=10.12 >> $GITHUB_ENV
       - name: Disable scmtools local scheme
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: >-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest]
+        # macos-13 is an intel runner, macos-latest is apple silicon
+        os: [macos-13, macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest]
     env:
       SCCACHE_VERSION: 0.2.13
       GITHUB_WORKSPACE: "${{github.workspace}}"
+      MACOSX_DEPLOYMENT_TARGET: "10.12"
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

Basically fixes #1279 by bumping minimum MacOS version from `10.9` (`cibuildwheel` default) to `10.12`.

`Rustc` requires `MACOSX_DEPLOYMENT_TARGET >= 3.12` while `cibuildwheel` sets the `MACOSX_DEPLOYMENT_TARGET` to `10.9` by default, if not specified by the user.

ref 0: [cibuildwheel/macos.py](https://github.com/pypa/cibuildwheel/blob/main/cibuildwheel/macos.py#L285-L306)

ref 1: [rustc/src/platform-support/apple-darwin.md](https://github.com/rust-lang/rust/blob/d8e44b722a93e55cbc9a8188dfbfe3faf1226096/src/doc/rustc/src/platform-support/apple-darwin.md?plain=1#L33C1-L37C10)

