### PR TITLE
allow configuring empty formatter lists in codemod CLI

### DIFF
--- a/libcst/tool.py
+++ b/libcst/tool.py
@@ -377,7 +377,10 @@ def _codemod_impl(proc_name: str, command_args: List[str]) -> int:  # noqa: C901
     command_instance = command_class(CodemodContext(), **codemod_args)
 
     # Sepcify target version for black formatter
-    if any(config["formatter"]) and os.path.basename(config["formatter"][0]) in ("black", "black.exe"):
+    if any(config["formatter"]) and os.path.basename(config["formatter"][0]) in (
+        "black",
+        "black.exe",
+    ):
         parsed_version = parse_version_string(args.python_version)
 
         config["formatter"] = [

--- a/libcst/tool.py
+++ b/libcst/tool.py
@@ -377,7 +377,7 @@ def _codemod_impl(proc_name: str, command_args: List[str]) -> int:  # noqa: C901
     command_instance = command_class(CodemodContext(), **codemod_args)
 
     # Sepcify target version for black formatter
-    if os.path.basename(config["formatter"][0]) in ("black", "black.exe"):
+    if any(config["formatter"]) and os.path.basename(config["formatter"][0]) in ("black", "black.exe"):
         parsed_version = parse_version_string(args.python_version)
 
         config["formatter"] = [


### PR DESCRIPTION
## Summary

Right now if you have an empty formatter list, you'll crash on this line:

```
goldbaum at Nathans-MBP in ~/Documents/numpy on format-to-fstring
± python3 -m libcst.tool codemod --no-format convert_format_to_fstring.ConvertFormatStringCommand .
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/goldbaum/.pyenv/versions/3.13.2/lib/python3.13/site-packages/libcst/tool.py", line 688, in <module>
    main(os.environ.get("LIBCST_TOOL_COMMAND_NAME", "libcst.tool"), sys.argv[1:])
    ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/goldbaum/.pyenv/versions/3.13.2/lib/python3.13/site-packages/libcst/tool.py", line 683, in main
    return lookup.get(args.action or None, _invalid_command)(proc_name, command_args)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/goldbaum/.pyenv/versions/3.13.2/lib/python3.13/site-packages/libcst/tool.py", line 380, in _codemod_impl
    if os.path.basename(config["formatter"][0]) in ("black", "black.exe"):
                        ~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

I think having an empty formatter list is a reasonable thing. You'll still error out later unless you don't pass `--no-format` to the CLI tool.

## Test Plan

Right now the codemod CLI doesn't have great tests so it's not easy to add a new test. Happy to talk about that though since I think having better end-to-end tests will make writing multithreaded stress tests easier.