### PR TITLE
Fix issue #875: Reorder IfExp fields to match evaluation order

### DIFF
--- a/libcst/_exceptions.py
+++ b/libcst/_exceptions.py
@@ -8,7 +8,6 @@ from typing import Any, Callable, final, Optional, Sequence, Tuple
 
 from libcst._tabs import expand_tabs
 
-
 _NEWLINE_CHARS: str = "\r\n"
 
 

--- a/libcst/_nodes/expression.py
+++ b/libcst/_nodes/expression.py
@@ -18,7 +18,6 @@ from tokenize import (
 from typing import Callable, Generator, Literal, Optional, Sequence, Union
 
 from libcst import CSTLogicError
-
 from libcst._add_slots import add_slots
 from libcst._maybe_sentinel import MaybeSentinel
 from libcst._nodes.base import CSTCodegenError, CSTNode, CSTValidationError
@@ -2741,11 +2740,11 @@ class IfExp(BaseExpression):
     If statements are provided by :class:`If` and :class:`Else` nodes.
     """
 
-    #: The test to perform.
-    test: BaseExpression
-
     #: The expression to evaluate when the test is true.
     body: BaseExpression
+
+    #: The test to perform.
+    test: BaseExpression
 
     #: The expression to evaluate when the test is false.
     orelse: BaseExpression

--- a/libcst/_nodes/statement.py
+++ b/libcst/_nodes/statement.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass, field
 from typing import Literal, Optional, Pattern, Sequence, Union
 
 from libcst import CSTLogicError
-
 from libcst._add_slots import add_slots
 from libcst._maybe_sentinel import MaybeSentinel
 from libcst._nodes.base import CSTNode, CSTValidationError

--- a/libcst/_nodes/tests/test_cst_node.py
+++ b/libcst/_nodes/tests/test_cst_node.py
@@ -146,8 +146,7 @@ class CSTNodeTest(UnitTest):
                     ),
                 )
             ),
-            dedent(
-                """
+            dedent("""
                 SimpleStatementLine(
                     body=[
                         Pass(
@@ -188,8 +187,7 @@ class CSTNodeTest(UnitTest):
                         ),
                     ),
                 )
-                """
-            ).strip(),
+                """).strip(),
         )
 
     def test_visit(self) -> None:

--- a/libcst/_nodes/tests/test_ifexp.py
+++ b/libcst/_nodes/tests/test_ifexp.py
@@ -114,8 +114,8 @@ class IfExpTest(CSTNodeTest):
         (
             (
                 lambda: cst.IfExp(
-                    cst.Name("bar"),
                     cst.Name("foo"),
+                    cst.Name("bar"),
                     cst.Name("baz"),
                     lpar=(cst.LeftParen(),),
                 ),
@@ -123,8 +123,8 @@ class IfExpTest(CSTNodeTest):
             ),
             (
                 lambda: cst.IfExp(
-                    cst.Name("bar"),
                     cst.Name("foo"),
+                    cst.Name("bar"),
                     cst.Name("baz"),
                     rpar=(cst.RightParen(),),
                 ),

--- a/libcst/_nodes/tests/test_module.py
+++ b/libcst/_nodes/tests/test_module.py
@@ -8,7 +8,6 @@ from typing import cast, Tuple
 import libcst as cst
 from libcst import parse_module, parse_statement
 from libcst._nodes.tests.base import CSTNodeTest
-
 from libcst.metadata import CodeRange, MetadataWrapper, PositionProvider
 from libcst.testing.utils import data_provider
 

--- a/libcst/_parser/conversions/expression.py
+++ b/libcst/_parser/conversions/expression.py
@@ -159,7 +159,7 @@ COMPOP_TOKEN_LUT: typing.Dict[str, typing.Type[BaseCompOp]] = {
 def convert_expression_input(
     config: ParserConfig, children: typing.Sequence[typing.Any]
 ) -> typing.Any:
-    (child, endmarker) = children
+    child, endmarker = children
     # HACK: UGLY! REMOVE THIS SOON!
     # Unwrap WithLeadingWhitespace if it exists. It shouldn't exist by this point, but
     # testlist isn't fully implemented, and we currently leak these partial objects.
@@ -177,7 +177,7 @@ def convert_namedexpr_test(
         return test
 
     # Convert all of the operations that have no precedence in a loop
-    (walrus, value) = assignment
+    walrus, value = assignment
     return WithLeadingWhitespace(
         NamedExpr(
             target=test.value,
@@ -201,7 +201,7 @@ def convert_test(
         (child,) = children
         return child
     else:
-        (body, if_token, test, else_token, orelse) = children
+        body, if_token, test, else_token, orelse = children
         return WithLeadingWhitespace(
             IfExp(
                 body=body.value,
@@ -718,7 +718,7 @@ def convert_trailer_arglist(
 def convert_trailer_subscriptlist(
     config: ParserConfig, children: typing.Sequence[typing.Any]
 ) -> typing.Any:
-    (lbracket, subscriptlist, rbracket) = children
+    lbracket, subscriptlist, rbracket = children
     return SubscriptPartial(
         lbracket=LeftSquareBracket(
             whitespace_after=parse_parenthesizable_whitespace(
@@ -1556,7 +1556,7 @@ def convert_comp_for(
         (sync_comp_for,) = children
         return sync_comp_for
     else:
-        (async_tok, sync_comp_for) = children
+        async_tok, sync_comp_for = children
         return sync_comp_for.with_changes(
             # asynchronous steals the `CompFor`'s `whitespace_before`.
             asynchronous=Asynchronous(whitespace_after=sync_comp_for.whitespace_before),
@@ -1594,7 +1594,7 @@ def convert_yield_expr(
         yield_node = Yield(value=None)
     else:
         # Yielding explicit value
-        (yield_token, yield_arg) = children
+        yield_token, yield_arg = children
         yield_node = Yield(
             value=yield_arg.value,
             whitespace_after_yield=parse_parenthesizable_whitespace(
@@ -1617,7 +1617,7 @@ def convert_yield_arg(
         return child
     else:
         # Its a yield from
-        (from_token, test) = children
+        from_token, test = children
 
         return WithLeadingWhitespace(
             From(

--- a/libcst/_parser/conversions/statement.py
+++ b/libcst/_parser/conversions/statement.py
@@ -121,7 +121,7 @@ AUGOP_TOKEN_LUT: Dict[str, Type[BaseAugOp]] = {
 
 @with_production("stmt_input", "stmt ENDMARKER")
 def convert_stmt_input(config: ParserConfig, children: Sequence[Any]) -> Any:
-    (child, endmarker) = children
+    child, endmarker = children
     return child
 
 
@@ -359,7 +359,7 @@ def convert_pass_stmt(config: ParserConfig, children: Sequence[Any]) -> Any:
 
 @with_production("del_stmt", "'del' exprlist")
 def convert_del_stmt(config: ParserConfig, children: Sequence[Any]) -> Any:
-    (del_name, exprlist) = children
+    del_name, exprlist = children
     return WithLeadingWhitespace(
         Del(
             target=exprlist.value,
@@ -393,7 +393,7 @@ def convert_return_stmt(config: ParserConfig, children: Sequence[Any]) -> Any:
             keyword.whitespace_before,
         )
     else:
-        (keyword, testlist) = children
+        keyword, testlist = children
         return WithLeadingWhitespace(
             Return(
                 value=testlist.value,
@@ -635,12 +635,12 @@ def convert_raise_stmt(config: ParserConfig, children: Sequence[Any]) -> Any:
         exc = None
         cause = None
     elif len(children) == 2:
-        (raise_token, test) = children
+        raise_token, test = children
         whitespace_after_raise = parse_simple_whitespace(config, test.whitespace_before)
         exc = test.value
         cause = None
     elif len(children) == 4:
-        (raise_token, test, from_token, source) = children
+        raise_token, test, from_token, source = children
         whitespace_after_raise = parse_simple_whitespace(config, test.whitespace_before)
         exc = test.value
         cause = From(
@@ -685,7 +685,7 @@ def _construct_nameitems(config: ParserConfig, names: Sequence[Any]) -> List[Nam
 
 @with_production("global_stmt", "'global' NAME (',' NAME)*")
 def convert_global_stmt(config: ParserConfig, children: Sequence[Any]) -> Any:
-    (global_token, *names) = children
+    global_token, *names = children
     return WithLeadingWhitespace(
         Global(
             names=tuple(_construct_nameitems(config, names)),
@@ -699,7 +699,7 @@ def convert_global_stmt(config: ParserConfig, children: Sequence[Any]) -> Any:
 
 @with_production("nonlocal_stmt", "'nonlocal' NAME (',' NAME)*")
 def convert_nonlocal_stmt(config: ParserConfig, children: Sequence[Any]) -> Any:
-    (nonlocal_token, *names) = children
+    nonlocal_token, *names = children
     return WithLeadingWhitespace(
         Nonlocal(
             names=tuple(_construct_nameitems(config, names)),
@@ -714,7 +714,7 @@ def convert_nonlocal_stmt(config: ParserConfig, children: Sequence[Any]) -> Any:
 @with_production("assert_stmt", "'assert' test [',' test]")
 def convert_assert_stmt(config: ParserConfig, children: Sequence[Any]) -> Any:
     if len(children) == 2:
-        (assert_token, test) = children
+        assert_token, test = children
         assert_node = Assert(
             whitespace_after_assert=parse_simple_whitespace(
                 config, test.whitespace_before
@@ -723,7 +723,7 @@ def convert_assert_stmt(config: ParserConfig, children: Sequence[Any]) -> Any:
             msg=None,
         )
     else:
-        (assert_token, test, comma_token, msg) = children
+        assert_token, test, comma_token, msg = children
         assert_node = Assert(
             whitespace_after_assert=parse_simple_whitespace(
                 config, test.whitespace_before
@@ -814,7 +814,7 @@ def convert_while_stmt(config: ParserConfig, children: Sequence[Any]) -> Any:
     while_token, test, while_colon_token, while_suite, *else_block = children
 
     if len(else_block) > 0:
-        (else_token, else_colon_token, else_suite) = else_block
+        else_token, else_colon_token, else_suite = else_block
         orelse = Else(
             leading_lines=parse_empty_lines(config, else_token.whitespace_before),
             whitespace_before_colon=parse_simple_whitespace(
@@ -854,7 +854,7 @@ def convert_for_stmt(config: ParserConfig, children: Sequence[Any]) -> Any:
     ) = children
 
     if len(else_block) > 0:
-        (else_token, else_colon_token, else_suite) = else_block
+        else_token, else_colon_token, else_suite = else_block
         orelse = Else(
             leading_lines=parse_empty_lines(config, else_token.whitespace_before),
             whitespace_before_colon=parse_simple_whitespace(
@@ -958,14 +958,14 @@ def convert_except_clause(config: ParserConfig, children: Sequence[Any]) -> Any:
         test = None
         name = None
     elif len(children) == 2:
-        (except_token, test_node) = children
+        except_token, test_node = children
         whitespace_after_except = parse_simple_whitespace(
             config, except_token.whitespace_after
         )
         test = test_node.value
         name = None
     else:
-        (except_token, test_node, as_token, name_token) = children
+        except_token, test_node, as_token, name_token = children
         whitespace_after_except = parse_simple_whitespace(
             config, except_token.whitespace_after
         )
@@ -993,7 +993,7 @@ def convert_except_clause(config: ParserConfig, children: Sequence[Any]) -> Any:
 )
 @with_production("with_stmt", "'with' with_item ':' suite", version="<3.1")
 def convert_with_stmt(config: ParserConfig, children: Sequence[Any]) -> Any:
-    (with_token, *items, colon_token, suite) = children
+    with_token, *items, colon_token, suite = children
     item_nodes: List[WithItem] = []
 
     for with_item, maybe_comma in grouper(items, 2):
@@ -1031,7 +1031,7 @@ def convert_with_stmt(config: ParserConfig, children: Sequence[Any]) -> Any:
 @with_production("with_item", "test ['as' expr]")
 def convert_with_item(config: ParserConfig, children: Sequence[Any]) -> Any:
     if len(children) == 3:
-        (test, as_token, expr_node) = children
+        test, as_token, expr_node = children
         test_node = test.value
         asname = AsName(
             whitespace_before_as=parse_simple_whitespace(

--- a/libcst/_parser/parso/tests/test_tokenize.py
+++ b/libcst/_parser/parso/tests/test_tokenize.py
@@ -68,14 +68,12 @@ class ParsoTokenizerTest(UnitTest):
 
     def test_function_whitespace(self):
         # Test function definition whitespace identification
-        fundef = dedent(
-            """
+        fundef = dedent("""
         def test_whitespace(*args, **kwargs):
             x = 1
             if x > 0:
                 print(True)
-        """
-        )
+        """)
         token_list = _get_token_list(fundef)
         for _, value, _, prefix in token_list:
             if value == "test_whitespace":
@@ -122,12 +120,10 @@ class ParsoTokenizerTest(UnitTest):
         ]
 
     def test_identifier_contains_unicode(self):
-        fundef = dedent(
-            """
+        fundef = dedent("""
         def 我あφ():
             pass
-        """
-        )
+        """)
         token_list = _get_token_list(fundef)
         unicode_token = token_list[1]
         assert unicode_token[0] == NAME
@@ -237,13 +233,11 @@ class ParsoTokenizerTest(UnitTest):
         assert endmarker.string == ""
 
     def test_indent_error_recovery(self):
-        code = dedent(
-            """\
+        code = dedent("""\
                             str(
             from x import a
             def
-            """
-        )
+            """)
         lst = _get_token_list(code)
         expected = [
             # `str(`
@@ -268,13 +262,11 @@ class ParsoTokenizerTest(UnitTest):
         assert [t.type for t in lst] == expected
 
     def test_error_token_after_dedent(self):
-        code = dedent(
-            """\
+        code = dedent("""\
             class C:
                 pass
             $foo
-            """
-        )
+            """)
         lst = _get_token_list(code)
         expected = [
             NAME,
@@ -298,23 +290,17 @@ class ParsoTokenizerTest(UnitTest):
         There used to be an issue that the parentheses counting would go below
         zero. This should not happen.
         """
-        code = dedent(
-            """\
+        code = dedent("""\
             }
             {
               }
-            """
-        )
+            """)
         lst = _get_token_list(code)
         assert [t.type for t in lst] == [OP, NEWLINE, OP, OP, NEWLINE, ENDMARKER]
 
     def test_form_feed(self):
