### PR TITLE
fixes match statements to work with PositionProvider

### DIFF
--- a/libcst/_nodes/statement.py
+++ b/libcst/_nodes/statement.py
@@ -2886,6 +2886,9 @@ class MatchCase(CSTNode):
                 state.add_token("if")
                 self.whitespace_after_if._codegen(state)
                 guard._codegen(state)
+            else:
+                self.whitespace_before_if._codegen(state)
+                self.whitespace_after_if._codegen(state)
 
             self.whitespace_before_colon._codegen(state)
             state.add_token(":")
@@ -3472,6 +3475,13 @@ class MatchAs(MatchPattern):
                 if ws_after is MaybeSentinel.DEFAULT:
                     state.add_token(" ")
                 elif isinstance(ws_after, BaseParenthesizableWhitespace):
+                    ws_after._codegen(state)
+            else:
+                ws_before = self.whitespace_before_as
+                if isinstance(ws_before, BaseParenthesizableWhitespace):
+                    ws_before._codegen(state)
+                ws_after = self.whitespace_after_as
+                if isinstance(ws_after, BaseParenthesizableWhitespace):
                     ws_after._codegen(state)
             if name is None:
                 state.add_token("_")

--- a/libcst/metadata/tests/test_position_provider.py
+++ b/libcst/metadata/tests/test_position_provider.py
@@ -90,14 +90,12 @@ class PositionProviderTest(UnitTest):
             METADATA_DEPENDENCIES = (PositionProvider,)
 
             def visit_Match(self, node: cst.Match) -> None:
-                # Test that match statement has correct position
                 test.assertEqual(
                     self.get_metadata(PositionProvider, node),
                     CodeRange((2, 0), (5, 16)),
                 )
 
             def visit_MatchCase(self, node: cst.MatchCase) -> None:
-                # Test that match cases have correct positions
                 if (
                     isinstance(node.pattern, cst.MatchAs)
                     and node.pattern.name
@@ -117,7 +115,6 @@ class PositionProviderTest(UnitTest):
                         CodeRange((4, 4), (4, 16)),
                     )
                 elif isinstance(node.pattern, cst.MatchAs) and not node.pattern.name:
-                    # This is the wildcard case `case _: pass`
                     test.assertEqual(
                         self.get_metadata(PositionProvider, node),
                         CodeRange((5, 4), (5, 16)),

--- a/libcst/metadata/tests/test_position_provider.py
+++ b/libcst/metadata/tests/test_position_provider.py
@@ -166,3 +166,25 @@ class PositionProvidingCodegenStateTest(UnitTest):
 
         # check syntactic position ignores whitespace
         self.assertEqual(state.provider._computed[node], CodeRange((1, 1), (1, 5)))
+
+
+class MatchProviderTest(UnitTest):
+    def test_match_provider(self) -> None:
+        class Visitor(cst.CSTVisitor):
+            METADATA_DEPENDENCIES = (PositionProvider,)
+
+            def on_visit(self, node):
+                print(self.get_metadata(PositionProvider, node).start.line)
+                return super().on_visit(node)
+
+
+        code = """
+match status:
+    case b: pass
+    case c: pass
+    case _: pass
+"""
+        
+        wrapper = MetadataWrapper(parse_module(code))
+        visitor = Visitor()
+        module = wrapper.visit(visitor)

--- a/libcst/metadata/tests/test_position_provider.py
+++ b/libcst/metadata/tests/test_position_provider.py
@@ -83,6 +83,56 @@ class PositionProviderTest(UnitTest):
         wrapper = MetadataWrapper(parse_module("pass"))
         wrapper.visit_batched([ABatchable()])
 
+    def test_match_statement_position_metadata(self) -> None:
+        test = self
+
+        class MatchPositionVisitor(CSTVisitor):
+            METADATA_DEPENDENCIES = (PositionProvider,)
+
+            def visit_Match(self, node: cst.Match) -> None:
+                # Test that match statement has correct position
+                test.assertEqual(
+                    self.get_metadata(PositionProvider, node),
+                    CodeRange((2, 0), (5, 16)),
+                )
+
+            def visit_MatchCase(self, node: cst.MatchCase) -> None:
+                # Test that match cases have correct positions
+                if (
+                    isinstance(node.pattern, cst.MatchAs)
+                    and node.pattern.name
+                    and node.pattern.name.value == "b"
+                ):
+                    test.assertEqual(
+                        self.get_metadata(PositionProvider, node),
+                        CodeRange((3, 4), (3, 16)),
+                    )
+                elif (
+                    isinstance(node.pattern, cst.MatchAs)
+                    and node.pattern.name
+                    and node.pattern.name.value == "c"
+                ):
+                    test.assertEqual(
+                        self.get_metadata(PositionProvider, node),
+                        CodeRange((4, 4), (4, 16)),
+                    )
+                elif isinstance(node.pattern, cst.MatchAs) and not node.pattern.name:
+                    # This is the wildcard case `case _: pass`
+                    test.assertEqual(
+                        self.get_metadata(PositionProvider, node),
+                        CodeRange((5, 4), (5, 16)),
+                    )
+
+        code = """
+match status:
+    case b: pass
+    case c: pass
+    case _: pass
+"""
+
+        wrapper = MetadataWrapper(parse_module(code))
+        wrapper.visit(MatchPositionVisitor())
+
 
 class PositionProvidingCodegenStateTest(UnitTest):
     def test_codegen_initial_position(self) -> None:
@@ -166,25 +216,3 @@ class PositionProvidingCodegenStateTest(UnitTest):
 
         # check syntactic position ignores whitespace
         self.assertEqual(state.provider._computed[node], CodeRange((1, 1), (1, 5)))
-
-
-class MatchProviderTest(UnitTest):
-    def test_match_provider(self) -> None:
-        class Visitor(cst.CSTVisitor):
-            METADATA_DEPENDENCIES = (PositionProvider,)
-
-            def on_visit(self, node):
-                print(self.get_metadata(PositionProvider, node).start.line)
-                return super().on_visit(node)
-
-
-        code = """
-match status:
-    case b: pass
-    case c: pass
-    case _: pass
-"""
-        
-        wrapper = MetadataWrapper(parse_module(code))
-        visitor = Visitor()
-        module = wrapper.visit(visitor)


### PR DESCRIPTION
## Summary

(This is a rebase of https://github.com/Instagram/LibCST/pull/1369)

Fixes https://github.com/Instagram/LibCST/issues/1322 where PositionProvider does not provide positions for whitespace. The issue seems to be that when there is no pattern for whitespace nodes during codegen, then they are not included in the position metadata.

## Test Plan

* Added a test
* Verified this test failed
* Implemented fix and verified fix
