### PR TITLE
bump version to 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+# 1.9.0 - 2026-07-29
+
+## Added
+* Add support for Python 3.15 by @AlexWaygood and @thatch in https://github.com/Instagram/LibCST/pull/1454 and https://github.com/Instagram/LibCST/pull/1456
+* Add `CodemodCommand` helpers for adding and removing imports by @frvnkliu in https://github.com/Instagram/LibCST/pull/1432
+
+## Fixed
+* Recognize Python 3.14 parser configurations by @bowiechen in https://github.com/Instagram/LibCST/pull/1452
+* Allow a trailing comma after `**rest` in class patterns by @itamaro in https://github.com/Instagram/LibCST/pull/1438
+
+## Updated
+* Document the new `CodemodCommand` import helpers by @frvnkliu in https://github.com/Instagram/LibCST/pull/1437
+* Fix the `tokenize` function's docstring grammar by @galenseilis in https://github.com/Instagram/LibCST/pull/1434
+* Remove the retired macOS 13 runner from CI by @drinkmorewaterr in https://github.com/Instagram/LibCST/pull/1433
+
+## New Contributors
+* @AlexWaygood made their first contribution in https://github.com/Instagram/LibCST/pull/1454
+* @bowiechen made their first contribution in https://github.com/Instagram/LibCST/pull/1452
+* @galenseilis made their first contribution in https://github.com/Instagram/LibCST/pull/1434
+
+**Full Changelog**: https://github.com/Instagram/LibCST/compare/v1.8.6...v1.9.0
+
 # 1.8.6 - 2025-11-03
 
 ## What's Changed

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ A Concrete Syntax Tree (CST) parser and serializer library for Python
 
 .. intro-start
 
-LibCST parses Python 3.0 -> 3.14 source code as a CST tree that keeps
+LibCST parses Python 3.0 -> 3.15 source code as a CST tree that keeps
 all formatting details (comments, whitespaces, parentheses, etc). It's useful for
 building automated refactoring (codemod) applications and linters.
 

--- a/libcst/_parser/tests/test_config.py
+++ b/libcst/_parser/tests/test_config.py
@@ -27,7 +27,10 @@ class ConfigTest(UnitTest):
             PythonVersionInfo(3, 14), _pick_compatible_python_version("3.14")
         )
         self.assertEqual(
-            PythonVersionInfo(3, 14), _pick_compatible_python_version("4.0")
+            PythonVersionInfo(3, 15), _pick_compatible_python_version("3.15")
+        )
+        self.assertEqual(
+            PythonVersionInfo(3, 15), _pick_compatible_python_version("4.0")
         )
         with self.assertRaisesRegex(
             ValueError,

--- a/libcst/_parser/types/config.py
+++ b/libcst/_parser/types/config.py
@@ -58,6 +58,7 @@ KNOWN_PYTHON_VERSION_STRINGS = [
     "3.12",
     "3.13",
     "3.14",
+    "3.15",
 ]
 
 
@@ -89,7 +90,7 @@ class PartialParserConfig:
     #: If unspecified, it will default to the syntax of the running interpreter
     #: (rounding down from among the following list).
     #:
-    #: Currently, only Python 3.0, 3.1, 3.3, and Python 3.5 through 3.14
+    #: Currently, only Python 3.0, 3.1, 3.3, and Python 3.5 through 3.15
     #: syntax is supported.
     #: The gaps did not have any syntax changes from the version prior.
     python_version: Union[str, AutoConfig] = AutoConfig.token

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -280,7 +280,7 @@ checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libcst"
-version = "1.8.6"
+version = "1.9.0"
 dependencies = [
  "annotate-snippets",
  "criterion",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "libcst_derive"
-version = "1.8.6"
+version = "1.9.0"
 dependencies = [
  "quote",
  "syn",

--- a/native/libcst/Cargo.toml
+++ b/native/libcst/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "libcst"
-version = "1.8.6"
+version = "1.9.0"
 authors = ["LibCST Developers"]
 edition = "2018"
 rust-version = "1.83"
@@ -42,7 +42,7 @@ peg = "0.8.5"
 annotate-snippets = "0.11.5"
 regex = "1.11.2"
 memchr = "2.7.4"
-libcst_derive = { path = "../libcst_derive", version = "1.8.6" }
+libcst_derive = { path = "../libcst_derive", version = "1.9.0" }
 
 [dev-dependencies]
 criterion = { version = "0.6.0", features = ["html_reports"] }

--- a/native/libcst_derive/Cargo.toml
+++ b/native/libcst_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcst_derive"
-version = "1.8.6"
+version = "1.9.0"
 edition = "2018"
 description = "Proc macro helpers for libcst."
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "setuptools-scm", "setuptools-rust", "wheel"]
 
 [project]
 name = "libcst"
-description = "A concrete syntax tree with AST-like properties for Python 3.0 through 3.14 programs."
+description = "A concrete syntax tree with AST-like properties for Python 3.0 through 3.15 programs."
 readme = "README.rst"
 dynamic = ["version"]
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

- bump the native Rust crates to 1.9.0
- add the v1.9.0 changelog
- update Python 3.15 support metadata and parser configuration

## Test Plan

- `uv run poe test`
- `uv run poe lint`
- `uv run poe typecheck`
- `cargo test --manifest-path native/Cargo.toml --release --no-default-features`
- build 1.9.0 wheel and source distribution
- build documentation