### PR TITLE
WIP: fix contention on free-threaded build

### DIFF
--- a/libcst/_visitors.py
+++ b/libcst/_visitors.py
@@ -21,11 +21,15 @@ if TYPE_CHECKING:
 CSTVisitorT = Union["CSTTransformer", "CSTVisitor"]
 
 cache = threading.local()
+marker = object()
 
 def type_lookup(tp, name, default=None):
     if not hasattr(cache, "_cache"):
         cache._cache = {}
-    return cache._cache.setdefault((tp, name, default), getattr(tp, name, default))
+    value = cache._cache.get((tp, name, default), marker)
+    if value is marker:
+        value = cache._cache.setdefault((tp, name, default), getattr(tp, name, default))
+    return value
 
 
 class CSTTransformer(CSTTypedTransformerFunctions, MetadataDependent):

--- a/libcst/_visitors.py
+++ b/libcst/_visitors.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import sys
+
 from typing import TYPE_CHECKING, Union
 
 from libcst._flatten_sentinel import FlattenSentinel
@@ -39,7 +41,7 @@ class CSTTransformer(CSTTypedTransformerFunctions, MetadataDependent):
         Returns ``True`` if children should be visited, and returns ``False``
         otherwise.
         """
-        visit_func = getattr(self, f"visit_{type(node).__name__}", None)
+        visit_func = getattr(self, sys.intern(f"visit_{type(node).__name__}"), None)
         if visit_func is not None:
             retval = visit_func(node)
         else:
@@ -66,7 +68,7 @@ class CSTTransformer(CSTTypedTransformerFunctions, MetadataDependent):
         exception if this node is required. As a convenience, you can use
         :func:`RemoveFromParent` as an alias to :attr:`RemovalSentinel.REMOVE`.
         """
-        leave_func = getattr(self, f"leave_{type(original_node).__name__}", None)
+        leave_func = getattr(self, sys.intern(f"leave_{type(original_node).__name__}"), None)
         if leave_func is not None:
             updated_node = leave_func(original_node, updated_node)
 
@@ -79,7 +81,7 @@ class CSTTransformer(CSTTypedTransformerFunctions, MetadataDependent):
         attributes are visited in the order that they appear in source that this
         node originates from.
         """
-        visit_func = getattr(self, f"visit_{type(node).__name__}_{attribute}", None)
+        visit_func = getattr(self, sys.intern(f"visit_{type(node).__name__}_{attribute}"), None)
         if visit_func is not None:
             visit_func(node)
 
@@ -93,7 +95,7 @@ class CSTTransformer(CSTTypedTransformerFunctions, MetadataDependent):
         management.
         """
         leave_func = getattr(
-            self, f"leave_{type(original_node).__name__}_{attribute}", None
+            self, sys.intern(f"leave_{type(original_node).__name__}_{attribute}"), None
         )
         if leave_func is not None:
             leave_func(original_node)
@@ -118,7 +120,7 @@ class CSTVisitor(CSTTypedVisitorFunctions, MetadataDependent):
         Returns ``True`` if children should be visited, and returns ``False``
         otherwise.
         """
-        visit_func = getattr(self, f"visit_{type(node).__name__}", None)
+        visit_func = getattr(self, sys.intern(f"visit_{type(node).__name__}"), None)
         if visit_func is not None:
             retval = visit_func(node)
         else:
@@ -132,7 +134,7 @@ class CSTVisitor(CSTTypedVisitorFunctions, MetadataDependent):
         the :func:`~libcst.CSTVisitor.on_visit` function for this node returns
         ``False``, this function will still be called on that node.
         """
-        leave_func = getattr(self, f"leave_{type(original_node).__name__}", None)
+        leave_func = getattr(self, sys.intern(f"leave_{type(original_node).__name__}"), None)
         if leave_func is not None:
             leave_func(original_node)
 