-        error_token, endmarker = _get_token_list(
-            dedent(
-                '''\
-            \f"""'''
-            )
-        )
+        error_token, endmarker = _get_token_list(dedent('''\
+            \f"""'''))
         assert error_token.prefix == "\f"
         assert error_token.string == '"""'
         assert endmarker.prefix == ""

--- a/libcst/_parser/tests/test_parse_errors.py
+++ b/libcst/_parser/tests/test_parse_errors.py
@@ -19,150 +19,126 @@ class ParseErrorsTest(UnitTest):
             # _wrapped_tokenize raises these exceptions
             "wrapped_tokenize__invalid_token": (
                 lambda: cst.parse_module("'"),
-                dedent(
-                    """
+                dedent("""
                     Syntax Error @ 1:1.
                     "'" is not a valid token.
 
                     '
                     ^
-                    """
-                ).strip(),
+                    """).strip(),
             ),
             "wrapped_tokenize__expected_dedent": (
                 lambda: cst.parse_module("if False:\n    pass\n  pass"),
-                dedent(
-                    """
+                dedent("""
                     Syntax Error @ 3:1.
                     Inconsistent indentation. Expected a dedent.
 
                       pass
                     ^
-                    """
-                ).strip(),
+                    """).strip(),
             ),
             "wrapped_tokenize__mismatched_braces": (
                 lambda: cst.parse_module("abcd)"),
-                dedent(
-                    """
+                dedent("""
                     Syntax Error @ 1:5.
                     Encountered a closing brace without a matching opening brace.
 
                     abcd)
                         ^
-                    """
-                ).strip(),
+                    """).strip(),
             ),
             # _base_parser raises these exceptions
             "base_parser__unexpected_indent": (
                 lambda: cst.parse_module("    abcd"),
-                dedent(
-                    """
+                dedent("""
                     Syntax Error @ 1:5.
                     Incomplete input. Unexpectedly encountered an indent.
 
                         abcd
                         ^
-                    """
-                ).strip(),
+                    """).strip(),
             ),
             "base_parser__unexpected_dedent": (
                 lambda: cst.parse_module("if False:\n    (el for el\n"),
-                dedent(
-                    """
+                dedent("""
                     Syntax Error @ 3:1.
                     Incomplete input. Encountered a dedent, but expected 'in'.
 
                         (el for el
                                   ^
-                    """
-                ).strip(),
+                    """).strip(),
             ),
             "base_parser__multiple_possibilities": (
                 lambda: cst.parse_module("try: pass"),
-                dedent(
-                    """
+                dedent("""
                     Syntax Error @ 2:1.
                     Incomplete input. Encountered end of file (EOF), but expected 'except', or 'finally'.
 
                     try: pass
                              ^
-                    """
-                ).strip(),
+                    """).strip(),
             ),
             # conversion functions raise these exceptions.
             # `_base_parser` is responsible for attaching location information.
             "convert_nonterminal__dict_unpacking": (
                 lambda: cst.parse_expression("{**el for el in []}"),
-                dedent(
-                    """
+                dedent("""
                     Syntax Error @ 1:19.
                     dict unpacking cannot be used in dict comprehension
 
                     {**el for el in []}
                                       ^
-                    """
-                ).strip(),
+                    """).strip(),
             ),
             "convert_nonterminal__arglist_non_default_after_default": (
                 lambda: cst.parse_statement("def fn(first=None, second): ..."),
-                dedent(
-                    """
+                dedent("""
                     Syntax Error @ 1:26.
                     Cannot have a non-default argument following a default argument.
 
                     def fn(first=None, second): ...
                                              ^
-                    """
-                ).strip(),
+                    """).strip(),
             ),
             "convert_nonterminal__arglist_trailing_param_star_without_comma": (
                 lambda: cst.parse_statement("def fn(abc, *): ..."),
-                dedent(
-                    """
+                dedent("""
                     Syntax Error @ 1:14.
                     Named (keyword) arguments must follow a bare *.
 
                     def fn(abc, *): ...
                                  ^
-                    """
-                ).strip(),
+                    """).strip(),
             ),
             "convert_nonterminal__arglist_trailing_param_star_with_comma": (
                 lambda: cst.parse_statement("def fn(abc, *,): ..."),
-                dedent(
-                    """
+                dedent("""
                     Syntax Error @ 1:15.
                     Named (keyword) arguments must follow a bare *.
 
                     def fn(abc, *,): ...
                                   ^
-                    """
-                ).strip(),
+                    """).strip(),
             ),
             "convert_nonterminal__class_arg_positional_after_keyword": (
                 lambda: cst.parse_statement("class Cls(first=None, second): ..."),
-                dedent(
-                    """
+                dedent("""
                     Syntax Error @ 2:1.
                     Positional argument follows keyword argument.
 
                     class Cls(first=None, second): ...
                                                       ^
-                    """
-                ).strip(),
+                    """).strip(),
             ),
             "convert_nonterminal__class_arg_positional_expansion_after_keyword": (
                 lambda: cst.parse_statement("class Cls(first=None, *second): ..."),
-                dedent(
-                    """
+                dedent("""
                     Syntax Error @ 2:1.
                     Positional argument follows keyword argument.
 
                     class Cls(first=None, *second): ...
                                                        ^
-                    """
-                ).strip(),
+                    """).strip(),
             ),
         }
     )

