### PR TITLE
avoid property access in `BatchableCSTVisitor.get_visitors`

### DIFF
--- a/libcst/_batched_visitor.py
+++ b/libcst/_batched_visitor.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import inspect
 from typing import (
     Callable,
     cast,
@@ -44,20 +43,19 @@ class BatchableCSTVisitor(CSTTypedVisitorFunctions, MetadataDependent):
         excluding all empty stubs.
         """
 
-        methods = inspect.getmembers(
-            self,
-            lambda m: (
-                inspect.ismethod(m)
-                and (m.__name__.startswith("visit_") or m.__name__.startswith("leave_"))
-                and not getattr(m, "_is_no_op", False)
-            ),
-        )
+        methods = {
+            name: method
+            for name in dir(self)
+            if name.startswith(("visit_", "leave_"))
+            and callable(method := getattr(self, name))
+            and not getattr(method, "_is_no_op", False)
+        }
 
         # TODO: verify all visitor methods reference valid node classes.
         # for name, __ in methods:
         #     ...
 
-        return dict(methods)
+        return methods
 
 
 def visit_batched(

--- a/libcst/tests/test_batched_visitor.py
+++ b/libcst/tests/test_batched_visitor.py
@@ -70,3 +70,20 @@ class BatchedVisitorTest(UnitTest):
         self.assertEqual(
             object.__getattribute__(if_, "whitespace_before_test"), mock.leave_If()
         )
+
+    def test_no_property_access(self) -> None:
+        mock = Mock()
+
+        class Batchable(BatchableCSTVisitor):
+            @property
+            def evil_property(self) -> str:
+                mock.evil_property()
+                return "evil"
+
+            def visit_Module(self, node: cst.Module) -> None:
+                mock.visit_Module()
+
+        _ = visit_batched(parse_module("if True: pass"), [Batchable()])
+
+        mock.visit_Module.assert_called_once()
+        mock.evil_property.assert_not_called()


### PR DESCRIPTION
`BatchableCSTVisitor.get_visitors` uses `inspect.getmembers`, but because that uses `getattr`, all properties of the `Visitor` class will be executed. This is bad for performance, can cause side effects. In case of the `ContextAwareVisitor.module` property, this will even result in a `ValueError`, for example when calling `visit_batched` with the following visitor:

```py
class _ExportsVisitor(GatherExportsVisitor, cst.BatchableCSTVisitor): pass
```


The fix is to filter out the names that start with `visit_` or `leave_` **before** using `getattr`. An additional advantage of this approach is that it's quite a bit faster, because it avoids having to call the predicate function for each member of the visitor. 