@@ -143,7 +145,7 @@ class CSTVisitor(CSTTypedVisitorFunctions, MetadataDependent):
         attributes are visited in the order that they appear in source that this
         node originates from.
         """
-        visit_func = getattr(self, f"visit_{type(node).__name__}_{attribute}", None)
+        visit_func = getattr(self, sys.intern(f"visit_{type(node).__name__}_{attribute}"), None)
         if visit_func is not None:
             visit_func(node)
 
@@ -153,7 +155,7 @@ class CSTVisitor(CSTTypedVisitorFunctions, MetadataDependent):
         :func:`~libcst.CSTVisitor.on_leave` on the node.
         """
         leave_func = getattr(
-            self, f"leave_{type(original_node).__name__}_{attribute}", None
+            self, sys.intern(f"leave_{type(original_node).__name__}_{attribute}"), None
         )
         if leave_func is not None:
             leave_func(original_node)

--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -627,7 +627,6 @@ def parallel_exec_transform_with_prettyprint(  # noqa: C901
         pool_impl = DummyExecutor
     elif not getattr(sys, "_is_gil_enabled", lambda: True)():
         from concurrent.futures import ThreadPoolExecutor
-
         pool_impl = functools.partial(ThreadPoolExecutor, max_workers=jobs)
     else:
         from concurrent.futures import ProcessPoolExecutor

--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -8,19 +8,30 @@ Provides helpers for CLI interaction.
 """
 
 import difflib
+import functools
 import os.path
 import re
-import functools
 import subprocess
 import sys
 import time
 import traceback
 from concurrent.futures import as_completed, Executor
 from copy import deepcopy
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from multiprocessing import cpu_count
 from pathlib import Path
-from typing import Any, AnyStr, cast, Dict, List, Optional, Sequence, Union, Callable
+from typing import (
+    Any,
+    AnyStr,
+    Callable,
+    cast,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Type,
+    Union,
+)
 
 from libcst import parse_module, PartialParserConfig
 from libcst.codemod._codemod import Codemod
@@ -215,8 +226,8 @@ class ExecutionConfig:
 
 
 def _execute_transform(  # noqa: C901
-    codemod_class,
-    codemod_args,
+    codemod_class: Type[Codemod],
+    codemod_args: Dict[str, object],
     filename: str,
     config: ExecutionConfig,
 ) -> ExecutionResult:
@@ -515,7 +526,7 @@ def _execute_transform_wrap(
 
 
 def parallel_exec_transform_with_prettyprint(  # noqa: C901
-    codemod_class: Codemod,
+    codemod_class: Type[Codemod],
     codemod_args: dict[str, str],
     files: Sequence[str],
     *,

--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -615,7 +615,7 @@ def parallel_exec_transform_with_prettyprint(  # noqa: C901
         # Let's just use a dummy synchronous executor.
         jobs = 1
         pool_impl = DummyExecutor
-    elif getattr(sys, "_is_gil_enabled", lambda: False)():
+    elif not getattr(sys, "_is_gil_enabled", lambda: True)():
         from concurrent.futures import ThreadPoolExecutor
 
         pool_impl = functools.partial(ThreadPoolExecutor, max_workers=jobs)

--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -10,16 +10,17 @@ Provides helpers for CLI interaction.
 import difflib
 import os.path
 import re
+import functools
 import subprocess
 import sys
 import time
 import traceback
-from concurrent.futures import as_completed, Executor, ProcessPoolExecutor
+from concurrent.futures import as_completed, Executor
 from copy import deepcopy
 from dataclasses import dataclass, replace
 from multiprocessing import cpu_count
 from pathlib import Path
-from typing import Any, AnyStr, cast, Dict, List, Optional, Sequence, Union
+from typing import Any, AnyStr, cast, Dict, List, Optional, Sequence, Union, Callable
 
 from libcst import parse_module, PartialParserConfig
 from libcst.codemod._codemod import Codemod
@@ -608,14 +609,20 @@ def parallel_exec_transform_with_prettyprint(  # noqa: C901
         python_version=python_version,
     )
 
-    pool_impl: type[Executor]
+    pool_impl: Callable[[], Executor]
     if total == 1 or jobs == 1:
         # Simple case, we should not pay for process overhead.
         # Let's just use a dummy synchronous executor.
         jobs = 1
         pool_impl = DummyExecutor
+    elif getattr(sys, "_is_gil_enabled", lambda: False)():
+        from concurrent.futures import ThreadPoolExecutor
+
+        pool_impl = functools.partial(ThreadPoolExecutor, max_workers=jobs)
     else:
-        pool_impl = ProcessPoolExecutor
+        from concurrent.futures import ProcessPoolExecutor
+
+        pool_impl = functools.partial(ProcessPoolExecutor, max_workers=jobs)
         # Warm the parser, pre-fork.
         parse_module(
             "",
@@ -631,7 +638,7 @@ def parallel_exec_transform_with_prettyprint(  # noqa: C901
     warnings: int = 0
     skips: int = 0
 
-    with pool_impl(max_workers=jobs) as executor:  # type: ignore
+    with pool_impl() as executor:  # type: ignore
         args = [
             {
                 "transformer": transform,

--- a/libcst/codemod/_cli.py
+++ b/libcst/codemod/_cli.py
@@ -14,16 +14,17 @@ import subprocess
 import sys
 import time
 import traceback
+from concurrent.futures import as_completed, Executor, ProcessPoolExecutor
 from copy import deepcopy
 from dataclasses import dataclass, replace
-from multiprocessing import cpu_count, Pool
+from multiprocessing import cpu_count
 from pathlib import Path
 from typing import Any, AnyStr, cast, Dict, List, Optional, Sequence, Union
 
 from libcst import parse_module, PartialParserConfig
 from libcst.codemod._codemod import Codemod
 from libcst.codemod._context import CodemodContext
-from libcst.codemod._dummy_pool import DummyPool
+from libcst.codemod._dummy_pool import DummyExecutor
 from libcst.codemod._runner import (
     SkipFile,
     SkipReason,
@@ -607,13 +608,14 @@ def parallel_exec_transform_with_prettyprint(  # noqa: C901
         python_version=python_version,
     )
 
+    pool_impl: type[Executor]
     if total == 1 or jobs == 1:
         # Simple case, we should not pay for process overhead.
-        # Let's just use a dummy synchronous pool.
+        # Let's just use a dummy synchronous executor.
         jobs = 1
-        pool_impl = DummyPool
+        pool_impl = DummyExecutor
     else:
-        pool_impl = Pool
+        pool_impl = ProcessPoolExecutor
         # Warm the parser, pre-fork.
         parse_module(
             "",
@@ -629,7 +631,7 @@ def parallel_exec_transform_with_prettyprint(  # noqa: C901
     warnings: int = 0
     skips: int = 0
 
-    with pool_impl(processes=jobs) as p:  # type: ignore
+    with pool_impl(max_workers=jobs) as executor:  # type: ignore
         args = [
             {
                 "transformer": transform,
@@ -640,9 +642,9 @@ def parallel_exec_transform_with_prettyprint(  # noqa: C901
             for filename in files
         ]
         try:
-            for result in p.imap_unordered(
-                _execute_transform_wrap, args, chunksize=chunksize
-            ):
+            futures = [executor.submit(_execute_transform_wrap, arg) for arg in args]
+            for future in as_completed(futures):
+                result = future.result()
                 # Print an execution result, keep track of failures
                 _print_parallel_result(
                     result,

--- a/libcst/codemod/_dummy_pool.py
+++ b/libcst/codemod/_dummy_pool.py
@@ -22,9 +22,6 @@ class DummyExecutor(Executor):
     Synchronous dummy `concurrent.futures.Executor` analogue.
     """
 
-    def __init__(self, max_workers: Optional[int] = None) -> None:
-        pass
-
     def submit(
         self,
         # pyre-ignore

--- a/libcst/codemod/_dummy_pool.py
+++ b/libcst/codemod/_dummy_pool.py
@@ -3,37 +3,53 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import sys
+from concurrent.futures import Executor, Future
 from types import TracebackType
-from typing import Callable, Generator, Iterable, Optional, Type, TypeVar
+from typing import Callable, Optional, Type, TypeVar
 
-RetT = TypeVar("RetT")
-ArgT = TypeVar("ArgT")
+if sys.version_info >= (3, 10):
+    from typing import ParamSpec
+else:
+    from typing_extensions import ParamSpec
+
+Return = TypeVar("Return")
+ParamSpec = ParamSpec("ParamSpec")
 
 
-class DummyPool:
+class DummyExecutor(Executor):
     """
-    Synchronous dummy `multiprocessing.Pool` analogue.
+    Synchronous dummy `concurrent.futures.Executor` analogue.
     """
 
-    def __init__(self, processes: Optional[int] = None) -> None:
+    def __init__(self, max_workers: Optional[int] = None) -> None:
         pass
 
-    def imap_unordered(
+    def submit(
         self,
-        func: Callable[[ArgT], RetT],
-        iterable: Iterable[ArgT],
-        chunksize: Optional[int] = None,
-    ) -> Generator[RetT, None, None]:
-        for args in iterable:
-            yield func(args)
+        # pyre-ignore
+        fn: Callable[ParamSpec, Return],
+        # pyre-ignore
+        *args: ParamSpec.args,
+        # pyre-ignore
+        **kwargs: ParamSpec.kwargs,
+        # pyre-ignore
+    ) -> Future[Return]:
+        future: Future[Return] = Future()
+        try:
+            result = fn(*args, **kwargs)
+            future.set_result(result)
+        except Exception as exc:
+            future.set_exception(exc)
+        return future
 
-    def __enter__(self) -> "DummyPool":
+    def __enter__(self) -> "DummyExecutor":
         return self
 
     def __exit__(
         self,
-        exc_type: Optional[Type[Exception]],
-        exc: Optional[Exception],
-        tb: Optional[TracebackType],
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
     ) -> None:
         pass

--- a/libcst/matchers/_visitors.py
+++ b/libcst/matchers/_visitors.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import sys
+
 from inspect import ismethod, signature
 from typing import (
     Any,
@@ -62,7 +64,7 @@ CONCRETE_METHODS: Set[str] = {
 
 def is_property(obj: object, attr_name: str) -> bool:
     """Check if obj.attr is a property without evaluating it."""
-    return isinstance(getattr(type(obj), attr_name, None), property)
+    return isinstance(getattr(type(obj), sys.intern(attr_name), None), property)
 
 
 # pyre-ignore We don't care about Any here, its not exposed.
@@ -499,7 +501,7 @@ class MatcherDecoratableTransformer(CSTTransformer):
 
         # Now, evaluate whether this current function has any matchers it requires.
         if not _should_allow_visit(
-            self._matchers, getattr(self, f"visit_{type(node).__name__}", None)
+            self._matchers, getattr(self, sys.intern(f"visit_{type(node).__name__}"), None)
         ):
             # We shouldn't visit this directly. However, we should continue
             # visiting its children.
@@ -514,7 +516,7 @@ class MatcherDecoratableTransformer(CSTTransformer):
     ) -> Union[CSTNodeT, cst.RemovalSentinel]:
         # First, evaluate whether this current function has a decorator on it.
         if _should_allow_visit(
-            self._matchers, getattr(self, f"leave_{type(original_node).__name__}", None)
+            self._matchers, getattr(self, sys.intern(f"leave_{type(original_node).__name__}"), None)
         ):
             retval = CSTTransformer.on_leave(self, original_node, updated_node)
         else:
@@ -543,7 +545,7 @@ class MatcherDecoratableTransformer(CSTTransformer):
         # Evaluate whether this current function has a decorator on it.
         if _should_allow_visit(
             self._matchers,
-            getattr(self, f"visit_{type(node).__name__}_{attribute}", None),
+            getattr(self, sys.intern(f"visit_{type(node).__name__}_{attribute}"), None),
         ):
             # Either the visit_func doesn't exist, we have no matchers, or we passed all
             # matchers. In either case, just call the superclass behavior.
@@ -553,7 +555,7 @@ class MatcherDecoratableTransformer(CSTTransformer):
         # Evaluate whether this current function has a decorator on it.
         if _should_allow_visit(
             self._matchers,
-            getattr(self, f"leave_{type(original_node).__name__}_{attribute}", None),
+            getattr(self, sys.intern(f"leave_{type(original_node).__name__}_{attribute}"), None),
         ):
             # Either the visit_func doesn't exist, we have no matchers, or we passed all
             # matchers. In either case, just call the superclass behavior.
@@ -711,7 +713,7 @@ class MatcherDecoratableVisitor(CSTVisitor):
 
         # Now, evaluate whether this current function has a decorator on it.
         if not _should_allow_visit(
-            self._matchers, getattr(self, f"visit_{type(node).__name__}", None)
+            self._matchers, getattr(self, sys.intern(f"visit_{type(node).__name__}"), None)
         ):
             # We shouldn't visit this directly. However, we should continue
             # visiting its children.
@@ -724,7 +726,7 @@ class MatcherDecoratableVisitor(CSTVisitor):
     def on_leave(self, original_node: cst.CSTNode) -> None:
         # First, evaluate whether this current function has a decorator on it.
         if _should_allow_visit(
-            self._matchers, getattr(self, f"leave_{type(original_node).__name__}", None)
+            self._matchers, getattr(self, sys.intern(f"leave_{type(original_node).__name__}"), None)
         ):
             CSTVisitor.on_leave(self, original_node)
 
@@ -743,7 +745,7 @@ class MatcherDecoratableVisitor(CSTVisitor):
         # Evaluate whether this current function has a decorator on it.
         if _should_allow_visit(
             self._matchers,
-            getattr(self, f"visit_{type(node).__name__}_{attribute}", None),
+            getattr(self, sys.intern(f"visit_{type(node).__name__}_{attribute}"), None),
         ):
             # Either the visit_func doesn't exist, we have no matchers, or we passed all
             # matchers. In either case, just call the superclass behavior.
@@ -753,7 +755,7 @@ class MatcherDecoratableVisitor(CSTVisitor):
         # Evaluate whether this current function has a decorator on it.
         if _should_allow_visit(
             self._matchers,
-            getattr(self, f"leave_{type(original_node).__name__}_{attribute}", None),
+            getattr(self, sys.intern(f"leave_{type(original_node).__name__}_{attribute}"), None),
         ):
             # Either the visit_func doesn't exist, we have no matchers, or we passed all
             # matchers. In either case, just call the superclass behavior.

--- a/libcst/matchers/_visitors.py
+++ b/libcst/matchers/_visitors.py
@@ -3,8 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import sys
-
 from inspect import ismethod, signature
 from typing import (
     Any,
@@ -46,6 +44,7 @@ from libcst.matchers._matcher_base import (
     replace,
 )
 from libcst.matchers._return_types import TYPED_FUNCTION_RETURN_MAPPING
+from libcst._visitors import type_lookup
 
 try:
     # PEP 604 unions, in Python 3.10+
@@ -64,7 +63,7 @@ CONCRETE_METHODS: Set[str] = {
 
 def is_property(obj: object, attr_name: str) -> bool:
     """Check if obj.attr is a property without evaluating it."""
-    return isinstance(getattr(type(obj), sys.intern(attr_name), None), property)
+    return isinstance(type_lookup(type(obj), attr_name, None), property)
 
 
 # pyre-ignore We don't care about Any here, its not exposed.
@@ -501,7 +500,7 @@ class MatcherDecoratableTransformer(CSTTransformer):
 
         # Now, evaluate whether this current function has any matchers it requires.
         if not _should_allow_visit(
-            self._matchers, getattr(self, sys.intern(f"visit_{type(node).__name__}"), None)
+            self._matchers, type_lookup(self, f"visit_{type(node).__name__}", None)
         ):
             # We shouldn't visit this directly. However, we should continue
             # visiting its children.
@@ -516,7 +515,7 @@ class MatcherDecoratableTransformer(CSTTransformer):
     ) -> Union[CSTNodeT, cst.RemovalSentinel]:
         # First, evaluate whether this current function has a decorator on it.
         if _should_allow_visit(
-            self._matchers, getattr(self, sys.intern(f"leave_{type(original_node).__name__}"), None)
+            self._matchers, type_lookup(self, f"leave_{type(original_node).__name__}", None)
         ):
             retval = CSTTransformer.on_leave(self, original_node, updated_node)
         else:
@@ -545,7 +544,7 @@ class MatcherDecoratableTransformer(CSTTransformer):
         # Evaluate whether this current function has a decorator on it.
         if _should_allow_visit(
             self._matchers,
-            getattr(self, sys.intern(f"visit_{type(node).__name__}_{attribute}"), None),
+            type_lookup(self, f"visit_{type(node).__name__}_{attribute}", None),
         ):
             # Either the visit_func doesn't exist, we have no matchers, or we passed all
             # matchers. In either case, just call the superclass behavior.
@@ -555,7 +554,7 @@ class MatcherDecoratableTransformer(CSTTransformer):
         # Evaluate whether this current function has a decorator on it.
         if _should_allow_visit(
             self._matchers,
-            getattr(self, sys.intern(f"leave_{type(original_node).__name__}_{attribute}"), None),
+            type_lookup(self, f"leave_{type(original_node).__name__}_{attribute}", None),
         ):
             # Either the visit_func doesn't exist, we have no matchers, or we passed all
             # matchers. In either case, just call the superclass behavior.
@@ -713,7 +712,7 @@ class MatcherDecoratableVisitor(CSTVisitor):
 
         # Now, evaluate whether this current function has a decorator on it.
         if not _should_allow_visit(
-            self._matchers, getattr(self, sys.intern(f"visit_{type(node).__name__}"), None)
+            self._matchers, type_lookup(self, f"visit_{type(node).__name__}", None)
         ):
             # We shouldn't visit this directly. However, we should continue
             # visiting its children.
@@ -726,7 +725,7 @@ class MatcherDecoratableVisitor(CSTVisitor):
     def on_leave(self, original_node: cst.CSTNode) -> None:
         # First, evaluate whether this current function has a decorator on it.
         if _should_allow_visit(
-            self._matchers, getattr(self, sys.intern(f"leave_{type(original_node).__name__}"), None)
+            self._matchers, type_lookup(self, f"leave_{type(original_node).__name__}", None)
         ):
             CSTVisitor.on_leave(self, original_node)
 
@@ -745,7 +744,7 @@ class MatcherDecoratableVisitor(CSTVisitor):
         # Evaluate whether this current function has a decorator on it.
         if _should_allow_visit(
             self._matchers,
-            getattr(self, sys.intern(f"visit_{type(node).__name__}_{attribute}"), None),
+            type_lookup(self, f"visit_{type(node).__name__}_{attribute}", None),
         ):
             # Either the visit_func doesn't exist, we have no matchers, or we passed all
             # matchers. In either case, just call the superclass behavior.
@@ -755,7 +754,7 @@ class MatcherDecoratableVisitor(CSTVisitor):
         # Evaluate whether this current function has a decorator on it.
         if _should_allow_visit(
             self._matchers,
-            getattr(self, sys.intern(f"leave_{type(original_node).__name__}_{attribute}"), None),
+            type_lookup(self, f"leave_{type(original_node).__name__}_{attribute}", None),
         ):
             # Either the visit_func doesn't exist, we have no matchers, or we passed all
             # matchers. In either case, just call the superclass behavior.

--- a/libcst/tests/test_e2e.py
+++ b/libcst/tests/test_e2e.py
@@ -60,10 +60,10 @@ class ToolE2ETest(TestCase):
             adir.mkdir()
 
             # Run command
-            command_instance = PrintToPPrintCommand(CodemodContext())
             files = gather_files(".")
             result = parallel_exec_transform_with_prettyprint(
-                command_instance,
+                PrintToPPrintCommand,
+                {},
                 files,
                 format_code=False,
                 hide_progress=True,

--- a/libcst/tool.py
+++ b/libcst/tool.py
@@ -374,7 +374,6 @@ def _codemod_impl(proc_name: str, command_args: List[str]) -> int:  # noqa: C901
             "unified_diff",
         }
     }
-    command_instance = command_class(CodemodContext(), **codemod_args)
 
     # Sepcify target version for black formatter
     if any(config["formatter"]) and os.path.basename(config["formatter"][0]) in (
@@ -397,6 +396,7 @@ def _codemod_impl(proc_name: str, command_args: List[str]) -> int:  # noqa: C901
 
         print("Codemodding from stdin", file=sys.stderr)
         oldcode = sys.stdin.read()
+        command_instance = command_class(CodemodContext(), **codemod_args)
         newcode = exec_transform_with_prettyprint(
             command_instance,
             oldcode,
@@ -421,7 +421,8 @@ def _codemod_impl(proc_name: str, command_args: List[str]) -> int:  # noqa: C901
     files = gather_files(args.path, include_stubs=args.include_stubs)
     try:
         result = parallel_exec_transform_with_prettyprint(
-            command_instance,
+            command_class,
+            codemod_args,
             files,
             jobs=args.jobs,
             unified_diff=args.unified_diff,

--- a/native/libcst/src/py.rs
+++ b/native/libcst/src/py.rs
@@ -6,7 +6,7 @@
 use crate::nodes::traits::py::TryIntoPy;
 use pyo3::prelude::*;
 
-#[pymodule]
+#[pymodule(gil_used = false)]
 #[pyo3(name = "native")]
 pub fn libcst_native(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     #[pyfn(m)]

--- a/native/libcst/src/py.rs
+++ b/native/libcst/src/py.rs
@@ -8,24 +8,30 @@ use pyo3::prelude::*;
 
 #[pymodule(gil_used = false)]
 #[pyo3(name = "native")]
-pub fn libcst_native(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
+pub fn libcst_native(m: &Bound<PyModule>) -> PyResult<()> {
     #[pyfn(m)]
     #[pyo3(signature = (source, encoding=None))]
     fn parse_module(source: String, encoding: Option<&str>) -> PyResult<PyObject> {
-        let m = crate::parse_module(source.as_str(), encoding)?;
-        Python::with_gil(|py| m.try_into_py(py))
+        Python::with_gil(|py| {
+            let m = py.allow_threads(|| crate::parse_module(source.as_str(), encoding))?;
+            m.try_into_py(py)
+        })
     }
 
     #[pyfn(m)]
     fn parse_expression(source: String) -> PyResult<PyObject> {
-        let expr = crate::parse_expression(source.as_str())?;
-        Python::with_gil(|py| expr.try_into_py(py))
+        Python::with_gil(|py| {
+            let expr = py.allow_threads(|| crate::parse_expression(source.as_str()))?;
+            expr.try_into_py(py)
+        })
     }
 
     #[pyfn(m)]
     fn parse_statement(source: String) -> PyResult<PyObject> {
-        let stm = crate::parse_statement(source.as_str())?;
-        Python::with_gil(|py| stm.try_into_py(py))
+        Python::with_gil(|py| {
+            let stm = py.allow_threads(|| crate::parse_statement(source.as_str()))?;
+            stm.try_into_py(py)
+        })
     }
 
     Ok(())


### PR DESCRIPTION
This uses thread-local storage to avoid a scaling bottleneck due to a global cache in CPython internals. Unfortunately it's pretty slow ~10% of the total runtime of my benchmark is in the `type_lookup` function, I'm going to look at whether it can be faster...

Also refactors some rust code so it doesn't block other threads from doing work if the interpreter requests a GC pass.

