### PR TITLE
Fix `noqa` comments

### DIFF
--- a/libcst/_parser/parso/python/token.py
+++ b/libcst/_parser/parso/python/token.py
@@ -27,7 +27,7 @@ try:
         ERROR_DEDENT: TokenType = native_token_type.ERROR_DEDENT
 
 except ImportError:
-    from libcst._parser.parso.python.py_token import (  # noqa F401
+    from libcst._parser.parso.python.py_token import (  # noqa: F401
         PythonTokenTypes,
         TokenType,
     )

--- a/libcst/_parser/types/token.py
+++ b/libcst/_parser/types/token.py
@@ -9,4 +9,4 @@ try:
 
     Token = tokenize.Token
 except ImportError:
-    from libcst._parser.types.py_token import Token  # noqa F401
+    from libcst._parser.types.py_token import Token  # noqa: F401


### PR DESCRIPTION
## Summary

At Sonar, we are working on suppressing linter issues on lines containing comments starting with `noqa`.

Doing so, and testing it on your source code, it seems that two of the `noqa` comments are missing `:` before the rule ID. 
Then, all issues on these lines are suppressed, rather than only the issue with the specific rule ID. I guess this was not the intent, and I propose to correct it. 
