### PR TITLE
fix(dependency): add back typing-extensions for 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ requires-python = ">=3.9"
 dependencies = [
     "pyyaml>=5.2; python_version < '3.13'",
     "pyyaml-ft>=8.0.0; python_version >= '3.13'",
+    "typing-extensions; python_version < '3.10'",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1207,6 +1207,7 @@ source = { editable = "." }
 dependencies = [
     { name = "pyyaml", marker = "python_full_version < '3.13'" },
     { name = "pyyaml-ft", marker = "python_full_version >= '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
 
 [package.dev-dependencies]
@@ -1257,6 +1258,7 @@ docs = [
 requires-dist = [
     { name = "pyyaml", marker = "python_full_version < '3.13'", specifier = ">=5.2" },
     { name = "pyyaml-ft", marker = "python_full_version >= '3.13'", specifier = ">=8.0.0" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
Missing typing-extensions breaks "from libcst.codemod import CodemodContext"

This can be verified by 

```shell
uv run --python 3.9 --with libcst==1.8.1 python -c "from libcst.codemod import CodemodContext"
```

it raises the following error

```
    from typing_extensions import ParamSpec
ModuleNotFoundError: No module named 'typing_extensions'
```

while it works fine for 3.10

```shell
uv run --python 3.10 --with libcst==1.8.1 python -c "from libcst.codemod import CodemodContext"
```

## Test Plan