--- a/libcst/_typed_visitor.py
+++ b/libcst/_typed_visitor.py
@@ -12,7 +12,6 @@ from libcst._maybe_sentinel import MaybeSentinel
 from libcst._removal_sentinel import RemovalSentinel
 from libcst._typed_visitor_base import mark_no_op
 
-
 if TYPE_CHECKING:
     from libcst._nodes.expression import (  # noqa: F401
         Annotation,
@@ -2551,19 +2550,19 @@ class CSTTypedBaseFunctions:
         pass
 
     @mark_no_op
-    def visit_IfExp_test(self, node: "IfExp") -> None:
-        pass
-
-    @mark_no_op
-    def leave_IfExp_test(self, node: "IfExp") -> None:
-        pass
-
-    @mark_no_op
     def visit_IfExp_body(self, node: "IfExp") -> None:
         pass
 
     @mark_no_op
     def leave_IfExp_body(self, node: "IfExp") -> None:
+        pass
+
+    @mark_no_op
+    def visit_IfExp_test(self, node: "IfExp") -> None:
+        pass
+
+    @mark_no_op
+    def leave_IfExp_test(self, node: "IfExp") -> None:
         pass
 
     @mark_no_op

--- a/libcst/_typed_visitor_base.py
+++ b/libcst/_typed_visitor_base.py
@@ -5,7 +5,6 @@
 
 from typing import Any, Callable, cast, TypeVar
 
-
 # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.
 F = TypeVar("F", bound=Callable)
 

--- a/libcst/codemod/commands/add_trailing_commas.py
+++ b/libcst/codemod/commands/add_trailing_commas.py
@@ -10,7 +10,6 @@ from typing import Dict, Optional
 import libcst as cst
 from libcst.codemod import CodemodContext, VisitorBasedCodemodCommand
 
-
 presets_per_formatter: Dict[str, Dict[str, int]] = {
     "black": {
         "parameter_count": 1,
@@ -24,8 +23,7 @@ presets_per_formatter: Dict[str, Dict[str, int]] = {
 
 
 class AddTrailingCommas(VisitorBasedCodemodCommand):
-    DESCRIPTION: str = textwrap.dedent(
-        """
+    DESCRIPTION: str = textwrap.dedent("""
         Codemod that adds trailing commas to arguments in function
         headers and function calls.
 
@@ -38,8 +36,7 @@ class AddTrailingCommas(VisitorBasedCodemodCommand):
 
         Applying this codemod (and then an autoformatter) may make
         it easier to read function definitions and calls
-        """
-    )
+        """)
 
     def __init__(
         self,

--- a/libcst/codemod/commands/tests/test_fix_pyre_directives.py
+++ b/libcst/codemod/commands/tests/test_fix_pyre_directives.py
@@ -14,9 +14,7 @@ class TestFixPyreDirectivesCommand(CodemodTest):
         """
         Tests that a pyre-strict inside the module header doesn't get touched.
         """
-        after = (
-            before
-        ) = """
+        after = before = """
             # pyre-strict
             from typing import List
 
@@ -29,9 +27,7 @@ class TestFixPyreDirectivesCommand(CodemodTest):
         """
         Tests that a pyre-strict inside the module header doesn't get touched.
         """
-        after = (
-            before
-        ) = """
+        after = before = """
             # This is some header comment.
             #
             # pyre-strict
@@ -46,9 +42,7 @@ class TestFixPyreDirectivesCommand(CodemodTest):
         """
         Tests that a pyre-strict inside the module header doesn't get touched.
         """
-        after = (
-            before
-        ) = """
+        after = before = """
             # pyre-strict
             #
             # This is some header comment.

--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -9,7 +9,6 @@ from typing import Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import libcst as cst
 import libcst.matchers as m
-
 from libcst.codemod._context import CodemodContext
 from libcst.codemod._visitor import ContextAwareTransformer
 from libcst.codemod.visitors._add_imports import AddImportsVisitor
@@ -18,7 +17,6 @@ from libcst.codemod.visitors._gather_imports import GatherImportsVisitor
 from libcst.codemod.visitors._imports import ImportItem
 from libcst.helpers import get_full_name_for_node
 from libcst.metadata import PositionProvider, QualifiedNameProvider
-
 
 NameOrAttribute = Union[cst.Name, cst.Attribute]
 NAME_OR_ATTRIBUTE = (cst.Name, cst.Attribute)

--- a/libcst/codemod/visitors/tests/test_gather_comments.py
+++ b/libcst/codemod/visitors/tests/test_gather_comments.py
@@ -20,25 +20,21 @@ class TestGatherCommentsVisitor(UnitTest):
         return instance
 
     def test_no_comments(self) -> None:
-        visitor = self.gather_comments(
-            """
+        visitor = self.gather_comments("""
             def foo() -> None:
                 pass
-            """
-        )
+            """)
         self.assertEqual(visitor.comments, {})
 
     def test_noqa_comments(self) -> None:
-        visitor = self.gather_comments(
-            """
+        visitor = self.gather_comments("""
             import a.b.c # noqa
             import d  # somethingelse
             # noqa
             def foo() -> None:
                 pass
 
-            """
-        )
+            """)
         self.assertEqual(visitor.comments.keys(), {1, 4})
         self.assertTrue(isinstance(visitor.comments[1], Comment))
         self.assertEqual(visitor.comments[1].value, "# noqa")

--- a/libcst/codemod/visitors/tests/test_gather_string_annotation_names.py
+++ b/libcst/codemod/visitors/tests/test_gather_string_annotation_names.py
@@ -18,44 +18,35 @@ class TestGatherNamesFromStringAnnotationsVisitor(UnitTest):
         return instance
 
     def test_no_annotations(self) -> None:
-        visitor = self.gather_names(
-            """
+        visitor = self.gather_names("""
             def foo() -> None:
                 pass
-            """
-        )
+            """)
         self.assertEqual(visitor.names, set())
 
     def test_simple_string_annotations(self) -> None:
-        visitor = self.gather_names(
-            """
+        visitor = self.gather_names("""
             def foo() -> "None":
                 pass
-            """
-        )
+            """)
         self.assertEqual(visitor.names, {"None"})
 
     def test_concatenated_string_annotations(self) -> None:
-        visitor = self.gather_names(
-            """
+        visitor = self.gather_names("""
             def foo() -> "No" "ne":
                 pass
-            """
-        )
+            """)
         self.assertEqual(visitor.names, {"None"})
 
     def test_typevars(self) -> None:
-        visitor = self.gather_names(
-            """
+        visitor = self.gather_names("""
             from typing import TypeVar as SneakyBastard
             V = SneakyBastard("V", bound="int")
-            """
-        )
+            """)
         self.assertEqual(visitor.names, {"V", "int"})
 
     def test_complex(self) -> None:
-        visitor = self.gather_names(
-            """
+        visitor = self.gather_names("""
             from typing import TypeVar, TYPE_CHECKING
             if TYPE_CHECKING:
                 from a import Container, Item
@@ -64,30 +55,25 @@ class TestGatherNamesFromStringAnnotationsVisitor(UnitTest):
             A = TypeVar("A", bound="Container[Item]")
             class X:
                 var: "ThisIsExpensiveToImport"  # noqa
-            """
-        )
+            """)
         self.assertEqual(
             visitor.names, {"A", "Item", "Container", "ThisIsExpensiveToImport"}
         )
 
     def test_dotted_names(self) -> None:
-        visitor = self.gather_names(
-            """
+        visitor = self.gather_names("""
             a: "api.http_exceptions.HttpException"
-            """
-        )
+            """)
         self.assertEqual(
             visitor.names,
             {"api", "api.http_exceptions", "api.http_exceptions.HttpException"},
         )
 
     def test_literals(self) -> None:
-        visitor = self.gather_names(
-            """
+        visitor = self.gather_names("""
             from typing import Literal
             a: Literal["in"]
             b: list[Literal["1x"]]
             c: Literal["Any"]
-            """
-        )
+            """)
         self.assertEqual(visitor.names, set())

--- a/libcst/codemod/visitors/tests/test_gather_unused_imports.py
+++ b/libcst/codemod/visitors/tests/test_gather_unused_imports.py
@@ -23,36 +23,29 @@ class TestGatherUnusedImportsVisitor(UnitTest):
         }
 
     def test_no_imports(self) -> None:
-        imports = self.gather_imports(
-            """
+        imports = self.gather_imports("""
             foo = 1
-            """
-        )
+            """)
         self.assertEqual(imports, set())
 
     def test_dotted_imports(self) -> None:
-        imports = self.gather_imports(
-            """
+        imports = self.gather_imports("""
             import a.b.c, d
             import x.y
             a.b(d)
-            """
-        )
+            """)
         self.assertEqual(imports, {"x.y"})
 
     def test_alias(self) -> None:
-        imports = self.gather_imports(
-            """
+        imports = self.gather_imports("""
             from bar import baz as baz_alias
             import bar as bar_alias
             bar_alias()
-            """
-        )
+            """)
         self.assertEqual(imports, {"baz_alias"})
 
     def test_import_complex(self) -> None:
-        imports = self.gather_imports(
-            """
+        imports = self.gather_imports("""
             import bar
             import baz, qux
             import a.b
@@ -65,13 +58,11 @@ class TestGatherUnusedImportsVisitor(UnitTest):
                 c.d(qux)
                 x.u
                 j()
-            """
-        )
+            """)
         self.assertEqual(imports, {"bar", "baz", "a.b", "g"})
 
     def test_import_from_complex(self) -> None:
-        imports = self.gather_imports(
-            """
+        imports = self.gather_imports("""
             from bar import qux, quux
             from a.b import c
             from d.e import f
@@ -82,22 +73,18 @@ class TestGatherUnusedImportsVisitor(UnitTest):
             def foo() -> None:
                 f(qux)
                 k()
-            """
-        )
+            """)
         self.assertEqual(imports, {"quux", "c", "o"})
 
     def test_exports(self) -> None:
-        imports = self.gather_imports(
-            """
+        imports = self.gather_imports("""
             import a
             __all__ = ["a"]
-            """
-        )
+            """)
         self.assertEqual(imports, set())
 
     def test_string_annotation(self) -> None:
-        imports = self.gather_imports(
-            """
+        imports = self.gather_imports("""
             from a import b
             from c import d
             import m, n.blah
@@ -105,24 +92,19 @@ class TestGatherUnusedImportsVisitor(UnitTest):
             bar: List["d"]
             quux: List["m.blah"]
             alma: List["n.blah"]
-            """
-        )
+            """)
         self.assertEqual(imports, set())
 
     def test_typevars(self) -> None:
-        imports = self.gather_imports(
-            """
+        imports = self.gather_imports("""
             from typing import TypeVar as Sneaky
             from a import b
             t = Sneaky("t", bound="b")
-            """
-        )
+            """)
         self.assertEqual(imports, set())
 
     def test_future(self) -> None:
-        imports = self.gather_imports(
-            """
+        imports = self.gather_imports("""
             from __future__ import cool_feature
-            """
-        )
+            """)
         self.assertEqual(imports, set())

--- a/libcst/display/graphviz.py
+++ b/libcst/display/graphviz.py
@@ -11,7 +11,6 @@ from collections.abc import Sequence
 from libcst import CSTNode
 from libcst.helpers import filter_node_fields
 
-
 _syntax_style = ', color="#777777", fillcolor="#eeeeee"'
 _value_style = ', color="#3e99ed", fillcolor="#b8d9f8"'
 
@@ -145,8 +144,7 @@ def dump_graphviz(
     ``show_defaults``.
     """
 
-    graphviz_settings = textwrap.dedent(
-        r"""
+    graphviz_settings = textwrap.dedent(r"""
         layout=dot;
         rankdir=TB;
         splines=line;
@@ -170,10 +168,7 @@ def dump_graphviz(
             fontsize=12,
             penwidth=2,
         ];
-        """[
-            1:
-        ]
-    )
+        """[1:])
 
     return "\n".join(
         ["digraph {", graphviz_settings]

--- a/libcst/display/tests/test_dump_graphviz.py
+++ b/libcst/display/tests/test_dump_graphviz.py
@@ -19,16 +19,12 @@ if TYPE_CHECKING:
 class CSTDumpGraphvizTest(UnitTest):
     """Check dump_graphviz contains CST nodes."""
 
-    source_code: str = dedent(
-        r"""
+    source_code: str = dedent(r"""
         def foo(a: str) -> None:
             pass ;
             pass
             return
-        """[
-            1:
-        ]
-    )
+        """[1:])
     cst: Module
 
     @classmethod

--- a/libcst/helpers/tests/test_node_fields.py
+++ b/libcst/helpers/tests/test_node_fields.py
@@ -17,7 +17,6 @@ from libcst import (
     Semicolon,
     SimpleStatementLine,
 )
-
 from libcst.helpers import (
     get_node_fields,
     is_default_node_field,

--- a/libcst/helpers/tests/test_template.py
+++ b/libcst/helpers/tests/test_template.py
@@ -33,27 +33,23 @@ class TemplateTest(UnitTest):
 
     def test_simple_module(self) -> None:
         module = parse_template_module(
-            self.dedent(
-                """
+            self.dedent("""
                 from {module} import {obj}
 
                 def foo() -> {obj}:
                     return {obj}()
-                """
-            ),
+                """),
             module=cst.Name("foo"),
             obj=cst.Name("Bar"),
         )
         self.assertEqual(
             module.code,
-            self.dedent(
-                """
+            self.dedent("""
                 from foo import Bar
 
                 def foo() -> Bar:
                     return Bar()
-                """
-            ),
+                """),
         )
 
     def test_simple_statement(self) -> None:

--- a/libcst/matchers/__init__.py
+++ b/libcst/matchers/__init__.py
@@ -10,7 +10,6 @@ from typing import Literal, Optional, Sequence, Union
 
 import libcst as cst
 from libcst.matchers._decorators import call_if_inside, call_if_not_inside, leave, visit
-
 from libcst.matchers._matcher_base import (
     AbstractBaseMatcherNodeMeta,
     AllOf,
@@ -6218,13 +6217,13 @@ class If(BaseCompoundStatement, BaseStatement, BaseMatcherNode):
 
 @dataclass(frozen=True, eq=False, unsafe_hash=False)
 class IfExp(BaseExpression, BaseMatcherNode):
-    test: Union[
+    body: Union[
         BaseExpressionMatchType,
         DoNotCareSentinel,
         OneOf[BaseExpressionMatchType],
         AllOf[BaseExpressionMatchType],
     ] = DoNotCare()
-    body: Union[
+    test: Union[
         BaseExpressionMatchType,
         DoNotCareSentinel,
         OneOf[BaseExpressionMatchType],

--- a/libcst/matchers/_return_types.py
+++ b/libcst/matchers/_return_types.py
@@ -75,7 +75,6 @@ from libcst._nodes.expression import (
     Yield,
 )
 from libcst._nodes.module import Module
-
 from libcst._nodes.op import (
     Add,
     AddAssign,
@@ -205,7 +204,6 @@ from libcst._nodes.whitespace import (
     TrailingWhitespace,
 )
 from libcst._removal_sentinel import RemovalSentinel
-
 
 TYPED_FUNCTION_RETURN_MAPPING: TypingDict[Type[CSTNode], object] = {
     Add: BaseBinaryOp,

--- a/libcst/matchers/tests/test_decorators.py
+++ b/libcst/matchers/tests/test_decorators.py
@@ -47,8 +47,7 @@ class MatchersGatingDecoratorsTest(UnitTest):
                 return updated_node
 
         # Parse a module and verify we visited correctly.
-        module = fixture(
-            """
+        module = fixture("""
             a = "foo"
             b = "bar"
 
@@ -57,8 +56,7 @@ class MatchersGatingDecoratorsTest(UnitTest):
 
             def bar() -> None:
                 return "foobar"
-        """
-        )
+        """)
         visitor = TestVisitor()
         module.visit(visitor)
 
@@ -82,8 +80,7 @@ class MatchersGatingDecoratorsTest(UnitTest):
                 self.func_visits.append(node.name.value)
 
         # Parse a module and verify we visited correctly.
-        module = fixture(
-            """
+        module = fixture("""
             a = "foo"
             b = "bar"
 
@@ -92,8 +89,7 @@ class MatchersGatingDecoratorsTest(UnitTest):
 
             def bar() -> None:
                 return "foobar"
-        """
-        )
+        """)
         visitor = TestVisitor()
         module.visit(visitor)
 
@@ -118,8 +114,7 @@ class MatchersGatingDecoratorsTest(UnitTest):
                 self.leaves.append(original_node.value)
 
         # Parse a module and verify we visited correctly.
-        module = fixture(
-            """
+        module = fixture("""
             a = "foo"
             b = "bar"
 
@@ -128,8 +123,7 @@ class MatchersGatingDecoratorsTest(UnitTest):
 
             def bar() -> None:
                 return "foobar"
-        """
-        )
+        """)
         visitor = TestVisitor()
         module.visit(visitor)
 
@@ -153,8 +147,7 @@ class MatchersGatingDecoratorsTest(UnitTest):
                 self.func_visits.append(node.name.value)
 
         # Parse a module and verify we visited correctly.
-        module = fixture(
-            """
+        module = fixture("""
             a = "foo"
             b = "bar"
 
@@ -163,8 +156,7 @@ class MatchersGatingDecoratorsTest(UnitTest):
 
             def bar() -> None:
                 return "foobar"
-        """
-        )
+        """)
         visitor = TestVisitor()
         module.visit(visitor)
 
@@ -185,16 +177,14 @@ class MatchersGatingDecoratorsTest(UnitTest):
                 self.visits.append(node.value)
 
         # Parse a module and verify we visited correctly.
-        module = fixture(
-            """
+        module = fixture("""
             def foo() -> None:
                 return "foo"
 
             class A:
                 def foo(self) -> None:
                     return "baz"
-            """
-        )
+            """)
         visitor = TestVisitor()
         module.visit(visitor)
 
@@ -214,16 +204,14 @@ class MatchersGatingDecoratorsTest(UnitTest):
                 self.visits.append(node.value)
 
         # Parse a module and verify we visited correctly.
-        module = fixture(
-            """
+        module = fixture("""
             def foo() -> None:
                 return "foo"
 
             class A:
                 def foo(self) -> None:
                     return "baz"
-            """
-        )
+            """)
         visitor = TestVisitor()
         module.visit(visitor)
 
@@ -250,8 +238,7 @@ class MatchersGatingDecoratorsTest(UnitTest):
                 return updated_node
 
         # Parse a module and verify we visited correctly.
-        module = fixture(
-            """
+        module = fixture("""
             a = "foo"
             b = "bar"
 
@@ -260,8 +247,7 @@ class MatchersGatingDecoratorsTest(UnitTest):
 
             def bar() -> None:
                 return "foobar"
-        """
-        )
+        """)
         visitor = TestVisitor()
         module.visit(visitor)
 
@@ -285,8 +271,7 @@ class MatchersGatingDecoratorsTest(UnitTest):
                 self.func_visits.append(node.name.value)
 
         # Parse a module and verify we visited correctly.
-        module = fixture(
-            """
+        module = fixture("""
             a = "foo"
             b = "bar"
 
@@ -295,8 +280,7 @@ class MatchersGatingDecoratorsTest(UnitTest):
 
             def bar() -> None:
                 return "foobar"
-        """
-        )
+        """)
         visitor = TestVisitor()
         module.visit(visitor)
 
@@ -321,8 +305,7 @@ class MatchersGatingDecoratorsTest(UnitTest):
                 self.leaves.append(original_node.value)
 
         # Parse a module and verify we visited correctly.
-        module = fixture(
-            """
+        module = fixture("""
             a = "foo"
             b = "bar"
 
@@ -331,8 +314,7 @@ class MatchersGatingDecoratorsTest(UnitTest):
 
             def bar() -> None:
                 return "foobar"
-        """
-        )
+        """)
         visitor = TestVisitor()
         module.visit(visitor)
 
@@ -356,8 +338,7 @@ class MatchersGatingDecoratorsTest(UnitTest):
                 self.func_visits.append(node.name.value)
 
         # Parse a module and verify we visited correctly.
-        module = fixture(
-            """
+        module = fixture("""
             a = "foo"
             b = "bar"
 
@@ -366,8 +347,7 @@ class MatchersGatingDecoratorsTest(UnitTest):
 
             def bar() -> None:
                 return "foobar"
-        """
-        )
+        """)
         visitor = TestVisitor()
         module.visit(visitor)
 
@@ -397,8 +377,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
                 return updated_node
 
         # Parse a module and verify we visited correctly.
-        module = fixture(
-            """
+        module = fixture("""
             a = "foo"
             b = "bar"
 
@@ -410,8 +389,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
 
             def baz() -> None:
                 return "foobar"
-        """
-        )
+        """)
         visitor = TestVisitor()
         module.visit(visitor)
 
@@ -436,8 +414,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
                 self.leaves.append(original_node.name.value)
 
         # Parse a module and verify we visited correctly.
-        module = fixture(
-            """
+        module = fixture("""
             a = "foo"
             b = "bar"
 
@@ -449,8 +426,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
 
             def baz() -> None:
                 return "foobar"
-        """
-        )
+        """)
         visitor = TestVisitor()
         module.visit(visitor)
 
@@ -480,8 +456,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
                 return updated_node
 
         # Parse a module and verify we visited correctly.
-        module = fixture(
-            """
+        module = fixture("""
             a = "foo"
             b = "bar"
 
@@ -493,8 +468,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
 
             def baz() -> None:
                 return "foobar"
-        """
-        )
+        """)
         visitor = TestVisitor()
         module.visit(visitor)
 
@@ -521,8 +495,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
                 self.leaves.append(original_node.name.value)
 
         # Parse a module and verify we visited correctly.
-        module = fixture(
-            """
+        module = fixture("""
             a = "foo"
             b = "bar"
 
@@ -534,8 +507,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
 
             def baz() -> None:
                 return "foobar"
-        """
-        )
+        """)
         visitor = TestVisitor()
         module.visit(visitor)
 
@@ -575,8 +547,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
                 return updated_node
 
         # Parse a module and verify we visited correctly.
-        module = fixture(
-            """
+        module = fixture("""
             a = "foo"
             b = "bar"
 
@@ -588,8 +559,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
 
             def baz() -> None:
                 return "foobar"
-        """
-        )
+        """)
         visitor = TestVisitor()
         module.visit(visitor)
 
@@ -622,8 +592,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
                 self.leaves.add(original_node.name.value + "2")
 
         # Parse a module and verify we visited correctly.
-        module = fixture(
-            """
+        module = fixture("""
             a = "foo"
             b = "bar"
 
@@ -635,8 +604,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
 
             def baz() -> None:
                 return "foobar"
-        """
-        )
+        """)
         visitor = TestVisitor()
         module.visit(visitor)
 
@@ -679,8 +647,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
                 return updated_node
 
         # Parse a module and verify we visited correctly.
-        module = fixture(
-            """
+        module = fixture("""
             a = "foo"
             b = "bar"
 
@@ -692,8 +659,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
 
             def baz() -> None:
                 return "foobarbaz"
-        """
-        )
+        """)
         visitor = TestVisitor()
         module.visit(visitor)
 
@@ -732,8 +698,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
                 self.leaves.add(literal_eval(original_node.value) + "2")
 
         # Parse a module and verify we visited correctly.
-        module = fixture(
-            """
+        module = fixture("""
             a = "foo"
             b = "bar"
 
@@ -745,8 +710,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
 
             def baz() -> None:
                 return "foobarbaz"
-        """
-        )
+        """)
         visitor = TestVisitor()
         module.visit(visitor)
 
@@ -786,8 +750,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
                 )
 
         # Parse a module and verify we visited correctly.
-        module = fixture(
-            """
+        module = fixture("""
             a = "foo"
             b = "bar"
 
@@ -799,12 +762,10 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
 
             def baz() -> None:
                 return "foobarbaz"
-            """
-        )
+            """)
         visitor = TestVisitor()
         actual = module.visit(visitor)
-        expected = fixture(
-            """
+        expected = fixture("""
             a = "foo"
             b = "bar"
 
@@ -816,8 +777,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
 
             def baz() -> None:
                 return "foobarbaz"
-            """
-        )
+            """)
         self.assertTrue(expected.deep_equals(actual))
 
     def test_call_if_inside_visitor_attribute(self) -> None:
@@ -837,8 +797,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
                 self.leaves.append(node.value)
 
         # Parse a module and verify we visited correctly.
-        module = fixture(
-            """
+        module = fixture("""
             a = "foo"
             b = "bar"
 
@@ -847,8 +806,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
 
             def bar() -> None:
                 return "foobar"
-        """
-        )
+        """)
         visitor = TestVisitor()
         module.visit(visitor)
 
@@ -873,8 +831,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
                 self.leaves.append(node.value)
 
         # Parse a module and verify we visited correctly.
-        module = fixture(
-            """
+        module = fixture("""
             a = "foo"
             b = "bar"
 
@@ -883,8 +840,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
 
             def bar() -> None:
                 return "foobar"
-        """
-        )
+        """)
         visitor = TestVisitor()
         module.visit(visitor)
 
@@ -909,8 +865,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
                 self.leaves.append(node.value)
 
         # Parse a module and verify we visited correctly.
-        module = fixture(
-            """
+        module = fixture("""
             a = "foo"
             b = "bar"
 
@@ -919,8 +874,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
 
             def bar() -> None:
                 return "foobar"
-        """
-        )
+        """)
         visitor = TestVisitor()
         module.visit(visitor)
 
@@ -945,8 +899,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
                 self.leaves.append(node.value)
 
         # Parse a module and verify we visited correctly.
-        module = fixture(
-            """
+        module = fixture("""
             a = "foo"
             b = "bar"
 
@@ -955,8 +908,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
 
             def bar() -> None:
                 return "foobar"
-        """
-        )
+        """)
         visitor = TestVisitor()
         module.visit(visitor)
 
@@ -978,8 +930,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
                 self.visits.append(node.value)
 
         # Parse a module and verify we visited correctly.
-        module = fixture(
-            """
+        module = fixture("""
             a = "foo"
             b = "bar"
 
@@ -988,8 +939,7 @@ class MatchersVisitLeaveDecoratorsTest(UnitTest):
 
             def bar() -> None:
                 return "foobar"
-        """
-        )
+        """)
         visitor = TestVisitor()
         module.visit(visitor)
 

--- a/libcst/matchers/tests/test_matchers_with_metadata.py
+++ b/libcst/matchers/tests/test_matchers_with_metadata.py
@@ -498,8 +498,7 @@ class MatchersVisitorMetadataTest(UnitTest):
                 ):
                     self.match_names.add(node.value)
 
-        module = self._make_fixture(
-            """
+        module = self._make_fixture("""
             a = 1 + 2
             b = 3 + 4 + d + e
             def foo() -> str:
@@ -509,8 +508,7 @@ class MatchersVisitorMetadataTest(UnitTest):
                 return b
             del foo
             del bar
-        """
-        )
+        """)
         visitor = TestVisitor()
         module.visit(visitor)
 
@@ -539,8 +537,7 @@ class MatchersVisitorMetadataTest(UnitTest):
                 ):
                     self.match_names.add(node.value)
 
-        module = self._make_fixture(
-            """
+        module = self._make_fixture("""
             a = 1 + 2
             b = 3 + 4 + d + e
             def foo() -> str:
@@ -550,8 +547,7 @@ class MatchersVisitorMetadataTest(UnitTest):
                 return b
             del foo
             del bar
-        """
-        )
+        """)
         visitor = TestTransformer()
         module.visit(visitor)
 
@@ -579,8 +575,7 @@ class MatchersVisitorMetadataTest(UnitTest):
                 # Only match name nodes that are being assigned to.
                 self.match_names.add(node.value)
 
-        module = self._make_fixture(
-            """
+        module = self._make_fixture("""
             a = 1 + 2
             b = 3 + 4 + d + e
             def foo() -> str:
@@ -590,8 +585,7 @@ class MatchersVisitorMetadataTest(UnitTest):
                 return b
             del foo
             del bar
-        """
-        )
+        """)
         visitor = TestVisitor()
         module.visit(visitor)
 
@@ -619,8 +613,7 @@ class MatchersVisitorMetadataTest(UnitTest):
                 # Only match name nodes that are being assigned to.
                 self.match_names.add(node.value)
 
-        module = self._make_fixture(
-            """
+        module = self._make_fixture("""
             a = 1 + 2
             b = 3 + 4 + d + e
             def foo() -> str:
@@ -630,8 +623,7 @@ class MatchersVisitorMetadataTest(UnitTest):
                 return b
             del foo
             del bar
-        """
-        )
+        """)
         visitor = TestTransformer()
         module.visit(visitor)
 

--- a/libcst/metadata/accessor_provider.py
+++ b/libcst/metadata/accessor_provider.py
@@ -7,7 +7,6 @@
 import dataclasses
 
 import libcst as cst
-
 from libcst.metadata.base_provider import VisitorMetadataProvider
 
 

--- a/libcst/metadata/tests/test_accessor_provider.py
+++ b/libcst/metadata/tests/test_accessor_provider.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import dataclasses
-
 from textwrap import dedent
 
 import libcst as cst

--- a/libcst/tests/__main__.py
+++ b/libcst/tests/__main__.py
@@ -5,6 +5,5 @@
 
 from unittest import main
 
-
 if __name__ == "__main__":
     main(module=None, verbosity=2)

--- a/libcst/tests/test_add_slots.py
+++ b/libcst/tests/test_add_slots.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from typing import ClassVar
 
 from libcst._add_slots import add_slots
-
 from libcst.testing.utils import UnitTest
 
 

--- a/libcst/tests/test_exceptions.py
+++ b/libcst/tests/test_exceptions.py
@@ -18,29 +18,25 @@ class ExceptionsTest(UnitTest):
                 cst.ParserSyntaxError(
                     "some message", lines=["abcd"], raw_line=1, raw_column=0
                 ),
-                dedent(
-                    """
+                dedent("""
                     Syntax Error @ 1:1.
                     some message
 
                     abcd
                     ^
-                    """
-                ).strip(),
+                    """).strip(),
             ),
             "tab_expansion": (
                 cst.ParserSyntaxError(
                     "some message", lines=["\tabcd\r\n"], raw_line=1, raw_column=2
                 ),
-                dedent(
-                    """
+                dedent("""
                     Syntax Error @ 1:10.
                     some message
 
                             abcd
                              ^
-                    """
-                ).strip(),
+                    """).strip(),
             ),
             "shows_last_line_with_text": (
                 cst.ParserSyntaxError(
@@ -49,15 +45,13 @@ class ExceptionsTest(UnitTest):
                     raw_line=5,
                     raw_column=0,
                 ),
-                dedent(
-                    """
+                dedent("""
                     Syntax Error @ 5:1.
                     some message
 
                     efgh
                         ^
-                    """
-                ).strip(),
+                    """).strip(),
             ),
             "empty_file": (
                 cst.ParserSyntaxError(

--- a/libcst/tests/test_roundtrip.py
+++ b/libcst/tests/test_roundtrip.py
@@ -9,7 +9,6 @@ from unittest import TestCase
 
 from libcst import CSTTransformer, parse_module
 
-
 fixtures: Path = Path(__file__).parent.parent.parent / "native/libcst/tests/fixtures"
 
 


### PR DESCRIPTION
This PR fixes issue #875 by reordering the fields of `IfExp` to `body, test, orelse`.
This matches the Python syntax order (`body if test else orelse`) and the logical evaluation order.
Previously, the order was `test, body, orelse`, which caused `repr(node)` to be confusing and inconsistent with visitor order (which was already correct).

Changes:
- Reordered `IfExp` fields in `libcst/_nodes/expression.py`.
- Updated `_visit_and_replace_children` in `IfExp` to match new order.
- Updated `libcst/_nodes/tests/test_ifexp.py` to use new field order in positional arguments.
- Ran `python -m libcst.codegen.generate all` to update generated matchers and visitors.
- Verified with reproduction script and existing tests.