### PR TITLE
Add manual PyPI release retries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,11 @@
 name: build
 on:
   workflow_call:
+    inputs:
+      checkout_ref:
+        description: Git ref containing the package sources to build
+        required: false
+        type: string
 
 jobs:
   # Build python wheels
@@ -26,6 +31,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+          ref: ${{ inputs.checkout_ref || github.ref }}
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
@@ -35,7 +41,7 @@ jobs:
         run: >-
           echo LIBCST_NO_LOCAL_SCHEME=1 >> $GITHUB_ENV
       - name: Enable building wheels for pre-release CPython versions
-        if: github.event_name != 'release'
+        if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
         run: echo CIBW_ENABLE=cpython-prerelease >> $GITHUB_ENV
       - name: Build wheels
         uses: pypa/cibuildwheel@v4.0.0rc1

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -5,6 +5,12 @@ on:
     types: [published]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_ref:
+        description: Git tag or commit containing the release sources
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -12,6 +18,8 @@ permissions:
 jobs:
   build:
     uses: Instagram/LibCST/.github/workflows/build.yml@main
+    with:
+      checkout_ref: ${{ inputs.release_ref || github.ref }}
   upload_release:
     name: Upload wheels to pypi
     runs-on: ubuntu-latest
@@ -23,6 +31,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+          ref: ${{ inputs.release_ref || github.ref }}
       - name: Download binary wheels
         id: download
         uses: actions/download-artifact@v5
@@ -55,7 +64,7 @@ jobs:
           packages-dir: ${{ steps.download.outputs.download-path }}
           skip-existing: true
       - name: Publish distribution 📦 to PyPI
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: ${{ steps.download.outputs.download-path }}


### PR DESCRIPTION
## Summary

- add a manual publishing trigger with a required release ref
- build wheels and the source distribution from that exact ref while using workflow code from `main`
- keep prerelease CPython wheels disabled for manual production retries

This allows an interrupted release upload to be retried safely with `skip-existing`.

## Test Plan

- parsed both workflows with PyYAML
- `git diff --check`