### PR TITLE
Drop support for 3.13t

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
-          - "3.13t"
           - "3.14"
           - "3.14t"
     steps:
@@ -102,7 +101,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.13t"]
+        python-version: ["3.10", "3.14t"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,6 @@ skip = [
     "*-musllinux_s390x",
     "*-musllinux_armv7l",
 ]
-enable = ["cpython-freethreading"]
 test-command = [
     "python --version",
     "python -m libcst.tool list",


### PR DESCRIPTION
## Summary

See the note at https://cibuildwheel.pypa.io/en/stable/changelog/#v341 and https://github.com/pypa/cibuildwheel/pull/2787.

The `cpython-freethreading` option will be removed in the next release of cibuildwheel.

I'm going through repositories on GitHub that enable this option and sending in PRs to disable it. Happy to answer questions about this.

If you're curious why 3.13t support is going away so soon, see https://py-free-threading.github.io/ci/#building-free-threaded-wheels-with-cibuildwheel for further guidance.

I also took the opportunity to drop 3.13t from the CI matrix.


