### PR TITLE
Respect overwrite_existing_annotations for attributes and globals

### DIFF
--- a/libcst/codemod/visitors/_apply_type_annotations.py
+++ b/libcst/codemod/visitors/_apply_type_annotations.py
@@ -1266,6 +1266,35 @@ class ApplyTypeAnnotationsVisitor(ContextAwareTransformer):
         else:
             return self._annotate_single_target(original_node, updated_node)
 
+    def leave_AnnAssign(
+        self,
+        original_node: cst.AnnAssign,
+        updated_node: cst.AnnAssign,
+    ) -> cst.AnnAssign:
+        # An attribute or global that already carries an annotation is only
+        # touched when we are explicitly told to overwrite existing annotations.
+        if not self.overwrite_existing_annotations:
+            return updated_node
+        target = original_node.target
+        if not isinstance(target, cst.Name):
+            return updated_node
+        self.qualifier.append(target.value)
+        qualifier_name = self._qualifier_name()
+        self.qualifier.pop()
+        annotation = self.annotations.attributes.get(qualifier_name)
+        if annotation is None or annotation.annotation.deep_equals(
+            updated_node.annotation.annotation
+        ):
+            return updated_node
+        self.already_annotated.add(qualifier_name)
+        if len(self.qualifier) == 0:
+            self.annotation_counts.global_annotations += 1
+        else:
+            self.annotation_counts.attribute_annotations += 1
+        return updated_node.with_changes(
+            annotation=self._quote_future_annotations(annotation),
+        )
+
     def leave_ImportFrom(
         self,
         original_node: cst.ImportFrom,

--- a/libcst/codemod/visitors/tests/test_apply_type_annotations.py
+++ b/libcst/codemod/visitors/tests/test_apply_type_annotations.py
@@ -1143,6 +1143,59 @@ class TestApplyAnnotationsVisitor(CodemodTest):
 
     @data_provider(
         {
+            "attribute": (
+                """
+                class X:
+                    x: int
+                """,
+                """
+                class X:
+                    x: str
+                """,
+                """
+                class X:
+                    x: int
+                """,
+            ),
+            "attribute_with_value": (
+                """
+                class X:
+                    x: int
+                """,
+                """
+                class X:
+                    x: str = 5
+                """,
+                """
+                class X:
+                    x: int = 5
+                """,
+            ),
+            "global": (
+                """
+                x: int
+                """,
+                """
+                x: str
+                """,
+                """
+                x: int
+                """,
+            ),
+        }
+    )
+    def test_annotate_attributes_with_existing_annotations(
+        self, stub: str, before: str, after: str
+    ) -> None:
+        self.run_test_case_with_flags(
+            stub=stub,
+            before=before,
+            after=after,
+            overwrite_existing_annotations=True,
+        )
+
+    @data_provider(
+        {
             "pep_604": (
                 """
                 def f(a: int | str, b: int | list[int | list[int | str]]) -> str: ...


### PR DESCRIPTION
Closes #1159

## Summary

`ApplyTypeAnnotationsVisitor` only overwrote existing annotations on function parameters and returns. An attribute or global that already carries an annotation is an `AnnAssign`, which the transformer never visited, so `overwrite_existing_annotations=True` had no effect there — patching `class X: x: str` with a stub `class X: x: int` left `x: str` unchanged.

Adds `leave_AnnAssign`, which (only when overwriting is requested) looks up the qualified name in the stub's attribute annotations and swaps in the stub annotation, recording it in the annotation counts.

## Test Plan

New `test_annotate_attributes_with_existing_annotations` in `libcst/codemod/visitors/tests/test_apply_type_annotations.py` covers a class attribute, an attribute with a value, and a module-level global. All three fail without the source change and pass with it; `libcst/codemod/` is otherwise unchanged (389 passed, with one pre-existing `test_codemod_formatter_error_input` failure present on a clean checkout too).

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
