### PR TITLE
fix: circular import error

### DIFF
--- a/libcst/_parser/entrypoints.py
+++ b/libcst/_parser/entrypoints.py
@@ -12,7 +12,6 @@ information
 from functools import partial
 from typing import Union
 
-from libcst import native
 from libcst._nodes.base import CSTNode
 from libcst._nodes.expression import BaseExpression
 from libcst._nodes.module import Module
@@ -33,6 +32,8 @@ def _parse(
 ) -> CSTNode:
 
     encoding, source_str = convert_to_utf8(source, partial=config)
+
+    from libcst import native
 
     if entrypoint == "file_input":
         parse = partial(native.parse_module, encoding=encoding)

--- a/libcst/tests/test_import.py
+++ b/libcst/tests/test_import.py
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from unittest import TestCase
+
+
+class TestImport(TestCase):
+    def test_import_libcst(self) -> None:
+        import libcst

--- a/libcst/tests/test_import.py
+++ b/libcst/tests/test_import.py
@@ -9,4 +9,4 @@ from unittest import TestCase
 
 class TestImport(TestCase):
     def test_import_libcst(self) -> None:
-        import libcst
+        import libcst  # noqa: F401


### PR DESCRIPTION
## Summary
Fixes circular import in libcst
## Test Plan

before:
```
thon -m unittest libcst/tests/test_import.py
E
======================================================================
ERROR: libcst (unittest.loader._FailedTest.libcst)
----------------------------------------------------------------------
ImportError: Failed to import test module: libcst
Traceback (most recent call last):
  File "/usr/local/fbcode/platform010/Python3.12.framework/Versions/3.12/lib/python3.12/unittest/loader.py", line 137, in loadTestsFromName
    module = __import__(module_name)
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/martinli/code/LibCST/libcst/__init__.py", line 216, in <module>
    from libcst._parser.entrypoints import parse_expression, parse_module, parse_statement
  File "/Users/martinli/code/LibCST/libcst/_parser/entrypoints.py", line 25, in <module>
    from libcst import native
ImportError: cannot import name 'native' from partially initialized module 'libcst' (most likely due to a circular import) (/Users/martinli/code/LibCST/libcst/__init__.py)


----------------------------------------------------------------------
Ran 1 test in 0.000s
```

after
```
martinli@martinli-mac LibCST % fbpython -m unittest libcst/tests/test_import.py
.
----------------------------------------------------------------------
Ran 1 test in 0.000s

OK
```