### PR TITLE
Recognize Python 3.14 parser config

### DIFF
--- a/libcst/_parser/tests/test_config.py
+++ b/libcst/_parser/tests/test_config.py
@@ -18,13 +18,16 @@ class ConfigTest(UnitTest):
             PythonVersionInfo(3, 1), _pick_compatible_python_version("3.1")
         )
         self.assertEqual(
-            PythonVersionInfo(3, 8), _pick_compatible_python_version("3.9")
+            PythonVersionInfo(3, 9), _pick_compatible_python_version("3.9")
         )
         self.assertEqual(
-            PythonVersionInfo(3, 8), _pick_compatible_python_version("3.10")
+            PythonVersionInfo(3, 10), _pick_compatible_python_version("3.10")
         )
         self.assertEqual(
-            PythonVersionInfo(3, 8), _pick_compatible_python_version("4.0")
+            PythonVersionInfo(3, 14), _pick_compatible_python_version("3.14")
+        )
+        self.assertEqual(
+            PythonVersionInfo(3, 14), _pick_compatible_python_version("4.0")
         )
         with self.assertRaisesRegex(
             ValueError,

--- a/libcst/_parser/types/config.py
+++ b/libcst/_parser/types/config.py
@@ -44,7 +44,21 @@ class AutoConfig(Enum):
 
 
 # This list should be kept in sorted order.
-KNOWN_PYTHON_VERSION_STRINGS = ["3.0", "3.1", "3.3", "3.5", "3.6", "3.7", "3.8"]
+KNOWN_PYTHON_VERSION_STRINGS = [
+    "3.0",
+    "3.1",
+    "3.3",
+    "3.5",
+    "3.6",
+    "3.7",
+    "3.8",
+    "3.9",
+    "3.10",
+    "3.11",
+    "3.12",
+    "3.13",
+    "3.14",
+]
 
 
 @add_slots
@@ -75,7 +89,8 @@ class PartialParserConfig:
     #: If unspecified, it will default to the syntax of the running interpreter
     #: (rounding down from among the following list).
     #:
-    #: Currently, only Python 3.0, 3.1, 3.3, 3.5, 3.6, 3.7 and 3.8 syntax is supported.
+    #: Currently, only Python 3.0, 3.1, 3.3, and Python 3.5 through 3.14
+    #: syntax is supported.
     #: The gaps did not have any syntax changes from the version prior.
     python_version: Union[str, AutoConfig] = AutoConfig.token
 


### PR DESCRIPTION
Updates PartialParserConfig's known Python grammar versions and compatibility selection tests through Python 3.14. This catches the parser config metadata up to the versions already supported elsewhere.