### PR TITLE
fix: key inherited metadata dependency cache per class

### DIFF
--- a/libcst/_metadata_dependent.py
+++ b/libcst/_metadata_dependent.py
@@ -82,17 +82,21 @@ class MetadataDependent(ABC):
 
         Recursively searches the MRO of the subclass for metadata dependencies.
         """
-        try:
-            # pyre-fixme[16]: use a hidden attribute to cache the property
-            return cls._INHERITED_METADATA_DEPENDENCIES_CACHE
-        except AttributeError:
-            dependencies = set()
-            for c in inspect.getmro(cls):
-                if issubclass(c, MetadataDependent):
-                    dependencies.update(c.METADATA_DEPENDENCIES)
-            # pyre-fixme[16]: use a hidden attribute to cache the property
-            cls._INHERITED_METADATA_DEPENDENCIES_CACHE = frozenset(dependencies)
-            return cls._INHERITED_METADATA_DEPENDENCIES_CACHE
+        # Read the cache out of ``cls.__dict__`` rather than with attribute
+        # lookup: a plain attribute read walks the MRO, so a value cached on a
+        # base class would be returned for every subclass that has not computed
+        # its own cache yet.
+        cache = cls.__dict__.get("_INHERITED_METADATA_DEPENDENCIES_CACHE")
+        if cache is not None:
+            return cache
+        dependencies = set()
+        for c in inspect.getmro(cls):
+            if issubclass(c, MetadataDependent):
+                dependencies.update(c.METADATA_DEPENDENCIES)
+        cache = frozenset(dependencies)
+        # pyre-fixme[16]: use a hidden attribute to cache the property
+        cls._INHERITED_METADATA_DEPENDENCIES_CACHE = cache
+        return cache
 
     @contextmanager
     def resolve(self, wrapper: "MetadataWrapper") -> Iterator[None]:

--- a/libcst/metadata/tests/test_metadata_provider.py
+++ b/libcst/metadata/tests/test_metadata_provider.py
@@ -330,6 +330,29 @@ class MetadataProviderTest(UnitTest):
         ):
             MetadataWrapper(cst.Module([])).visit(AVisitor())
 
+    def test_bare_visitor_does_not_poison_subclass_dependencies(self) -> None:
+        """
+        Tests that resolving a bare CSTTransformer does not cache an empty
+        dependency set that subclasses would then inherit through the MRO.
+        """
+
+        class ProviderA(VisitorMetadataProvider[bool]):
+            def visit_Pass(self, node: cst.Pass) -> None:
+                self.set_metadata(node, True)
+
+        class AVisitor(CSTTransformer):
+            METADATA_DEPENDENCIES = (ProviderA,)
+
+            def visit_Pass(self, node: cst.Pass) -> None:
+                self.get_metadata(ProviderA, node)
+
+        module = cst.parse_module("pass\n")
+        # Resolving the bare base class first caches its (empty) dependencies.
+        MetadataWrapper(module).visit(CSTTransformer())
+
+        self.assertEqual(AVisitor.get_inherited_dependencies(), {ProviderA})
+        MetadataWrapper(module).visit(AVisitor())
+
     def test_circular_dependency(self) -> None:
         """
         Tests that circular dependencies are detected.


### PR DESCRIPTION
Closes #1459

## Summary

`MetadataDependent.get_inherited_dependencies()` memoized into a plain class attribute and read it back with ordinary attribute lookup. That lookup walks the MRO, so resolving a bare `CSTTransformer`/`CSTVisitor` cached an empty `frozenset` onto the base class, and every subclass that had not yet computed its own cache inherited it — raising `METADATA_DEPENDENCIES` `KeyError`s even though the subclass declares the provider correctly. Reading the cache from `cls.__dict__` instead means each class only ever sees its own memoized value.

## Test Plan

Added `test_bare_visitor_does_not_poison_subclass_dependencies` to `libcst/metadata/tests/test_metadata_provider.py`, which resolves a bare `CSTTransformer` first and then asserts the subclass still reports its declared dependency. It fails on the unpatched source (`frozenset() != {ProviderA}`) and passes with the fix; `libcst/metadata/tests/`, `test_visitor.py` and `test_batched_visitor.py` are green (178 passed, only the pre-existing pyre-binary errors in `test_type_inference_provider.py`).

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
