### PR TITLE
Make CodemodCommand's supported_transforms order deterministic

### DIFF
--- a/libcst/codemod/_command.py
+++ b/libcst/codemod/_command.py
@@ -6,7 +6,7 @@
 import argparse
 import inspect
 from abc import ABC, abstractmethod
-from typing import Dict, Generator, List, Type, TypeVar
+from typing import Dict, Generator, List, Tuple, Type, TypeVar
 
 from libcst import Module
 from libcst.codemod._codemod import Codemod
@@ -75,13 +75,13 @@ class CodemodCommand(Codemod, ABC):
         # have a static method that other transforms can use which takes
         # a context and other optional args and modifies its own context key
         # accordingly. We import them here so that we don't have circular imports.
-        supported_transforms: Dict[str, Type[Codemod]] = {
-            AddImportsVisitor.CONTEXT_KEY: AddImportsVisitor,
-            RemoveImportsVisitor.CONTEXT_KEY: RemoveImportsVisitor,
-        }
+        supported_transforms: List[Tuple[str, Type[Codemod]]] = [
+            (AddImportsVisitor.CONTEXT_KEY, AddImportsVisitor),
+            (RemoveImportsVisitor.CONTEXT_KEY, RemoveImportsVisitor),
+        ]
 
         # For any visitors that we support auto-running, run them here if needed.
-        for key, transform in supported_transforms.items():
+        for key, transform in supported_transforms:
             if key in self.context.scratch:
                 # We have work to do, so lets run this.
                 tree = self._instantiate_and_run(transform, tree)


### PR DESCRIPTION
## Summary
Changed `supported_transforms` from `Dict[str, Type[Codemod]]` to `List[Tuple[str, Type[Codemod]]]` 
to ensure deterministic iteration order when applying transforms.

Previously, using a dictionary meant the order of `RemoveImportsVisitor` and `AddImportsVisitor` could vary across 
Python versions or runs (especially in Python 3.6 and earlier). By switching to a list of 
tuples, the transforms (AddImportsVisitor and RemoveImportsVisitor) will always be applied 
in a consistent, predictable order.

This improves reproducibility and makes debugging easier when multiple transforms are applied.

Also it makes more sense to always have `RemoveImportsVisitor` after `AddImportsVisitor` to cleanup any imports.

## Test Plan
1. Format your code
`uv run poe format`

2. Run the type checker
`uv run poe typecheck`

3. Test your changes
`uv run poe test`

4. Check linters
`uv run poe lint`

[Meta] Using this library as a part of my work at IG
