### PR TITLE
use released version of setup-python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      # TODO: update to tagged release when there is one
-      - uses: actions/setup-python@9e62be81b28222addecf85e47571213eb7680449
+      - uses: actions/setup-python@v5
         with:
           cache: pip
           cache-dependency-path: "pyproject.toml"
@@ -163,8 +162,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-      # TODO: update to tagged release when there is one
-      - uses: actions/setup-python@9e62be81b28222addecf85e47571213eb7680449
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: test


### PR DESCRIPTION
5.5.0 added support for `3.13t`: https://github.com/actions/setup-python/releases/tag/v5.5.0

