### PR TITLE
ci: add riscv64 wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
             macos-latest,
             ubuntu-latest,
             ubuntu-24.04-arm,
+            ubuntu-24.04-riscv,
             windows-latest,
             windows-11-arm,
           ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ skip = [
     "*-musllinux_ppc64le",
     "*-musllinux_s390x",
     "*-musllinux_armv7l",
+    "*-musllinux_riscv64",
 ]
 enable = ["cpython-freethreading"]
 test-command = [


### PR DESCRIPTION
## Summary
Now that cibuildwheel and PyPI support riscv64, we can start building riscv64 wheels.

As part of the [RISE project](https://riseproject.dev/) we are trying to build test and deploy the most popular python binary wheels for riscv64. We already support 70+ packages via the [wheel_builder](https://riseproject.gitlab.io/python/wheel_builder/) project. We already helped several of them to enable directly riscv64 support upstream.

Our next target is Arrow, but libCST is one of Arrow dependency, hence we would like to add riscv64 support here first.

This PR uses riscv64 native runners provided for free by RISE (https://riseproject.dev/2026/03/24/announcing-the-rise-risc-v-runners-free-native-risc-v-ci-on-github/). 

I also skip musllinux build, as it is done for other uncommon arch.

## Test Plan
Here are the links to my fork's run: 
- using native runners: 1h39 min:  https://github.com/justeph/LibCST/actions/runs/26106521899/job/76912859785 (what is used in this PR)
- using qemu, 3h: https://github.com/justeph/LibCST/actions/runs/26094087013/job/76727093395 (for comparison with native runners) 
