### PR TITLE
Fixes indented block position by PositionProvider (#1380)

### DIFF
--- a/libcst/metadata/tests/test_position_provider.py
+++ b/libcst/metadata/tests/test_position_provider.py
@@ -83,6 +83,62 @@ class PositionProviderTest(UnitTest):
         wrapper = MetadataWrapper(parse_module("pass"))
         wrapper.visit_batched([ABatchable()])
 
+    def test_indented_block_starting_with_decorated_function_def(self) -> None:
+        """
+        Tests that the position provider correctly computes positions in an indented block
+        starting with a decorated function definition.
+        """
+        test = self
+
+        class IndentedBlockVisitor(CSTVisitor):
+            METADATA_DEPENDENCIES = (PositionProvider,)
+
+            def visit_IndentedBlock(self, node: cst.IndentedBlock) -> None:
+                test.assertEqual(
+                    self.get_metadata(PositionProvider, node),
+                    CodeRange((3, 4), (5, 15)),
+                )
+
+        wrapper = MetadataWrapper(
+            parse_module(
+                """ # Empty line
+def foo():
+    @decorator
+    def func(): return 42
+    return func
+"""
+            )
+        )
+        wrapper.visit(IndentedBlockVisitor())
+
+    def test_indented_block_starting_with_decorated_class_def(self) -> None:
+        """
+        Tests that the position provider correctly computes positions in an indented block
+        starting with a decorated class definition.
+        """
+        test = self
+
+        class IndentedBlockVisitor(CSTVisitor):
+            METADATA_DEPENDENCIES = (PositionProvider,)
+
+            def visit_IndentedBlock(self, node: cst.IndentedBlock) -> None:
+                test.assertEqual(
+                    self.get_metadata(PositionProvider, node),
+                    CodeRange((3, 4), (5, 18)),
+                )
+
+        wrapper = MetadataWrapper(
+            parse_module(
+                """ # Empty line
+def foo():
+    @decorator
+    class MyClass: pass
+    return MyClass
+"""
+            )
+        )
+        wrapper.visit(IndentedBlockVisitor())
+
 
 class PositionProvidingCodegenStateTest(UnitTest):
     def test_codegen_initial_position(self) -> None:


### PR DESCRIPTION
## Summary
Added a check for `ClassDef` and `FunctionDef` nodes with decorators when they appear as the first node in an indented block.
In such cases, the `state.record_syntactic_position` is called with `start_node` being the first decorator of the class/function definition and not the definition itself.

## Test Plan
Added two tests, one for `ClassDef` and one for `FunctionDef` in `libcst/metadata/tests/test_position_provider.py` under `PositionProviderTest`

