### PR TITLE
Don't share transforms between thread pool tasks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         run: >-
           echo LIBCST_NO_LOCAL_SCHEME=1 >> $GITHUB_ENV
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.0
+        uses: pypa/cibuildwheel@v2.23.1
       - uses: actions/upload-artifact@v4
         with:
           path: wheelhouse/*.whl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         run: >-
           echo LIBCST_NO_LOCAL_SCHEME=1 >> $GITHUB_ENV
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.1
+        uses: pypa/cibuildwheel@v2.23.2
       - uses: actions/upload-artifact@v4
         with:
           path: wheelhouse/*.whl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest]
+        # macos-13 is an intel runner, macos-latest is apple silicon
+        os: [macos-13, macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest]
     env:
       SCCACHE_VERSION: 0.2.13
       GITHUB_WORKSPACE: "${{github.workspace}}"
@@ -24,6 +25,10 @@ jobs:
           cache: pip
           cache-dependency-path: "pyproject.toml"
           python-version: "3.12"
+      - name: Set MACOSX_DEPLOYMENT_TARGET for Intel MacOS
+        if: matrix.os == 'macos-13'
+        run: >-
+          echo MACOSX_DEPLOYMENT_TARGET=10.12 >> $GITHUB_ENV
       - name: Disable scmtools local scheme
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      # TODO: update to tagged release when there is one
-      - uses: actions/setup-python@9e62be81b28222addecf85e47571213eb7680449
+      - uses: actions/setup-python@v5
         with:
           cache: pip
           cache-dependency-path: "pyproject.toml"
@@ -163,8 +162,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-      # TODO: update to tagged release when there is one
-      - uses: actions/setup-python@9e62be81b28222addecf85e47571213eb7680449
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,51 @@ jobs:
           hatch run coverage combine .coverage.pure
           hatch run coverage report
 
+  # TODO:
+  # merge into regular CI once hatch has support for creating environments on
+  # the free-threaded build: https://github.com/pypa/hatch/issues/1931
+  free-threaded-tests:
+    name: "test (${{ matrix.os }}, 3.13t)"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      # TODO: update to tagged release when there is one
+      - uses: actions/setup-python@9e62be81b28222addecf85e47571213eb7680449
+        with:
+          cache: pip
+          cache-dependency-path: "pyproject.toml"
+          python-version: '3.13t'
+      - name: Build LibCST
+        run: |
+          # Install build-system.requires dependencies
+          pip install setuptools setuptools-scm setuptools-rust wheel
+          # Jupyter is annoying to install on free-threaded Python
+          pip install -e .[dev-without-jupyter] --no-build-isolation
+      - name: Native Parser Tests
+        # TODO: remove when native modules declare free-threaded support
+        env:
+          PYTHON_GIL: '0'
+        run: |
+          python -m coverage run -m libcst.tests
+      - name: Pure Parser Tests
+        env:
+          COVERAGE_FILE: .coverage.pure
+          LIBCST_PARSER_TYPE: pure
+        run: |
+          python -m coverage run -m libcst.tests
+      - name: Coverage
+        run: |
+          python -m coverage combine .coverage.pure
+          python -m coverage report
+
+
   # Run linters
   lint:
     runs-on: ubuntu-latest
@@ -110,6 +155,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.10", "3.13t"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -117,9 +163,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-      - uses: actions/setup-python@v5
+      # TODO: update to tagged release when there is one
+      - uses: actions/setup-python@9e62be81b28222addecf85e47571213eb7680449
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
       - name: test
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           # Install build-system.requires dependencies
           pip install setuptools setuptools-scm setuptools-rust wheel
           # Jupyter is annoying to install on free-threaded Python
-          pip install -e .[dev-without-jupyter] --no-build-isolation
+          pip install -e .[dev-without-jupyter]
       - name: Native Parser Tests
         # TODO: remove when native modules declare free-threaded support
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,21 @@
-# 1.6.0 - 2024-01-09
+# 1.7.0 - 2025-03-13
+
+## Added
+* add free-threaded CI by @ngoldbaum in https://github.com/Instagram/LibCST/pull/1312
+
+## Updated
+* Remove dependency on `chic` and upgrade `annotate-snippets` by @zanieb in https://github.com/Instagram/LibCST/pull/1293
+* Update for Pyo3 0.23 by @ngoldbaum in https://github.com/Instagram/LibCST/pull/1289
+* Bump PyO3 to 0.23.5 by @mgorny in https://github.com/Instagram/LibCST/pull/1311
+
+## New Contributors
+* @zanieb made their first contribution in https://github.com/Instagram/LibCST/pull/1293
+* @ngoldbaum made their first contribution in https://github.com/Instagram/LibCST/pull/1289
+* @mgorny made their first contribution in https://github.com/Instagram/LibCST/pull/1311
+
+**Full Changelog**: https://github.com/Instagram/LibCST/compare/v1.6.0...v1.7.0
+
+# 1.6.0 - 2025-01-09
 
 ## Fixed
 

--- a/libcst/_visitors.py
+++ b/libcst/_visitors.py
@@ -21,11 +21,15 @@ if TYPE_CHECKING:
 CSTVisitorT = Union["CSTTransformer", "CSTVisitor"]
 
 cache = threading.local()
+marker = object()
 
 def type_lookup(tp, name, default=None):
     if not hasattr(cache, "_cache"):
         cache._cache = {}
-    return cache._cache.setdefault((tp, name, default), getattr(tp, name, default))
+    value = cache._cache.get((tp, name, default), marker)
+    if value is marker:
+        value = cache._cache.setdefault((tp, name, default), getattr(tp, name, default))
+    return value
 
 
 class CSTTransformer(CSTTypedTransformerFunctions, MetadataDependent):

--- a/libcst/_visitors.py
+++ b/libcst/_visitors.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import sys
+
 from typing import TYPE_CHECKING, Union
 
 from libcst._flatten_sentinel import FlattenSentinel
@@ -39,7 +41,7 @@ class CSTTransformer(CSTTypedTransformerFunctions, MetadataDependent):
         Returns ``True`` if children should be visited, and returns ``False``
         otherwise.
         """
-        visit_func = getattr(self, f"visit_{type(node).__name__}", None)
+        visit_func = getattr(self, sys.intern(f"visit_{type(node).__name__}"), None)
         if visit_func is not None:
             retval = visit_func(node)
         else:
@@ -66,7 +68,7 @@ class CSTTransformer(CSTTypedTransformerFunctions, MetadataDependent):
         exception if this node is required. As a convenience, you can use
         :func:`RemoveFromParent` as an alias to :attr:`RemovalSentinel.REMOVE`.
         """
-        leave_func = getattr(self, f"leave_{type(original_node).__name__}", None)
+        leave_func = getattr(self, sys.intern(f"leave_{type(original_node).__name__}"), None)
         if leave_func is not None:
             updated_node = leave_func(original_node, updated_node)
 
@@ -79,7 +81,7 @@ class CSTTransformer(CSTTypedTransformerFunctions, MetadataDependent):
         attributes are visited in the order that they appear in source that this
         node originates from.
         """
-        visit_func = getattr(self, f"visit_{type(node).__name__}_{attribute}", None)
+        visit_func = getattr(self, sys.intern(f"visit_{type(node).__name__}_{attribute}"), None)
         if visit_func is not None:
             visit_func(node)
 
@@ -93,7 +95,7 @@ class CSTTransformer(CSTTypedTransformerFunctions, MetadataDependent):
         management.
         """
         leave_func = getattr(
-            self, f"leave_{type(original_node).__name__}_{attribute}", None
+            self, sys.intern(f"leave_{type(original_node).__name__}_{attribute}"), None
         )
         if leave_func is not None:
             leave_func(original_node)
@@ -118,7 +120,7 @@ class CSTVisitor(CSTTypedVisitorFunctions, MetadataDependent):
         Returns ``True`` if children should be visited, and returns ``False``
         otherwise.
         """
-        visit_func = getattr(self, f"visit_{type(node).__name__}", None)
+        visit_func = getattr(self, sys.intern(f"visit_{type(node).__name__}"), None)
         if visit_func is not None:
             retval = visit_func(node)
         else:
@@ -132,7 +134,7 @@ class CSTVisitor(CSTTypedVisitorFunctions, MetadataDependent):
         the :func:`~libcst.CSTVisitor.on_visit` function for this node returns
         ``False``, this function will still be called on that node.
         """
-        leave_func = getattr(self, f"leave_{type(original_node).__name__}", None)
+        leave_func = getattr(self, sys.intern(f"leave_{type(original_node).__name__}"), None)
         if leave_func is not None:
             leave_func(original_node)
 
@@ -143,7 +145,7 @@ class CSTVisitor(CSTTypedVisitorFunctions, MetadataDependent):
         attributes are visited in the order that they appear in source that this
         node originates from.
         """
-        visit_func = getattr(self, f"visit_{type(node).__name__}_{attribute}", None)
+        visit_func = getattr(self, sys.intern(f"visit_{type(node).__name__}_{attribute}"), None)
         if visit_func is not None:
             visit_func(node)
 
@@ -153,7 +155,7 @@ class CSTVisitor(CSTTypedVisitorFunctions, MetadataDependent):
         :func:`~libcst.CSTVisitor.on_leave` on the node.
         """
         leave_func = getattr(
-            self, f"leave_{type(original_node).__name__}_{attribute}", None
+            self, sys.intern(f"leave_{type(original_node).__name__}_{attribute}"), None
         )
         if leave_func is not None:
             leave_func(original_node)

--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -627,7 +627,6 @@ def parallel_exec_transform_with_prettyprint(  # noqa: C901
         pool_impl = DummyExecutor
     elif not getattr(sys, "_is_gil_enabled", lambda: True)():
         from concurrent.futures import ThreadPoolExecutor
-
         pool_impl = functools.partial(ThreadPoolExecutor, max_workers=jobs)
     else:
         from concurrent.futures import ProcessPoolExecutor

--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -8,19 +8,30 @@ Provides helpers for CLI interaction.
 """
 
 import difflib
+import functools
 import os.path
 import re
-import functools
 import subprocess
 import sys
 import time
 import traceback
 from concurrent.futures import as_completed, Executor
 from copy import deepcopy
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from multiprocessing import cpu_count
 from pathlib import Path
-from typing import Any, AnyStr, cast, Dict, List, Optional, Sequence, Union, Callable
+from typing import (
+    Any,
+    AnyStr,
+    Callable,
+    cast,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Type,
+    Union,
+)
 
 from libcst import parse_module, PartialParserConfig
 from libcst.codemod._codemod import Codemod
@@ -215,8 +226,8 @@ class ExecutionConfig:
 
 
 def _execute_transform(  # noqa: C901
-    codemod_class,
-    codemod_args,
+    codemod_class: Type[Codemod],
+    codemod_args: Dict[str, object],
     filename: str,
     config: ExecutionConfig,
 ) -> ExecutionResult:
@@ -515,7 +526,7 @@ def _execute_transform_wrap(
 
 
 def parallel_exec_transform_with_prettyprint(  # noqa: C901
-    codemod_class: Codemod,
+    codemod_class: Type[Codemod],
     codemod_args: dict[str, str],
     files: Sequence[str],
     *,

--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -615,7 +615,7 @@ def parallel_exec_transform_with_prettyprint(  # noqa: C901
         # Let's just use a dummy synchronous executor.
         jobs = 1
         pool_impl = DummyExecutor
-    elif getattr(sys, "_is_gil_enabled", lambda: False)():
+    elif not getattr(sys, "_is_gil_enabled", lambda: True)():
         from concurrent.futures import ThreadPoolExecutor
 
         pool_impl = functools.partial(ThreadPoolExecutor, max_workers=jobs)

--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -10,16 +10,17 @@ Provides helpers for CLI interaction.
 import difflib
 import os.path
 import re
+import functools
 import subprocess
 import sys
 import time
 import traceback
-from concurrent.futures import as_completed, Executor, ProcessPoolExecutor
+from concurrent.futures import as_completed, Executor
 from copy import deepcopy
 from dataclasses import dataclass, replace
 from multiprocessing import cpu_count
 from pathlib import Path
-from typing import Any, AnyStr, cast, Dict, List, Optional, Sequence, Union
+from typing import Any, AnyStr, cast, Dict, List, Optional, Sequence, Union, Callable
 
 from libcst import parse_module, PartialParserConfig
 from libcst.codemod._codemod import Codemod
@@ -608,14 +609,20 @@ def parallel_exec_transform_with_prettyprint(  # noqa: C901
         python_version=python_version,
     )
 
-    pool_impl: type[Executor]
+    pool_impl: Callable[[], Executor]
     if total == 1 or jobs == 1:
         # Simple case, we should not pay for process overhead.
         # Let's just use a dummy synchronous executor.
         jobs = 1
         pool_impl = DummyExecutor
+    elif getattr(sys, "_is_gil_enabled", lambda: False)():
+        from concurrent.futures import ThreadPoolExecutor
+
+        pool_impl = functools.partial(ThreadPoolExecutor, max_workers=jobs)
     else:
-        pool_impl = ProcessPoolExecutor
+        from concurrent.futures import ProcessPoolExecutor
+
+        pool_impl = functools.partial(ProcessPoolExecutor, max_workers=jobs)
         # Warm the parser, pre-fork.
         parse_module(
             "",
@@ -631,7 +638,7 @@ def parallel_exec_transform_with_prettyprint(  # noqa: C901
     warnings: int = 0
     skips: int = 0
 
-    with pool_impl(max_workers=jobs) as executor:  # type: ignore
+    with pool_impl() as executor:  # type: ignore
         args = [
             {
                 "transformer": transform,

--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -14,16 +14,17 @@ import subprocess
 import sys
 import time
 import traceback
+from concurrent.futures import as_completed, Executor, ProcessPoolExecutor
 from copy import deepcopy
 from dataclasses import dataclass, replace
-from multiprocessing import cpu_count, Pool
+from multiprocessing import cpu_count
 from pathlib import Path
 from typing import Any, AnyStr, cast, Dict, List, Optional, Sequence, Union
 
 from libcst import parse_module, PartialParserConfig
 from libcst.codemod._codemod import Codemod
 from libcst.codemod._context import CodemodContext
-from libcst.codemod._dummy_pool import DummyPool
+from libcst.codemod._dummy_pool import DummyExecutor
 from libcst.codemod._runner import (
     SkipFile,
     SkipReason,
@@ -607,13 +608,14 @@ def parallel_exec_transform_with_prettyprint(  # noqa: C901
         python_version=python_version,
     )
 
+    pool_impl: type[Executor]
     if total == 1 or jobs == 1:
         # Simple case, we should not pay for process overhead.
-        # Let's just use a dummy synchronous pool.
+        # Let's just use a dummy synchronous executor.
         jobs = 1
-        pool_impl = DummyPool
+        pool_impl = DummyExecutor
     else:
-        pool_impl = Pool
+        pool_impl = ProcessPoolExecutor
         # Warm the parser, pre-fork.
         parse_module(
             "",
@@ -629,7 +631,7 @@ def parallel_exec_transform_with_prettyprint(  # noqa: C901
     warnings: int = 0
     skips: int = 0
 
-    with pool_impl(processes=jobs) as p:  # type: ignore
+    with pool_impl(max_workers=jobs) as executor:  # type: ignore
         args = [
             {
                 "transformer": transform,
@@ -640,9 +642,9 @@ def parallel_exec_transform_with_prettyprint(  # noqa: C901
             for filename in files
         ]
         try:
-            for result in p.imap_unordered(
-                _execute_transform_wrap, args, chunksize=chunksize
-            ):
+            futures = [executor.submit(_execute_transform_wrap, arg) for arg in args]
+            for future in as_completed(futures):
+                result = future.result()
                 # Print an execution result, keep track of failures
                 _print_parallel_result(
                     result,

--- a/libcst/codemod/_dummy_pool.py
+++ b/libcst/codemod/_dummy_pool.py
@@ -22,9 +22,6 @@ class DummyExecutor(Executor):
     Synchronous dummy `concurrent.futures.Executor` analogue.
     """
 
-    def __init__(self, max_workers: Optional[int] = None) -> None:
-        pass
-
     def submit(
         self,
         # pyre-ignore

--- a/libcst/codemod/_dummy_pool.py
+++ b/libcst/codemod/_dummy_pool.py
@@ -3,37 +3,53 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import sys
+from concurrent.futures import Executor, Future
 from types import TracebackType
-from typing import Callable, Generator, Iterable, Optional, Type, TypeVar
+from typing import Callable, Optional, Type, TypeVar
 
-RetT = TypeVar("RetT")
-ArgT = TypeVar("ArgT")
+if sys.version_info >= (3, 10):
+    from typing import ParamSpec
+else:
+    from typing_extensions import ParamSpec
+
+Return = TypeVar("Return")
+ParamSpec = ParamSpec("ParamSpec")
 
 
-class DummyPool:
+class DummyExecutor(Executor):
     """
-    Synchronous dummy `multiprocessing.Pool` analogue.
+    Synchronous dummy `concurrent.futures.Executor` analogue.
     """
 
-    def __init__(self, processes: Optional[int] = None) -> None:
+    def __init__(self, max_workers: Optional[int] = None) -> None:
         pass
 
-    def imap_unordered(
+    def submit(
         self,
-        func: Callable[[ArgT], RetT],
-        iterable: Iterable[ArgT],
-        chunksize: Optional[int] = None,
-    ) -> Generator[RetT, None, None]:
-        for args in iterable:
-            yield func(args)
+        # pyre-ignore
+        fn: Callable[ParamSpec, Return],
+        # pyre-ignore
+        *args: ParamSpec.args,
+        # pyre-ignore
+        **kwargs: ParamSpec.kwargs,
+        # pyre-ignore
+    ) -> Future[Return]:
+        future: Future[Return] = Future()
+        try:
+            result = fn(*args, **kwargs)
+            future.set_result(result)
+        except Exception as exc:
+            future.set_exception(exc)
+        return future
 
-    def __enter__(self) -> "DummyPool":
+    def __enter__(self) -> "DummyExecutor":
         return self
 
     def __exit__(
         self,
-        exc_type: Optional[Type[Exception]],
-        exc: Optional[Exception],
-        tb: Optional[TracebackType],
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
     ) -> None:
         pass

--- a/libcst/matchers/_visitors.py
+++ b/libcst/matchers/_visitors.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import sys
+
 from inspect import ismethod, signature
 from typing import (
     Any,
@@ -62,7 +64,7 @@ CONCRETE_METHODS: Set[str] = {
 
 def is_property(obj: object, attr_name: str) -> bool:
     """Check if obj.attr is a property without evaluating it."""
-    return isinstance(getattr(type(obj), attr_name, None), property)
+    return isinstance(getattr(type(obj), sys.intern(attr_name), None), property)
 
 
 # pyre-ignore We don't care about Any here, its not exposed.
@@ -499,7 +501,7 @@ class MatcherDecoratableTransformer(CSTTransformer):
 
         # Now, evaluate whether this current function has any matchers it requires.
         if not _should_allow_visit(
-            self._matchers, getattr(self, f"visit_{type(node).__name__}", None)
+            self._matchers, getattr(self, sys.intern(f"visit_{type(node).__name__}"), None)
         ):
             # We shouldn't visit this directly. However, we should continue
             # visiting its children.
@@ -514,7 +516,7 @@ class MatcherDecoratableTransformer(CSTTransformer):
     ) -> Union[CSTNodeT, cst.RemovalSentinel]:
         # First, evaluate whether this current function has a decorator on it.
         if _should_allow_visit(
-            self._matchers, getattr(self, f"leave_{type(original_node).__name__}", None)
+            self._matchers, getattr(self, sys.intern(f"leave_{type(original_node).__name__}"), None)
         ):
             retval = CSTTransformer.on_leave(self, original_node, updated_node)
         else:
@@ -543,7 +545,7 @@ class MatcherDecoratableTransformer(CSTTransformer):
         # Evaluate whether this current function has a decorator on it.
         if _should_allow_visit(
             self._matchers,
-            getattr(self, f"visit_{type(node).__name__}_{attribute}", None),
+            getattr(self, sys.intern(f"visit_{type(node).__name__}_{attribute}"), None),
         ):
             # Either the visit_func doesn't exist, we have no matchers, or we passed all
             # matchers. In either case, just call the superclass behavior.
@@ -553,7 +555,7 @@ class MatcherDecoratableTransformer(CSTTransformer):
         # Evaluate whether this current function has a decorator on it.
         if _should_allow_visit(
             self._matchers,
-            getattr(self, f"leave_{type(original_node).__name__}_{attribute}", None),
+            getattr(self, sys.intern(f"leave_{type(original_node).__name__}_{attribute}"), None),
         ):
             # Either the visit_func doesn't exist, we have no matchers, or we passed all
             # matchers. In either case, just call the superclass behavior.
@@ -711,7 +713,7 @@ class MatcherDecoratableVisitor(CSTVisitor):
 
         # Now, evaluate whether this current function has a decorator on it.
         if not _should_allow_visit(
-            self._matchers, getattr(self, f"visit_{type(node).__name__}", None)
+            self._matchers, getattr(self, sys.intern(f"visit_{type(node).__name__}"), None)
         ):
             # We shouldn't visit this directly. However, we should continue
             # visiting its children.
@@ -724,7 +726,7 @@ class MatcherDecoratableVisitor(CSTVisitor):
     def on_leave(self, original_node: cst.CSTNode) -> None:
         # First, evaluate whether this current function has a decorator on it.
         if _should_allow_visit(
-            self._matchers, getattr(self, f"leave_{type(original_node).__name__}", None)
+            self._matchers, getattr(self, sys.intern(f"leave_{type(original_node).__name__}"), None)
         ):
             CSTVisitor.on_leave(self, original_node)
 
@@ -743,7 +745,7 @@ class MatcherDecoratableVisitor(CSTVisitor):
         # Evaluate whether this current function has a decorator on it.
         if _should_allow_visit(
             self._matchers,
-            getattr(self, f"visit_{type(node).__name__}_{attribute}", None),
+            getattr(self, sys.intern(f"visit_{type(node).__name__}_{attribute}"), None),
         ):
             # Either the visit_func doesn't exist, we have no matchers, or we passed all
             # matchers. In either case, just call the superclass behavior.
@@ -753,7 +755,7 @@ class MatcherDecoratableVisitor(CSTVisitor):
         # Evaluate whether this current function has a decorator on it.
         if _should_allow_visit(
             self._matchers,
-            getattr(self, f"leave_{type(original_node).__name__}_{attribute}", None),
+            getattr(self, sys.intern(f"leave_{type(original_node).__name__}_{attribute}"), None),
         ):
             # Either the visit_func doesn't exist, we have no matchers, or we passed all
             # matchers. In either case, just call the superclass behavior.

--- a/libcst/matchers/_visitors.py
+++ b/libcst/matchers/_visitors.py
@@ -3,8 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import sys
-
 from inspect import ismethod, signature
 from typing import (
     Any,
@@ -46,6 +44,7 @@ from libcst.matchers._matcher_base import (
     replace,
 )
 from libcst.matchers._return_types import TYPED_FUNCTION_RETURN_MAPPING
+from libcst._visitors import type_lookup
 
 try:
     # PEP 604 unions, in Python 3.10+
@@ -64,7 +63,7 @@ CONCRETE_METHODS: Set[str] = {
 
 def is_property(obj: object, attr_name: str) -> bool:
     """Check if obj.attr is a property without evaluating it."""
-    return isinstance(getattr(type(obj), sys.intern(attr_name), None), property)
+    return isinstance(type_lookup(type(obj), attr_name, None), property)
 
 
 # pyre-ignore We don't care about Any here, its not exposed.
@@ -501,7 +500,7 @@ class MatcherDecoratableTransformer(CSTTransformer):
 
         # Now, evaluate whether this current function has any matchers it requires.
         if not _should_allow_visit(
-            self._matchers, getattr(self, sys.intern(f"visit_{type(node).__name__}"), None)
+            self._matchers, type_lookup(self, f"visit_{type(node).__name__}", None)
         ):
             # We shouldn't visit this directly. However, we should continue
             # visiting its children.
@@ -516,7 +515,7 @@ class MatcherDecoratableTransformer(CSTTransformer):
     ) -> Union[CSTNodeT, cst.RemovalSentinel]:
         # First, evaluate whether this current function has a decorator on it.
         if _should_allow_visit(
-            self._matchers, getattr(self, sys.intern(f"leave_{type(original_node).__name__}"), None)
+            self._matchers, type_lookup(self, f"leave_{type(original_node).__name__}", None)
         ):
             retval = CSTTransformer.on_leave(self, original_node, updated_node)
         else:
@@ -545,7 +544,7 @@ class MatcherDecoratableTransformer(CSTTransformer):
         # Evaluate whether this current function has a decorator on it.
         if _should_allow_visit(
             self._matchers,
-            getattr(self, sys.intern(f"visit_{type(node).__name__}_{attribute}"), None),
+            type_lookup(self, f"visit_{type(node).__name__}_{attribute}", None),
         ):
             # Either the visit_func doesn't exist, we have no matchers, or we passed all
             # matchers. In either case, just call the superclass behavior.
@@ -555,7 +554,7 @@ class MatcherDecoratableTransformer(CSTTransformer):
         # Evaluate whether this current function has a decorator on it.
         if _should_allow_visit(
             self._matchers,
-            getattr(self, sys.intern(f"leave_{type(original_node).__name__}_{attribute}"), None),
+            type_lookup(self, f"leave_{type(original_node).__name__}_{attribute}", None),
         ):
             # Either the visit_func doesn't exist, we have no matchers, or we passed all
             # matchers. In either case, just call the superclass behavior.
@@ -713,7 +712,7 @@ class MatcherDecoratableVisitor(CSTVisitor):
 
         # Now, evaluate whether this current function has a decorator on it.
         if not _should_allow_visit(
-            self._matchers, getattr(self, sys.intern(f"visit_{type(node).__name__}"), None)
+            self._matchers, type_lookup(self, f"visit_{type(node).__name__}", None)
         ):
             # We shouldn't visit this directly. However, we should continue
             # visiting its children.
@@ -726,7 +725,7 @@ class MatcherDecoratableVisitor(CSTVisitor):
     def on_leave(self, original_node: cst.CSTNode) -> None:
         # First, evaluate whether this current function has a decorator on it.
         if _should_allow_visit(
-            self._matchers, getattr(self, sys.intern(f"leave_{type(original_node).__name__}"), None)
+            self._matchers, type_lookup(self, f"leave_{type(original_node).__name__}", None)
         ):
             CSTVisitor.on_leave(self, original_node)
 
@@ -745,7 +744,7 @@ class MatcherDecoratableVisitor(CSTVisitor):
         # Evaluate whether this current function has a decorator on it.
         if _should_allow_visit(
             self._matchers,
-            getattr(self, sys.intern(f"visit_{type(node).__name__}_{attribute}"), None),
+            type_lookup(self, f"visit_{type(node).__name__}_{attribute}", None),
         ):
             # Either the visit_func doesn't exist, we have no matchers, or we passed all
             # matchers. In either case, just call the superclass behavior.
@@ -755,7 +754,7 @@ class MatcherDecoratableVisitor(CSTVisitor):
         # Evaluate whether this current function has a decorator on it.
         if _should_allow_visit(
             self._matchers,
-            getattr(self, sys.intern(f"leave_{type(original_node).__name__}_{attribute}"), None),
+            type_lookup(self, f"leave_{type(original_node).__name__}_{attribute}", None),
         ):
             # Either the visit_func doesn't exist, we have no matchers, or we passed all
             # matchers. In either case, just call the superclass behavior.

--- a/libcst/tests/test_e2e.py
+++ b/libcst/tests/test_e2e.py
@@ -60,10 +60,10 @@ class ToolE2ETest(TestCase):
             adir.mkdir()
 
             # Run command
-            command_instance = PrintToPPrintCommand(CodemodContext())
             files = gather_files(".")
             result = parallel_exec_transform_with_prettyprint(
-                command_instance,
+                PrintToPPrintCommand,
+                {},
                 files,
                 format_code=False,
                 hide_progress=True,

--- a/libcst/tool.py
+++ b/libcst/tool.py
@@ -377,7 +377,10 @@ def _codemod_impl(proc_name: str, command_args: List[str]) -> int:  # noqa: C901
     command_instance = command_class(CodemodContext(), **codemod_args)
 
     # Sepcify target version for black formatter
-    if os.path.basename(config["formatter"][0]) in ("black", "black.exe"):
+    if any(config["formatter"]) and os.path.basename(config["formatter"][0]) in (
+        "black",
+        "black.exe",
+    ):
         parsed_version = parse_version_string(args.python_version)
 
         config["formatter"] = [

--- a/libcst/tool.py
+++ b/libcst/tool.py
@@ -374,7 +374,6 @@ def _codemod_impl(proc_name: str, command_args: List[str]) -> int:  # noqa: C901
             "unified_diff",
         }
     }
-    command_instance = command_class(CodemodContext(), **codemod_args)
 
     # Sepcify target version for black formatter
     if any(config["formatter"]) and os.path.basename(config["formatter"][0]) in (
@@ -397,6 +396,7 @@ def _codemod_impl(proc_name: str, command_args: List[str]) -> int:  # noqa: C901
 
         print("Codemodding from stdin", file=sys.stderr)
         oldcode = sys.stdin.read()
+        command_instance = command_class(CodemodContext(), **codemod_args)
         newcode = exec_transform_with_prettyprint(
             command_instance,
             oldcode,
@@ -421,7 +421,8 @@ def _codemod_impl(proc_name: str, command_args: List[str]) -> int:  # noqa: C901
     files = gather_files(args.path, include_stubs=args.include_stubs)
     try:
         result = parallel_exec_transform_with_prettyprint(
-            command_instance,
+            command_class,
+            codemod_args,
             files,
             jobs=args.jobs,
             unified_diff=args.unified_diff,

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -338,7 +338,7 @@ checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libcst"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "annotate-snippets",
  "criterion",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "libcst_derive"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "quote",
  "syn 2.0.75",

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -501,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fe09249128b3173d092de9523eaa75136bf7ba85e0d69eca241c7939c933cc"
+checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -519,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd3927b5a78757a0d71aa9dff669f903b1eb64b54142a9bd9f757f8fde65fd7"
+checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -529,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab6bb2102bd8f991e7749f130a70d05dd557613e39ed2deeee8e9ca0c4d548d"
+checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -539,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91871864b353fd5ffcb3f91f2f703a22a9797c91b9ab497b1acac7b07ae509c7"
+checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -551,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43abc3b80bc20f3facd86cd3c60beed58c3e2aa26213f3cda368de39c60a27e4"
+checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/native/libcst/Cargo.toml
+++ b/native/libcst/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "libcst"
-version = "1.6.0"
+version = "1.7.0"
 authors = ["LibCST Developers"]
 edition = "2018"
 rust-version = "1.70"

--- a/native/libcst/src/py.rs
+++ b/native/libcst/src/py.rs
@@ -6,7 +6,7 @@
 use crate::nodes::traits::py::TryIntoPy;
 use pyo3::prelude::*;
 
-#[pymodule]
+#[pymodule(gil_used = false)]
 #[pyo3(name = "native")]
 pub fn libcst_native(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     #[pyfn(m)]

--- a/native/libcst/src/py.rs
+++ b/native/libcst/src/py.rs
@@ -8,24 +8,30 @@ use pyo3::prelude::*;
 
 #[pymodule(gil_used = false)]
 #[pyo3(name = "native")]
-pub fn libcst_native(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
+pub fn libcst_native(m: &Bound<PyModule>) -> PyResult<()> {
     #[pyfn(m)]
     #[pyo3(signature = (source, encoding=None))]
     fn parse_module(source: String, encoding: Option<&str>) -> PyResult<PyObject> {
-        let m = crate::parse_module(source.as_str(), encoding)?;
-        Python::with_gil(|py| m.try_into_py(py))
+        Python::with_gil(|py| {
+            let m = py.allow_threads(|| crate::parse_module(source.as_str(), encoding))?;
+            m.try_into_py(py)
+        })
     }
 
     #[pyfn(m)]
     fn parse_expression(source: String) -> PyResult<PyObject> {
-        let expr = crate::parse_expression(source.as_str())?;
-        Python::with_gil(|py| expr.try_into_py(py))
+        Python::with_gil(|py| {
+            let expr = py.allow_threads(|| crate::parse_expression(source.as_str()))?;
+            expr.try_into_py(py)
+        })
     }
 
     #[pyfn(m)]
     fn parse_statement(source: String) -> PyResult<PyObject> {
-        let stm = crate::parse_statement(source.as_str())?;
-        Python::with_gil(|py| stm.try_into_py(py))
+        Python::with_gil(|py| {
+            let stm = py.allow_threads(|| crate::parse_statement(source.as_str()))?;
+            stm.try_into_py(py)
+        })
     }
 
     Ok(())

--- a/native/libcst_derive/Cargo.toml
+++ b/native/libcst_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcst_derive"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2018"
 description = "Proc macro helpers for libcst."
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,11 @@ dependencies = ["pyyaml>=5.2"]
 
 [project.optional-dependencies]
 dev = [
+    "libcst[dev-without-jupyter]",
+    "jupyter>=1.0.0",
+    "nbsphinx>=0.4.2",
+]
+dev-without-jupyter = [
     "black==24.8.0",
     "coverage[toml]>=4.5.4",
     "build>=0.10.0",
@@ -30,9 +35,7 @@ dev = [
     "Sphinx>=5.1.1",
     "hypothesis>=4.36.0",
     "hypothesmith>=0.0.4",
-    "jupyter>=1.0.0",
     "maturin>=1.7.0,<1.8",
-    "nbsphinx>=0.4.2",
     "prompt-toolkit>=2.0.9",
     "pyre-check==0.9.18; platform_system != 'Windows'",
     "setuptools_scm>=6.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,8 +83,7 @@ excludes = ["native/", "stubs/"]
 
 [tool.cibuildwheel]
 build-verbosity = 1
-environment = { PATH = "$PATH:$HOME/.cargo/bin" }
-environment-pass = ["LIBCST_NO_LOCAL_SCHEME"]
+environment = { PATH = "$PATH:$HOME/.cargo/bin", LIBCST_NO_LOCAL_SCHEME="1" }
 skip = [
     "pp*",
     "*-win32",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ skip = [
 ]
 
 [tool.cibuildwheel.linux]
+environment-pass = ["LIBCST_NO_LOCAL_SCHEME"]
 before-all = "yum install -y libatomic; curl https://sh.rustup.rs -sSf | env -u CARGO_HOME sh -s -- --default-toolchain stable --profile minimal -y"
 
 [tool.cibuildwheel.macos]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ excludes = ["native/", "stubs/"]
 [tool.cibuildwheel]
 build-verbosity = 1
 environment = { PATH = "$PATH:$HOME/.cargo/bin" }
+environment-pass = ["LIBCST_NO_LOCAL_SCHEME"]
 skip = [
     "pp*",
     "*-win32",


### PR DESCRIPTION
Note that this PR targets the `pr1295` branch.

Unfortunately I'm still seeing a substantial slowdown using threading compared with multiprocessing. I don't see anything obvious in a profile generated from `samply`. I want to try to test with Python 3.14 to see if it's a performance issue that's been fixed upstream already. I'll report back if I find anything, I might need to update the rust code a little to work with the latest version of PyO3.