### PR TITLE
Make PyPI publishing idempotent

### DIFF
--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -53,8 +53,10 @@ jobs:
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: ${{ steps.download.outputs.download-path }}
+          skip-existing: true
       - name: Publish distribution 📦 to PyPI
         if: github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: ${{ steps.download.outputs.download-path }}
+          skip-existing: true


### PR DESCRIPTION
## Summary

- skip package files that already exist on Test PyPI or PyPI
- allow interrupted publishing workflows to be rerun safely

## Test Plan

- parsed the workflow with PyYAML
- `git diff --check`