### PR TITLE
update pyo3 to 0.25

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -501,11 +501,10 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "f239d656363bcee73afef85277f1b281e8ac6212a1d42aa90e55b90ed43c47a4"
 dependencies = [
- "cfg-if",
  "indoc",
  "libc",
  "memoffset 0.9.0",
@@ -519,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "755ea671a1c34044fa165247aaf6f419ca39caa6003aee791a0df2713d8f1b6d"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -529,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "fc95a2e67091e44791d4ea300ff744be5293f394f1bafd9f78c080814d35956e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -539,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "a179641d1b93920829a62f15e87c0ed791b6c8db2271ba0fd7c2686090510214"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -551,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "9dff85ebcaab8c441b0e3f7ae40a6963ecea8a9f5e74f647e33fcf5ec9a1e89e"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -719,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.15"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4873307b7c257eddcb50c9bedf158eb669578359fb28428bef438fec8e6ba7c2"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "termcolor"

--- a/native/libcst/Cargo.toml
+++ b/native/libcst/Cargo.toml
@@ -36,7 +36,7 @@ trace = ["peg/trace"]
 
 [dependencies]
 paste = "1.0.15"
-pyo3 = { version = "0.23", optional = true }
+pyo3 = { version = "0.25", optional = true }
 thiserror = "1.0.63"
 peg = "0.8.4"
 annotate-snippets = "0.11.5"

--- a/native/libcst/src/nodes/parser_config.rs
+++ b/native/libcst/src/nodes/parser_config.rs
@@ -125,7 +125,8 @@ fn parser_config_asdict<'py>(py: Python<'py>, config: PyRef<'py, ParserConfig>) 
         ("version", config.version.clone_ref(py)),
         ("future_imports", config.future_imports.clone_ref(py)),
     ]
-    .into_py_dict_bound(py)
+    .into_py_dict(py)
+    .unwrap()
 }
 
 pub fn init_module(_py: Python, m: &PyModule) -> PyResult<()> {

--- a/native/libcst_derive/src/into_py.rs
+++ b/native/libcst_derive/src/into_py.rs
@@ -40,7 +40,7 @@ fn impl_into_py_enum(ast: &DeriveInput, e: &DataEnum) -> TokenStream {
                     Self::#varname { #(#fieldnames,)* .. } => {
                         use pyo3::types::PyAnyMethods;
 
-                        let libcst = pyo3::types::PyModule::import_bound(py, "libcst")?;
+                        let libcst = pyo3::types::PyModule::import(py, "libcst")?;
                         let kwargs = #kwargs_toks ;
                         Ok(libcst
                             .getattr(stringify!(#varname))
@@ -90,7 +90,7 @@ fn impl_into_py_struct(ast: &DeriveInput, e: &DataStruct) -> TokenStream {
         impl#generics crate::nodes::traits::py::TryIntoPy<pyo3::PyObject> for #ident #generics {
             fn try_into_py(self, py: pyo3::Python) -> pyo3::PyResult<pyo3::PyObject> {
                 use pyo3::types::PyAnyMethods;
-                let libcst = pyo3::types::PyModule::import_bound(py, "libcst")?;
+                let libcst = pyo3::types::PyModule::import(py, "libcst")?;
                 let kwargs = #kwargs_toks ;
                 Ok(libcst
                     .getattr(stringify!(#ident))
@@ -165,7 +165,7 @@ fn fields_to_kwargs(fields: &Fields, is_enum: bool) -> quote::__private::TokenSt
         #(#optional_rust_varnames.map(|x| x.try_into_py(py)).transpose()?.map(|x| (stringify!(#optional_py_varnames), x)),)*
     };
     if empty_kwargs {
-        quote! { pyo3::types::PyDict::new_bound(py) }
+        quote! { pyo3::types::PyDict::new(py) }
     } else {
         quote! {
             [ #kwargs_pairs #optional_pairs ]
@@ -173,7 +173,7 @@ fn fields_to_kwargs(fields: &Fields, is_enum: bool) -> quote::__private::TokenSt
                 .filter(|x| x.is_some())
                 .map(|x| x.as_ref().unwrap())
                 .collect::<Vec<_>>()
-                .into_py_dict_bound(py)
+                .into_py_dict(py)?
         }
     }
 }


### PR DESCRIPTION
Fixing the deprecations is needed to try testing with Python 3.14 on a pending PR to pyo3's main branch.
